### PR TITLE
feat: add backend configuration management

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -10,5 +10,6 @@
 
 - Added `backend/internal/config` with dotenv loading, typed settings, defaults, and validation.
 - `DATABASE_URL` is required; optional settings use `.env.example` defaults where defined.
-- Focused validation: `go test ./backend/internal/config/...`.
-- GitHub CLI authentication is unavailable in this worker, so issue/PR Workpad updates and PR handoff remain external follow-up.
+- Focused validation: `go test ./backend/internal/config/...` passes after adding `backend/go.sum` for `godotenv`.
+- Full local validation gate is `true` per `WORKFLOW.md`; repository has no CI configuration or declared project check names.
+- GitHub CLI is authenticated as `christophergm`; no PR exists yet for the Detent branch, so create one after pushing the fix and update issue #1 Workpad.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -5,3 +5,10 @@
 - Vite entry document is `frontend/index.html`; `BrowserRouter` serves `/` plus placeholder routes for `/classes`, `/assignments`, `/students`, and `/settings`.
 - Validation: `cd frontend && npm run build`, `npm run lint`, and repository gate `true`.
 - GitHub CLI is unauthenticated in this worker (`gh auth status` reports missing credentials), so issue Workpad/PR operations require a later authenticated handoff.
+
+## Backend configuration management
+
+- Added `backend/internal/config` with dotenv loading, typed settings, defaults, and validation.
+- `DATABASE_URL` is required; optional settings use `.env.example` defaults where defined.
+- Focused validation: `go test ./backend/internal/config/...`.
+- GitHub CLI authentication is unavailable in this worker, so issue/PR Workpad updates and PR handoff remain external follow-up.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -12,4 +12,5 @@
 - `DATABASE_URL` is required; optional settings use `.env.example` defaults where defined.
 - Focused validation: `go test ./backend/internal/config/...` passes after adding `backend/go.sum` for `godotenv`.
 - Full local validation gate is `true` per `WORKFLOW.md`; repository has no CI configuration or declared project check names.
-- GitHub CLI is authenticated as `christophergm`; no PR exists yet for the Detent branch, so create one after pushing the fix and update issue #1 Workpad.
+- GitHub CLI is authenticated as `christophergm`; PR #17 is open for the Detent branch and references issue #1.
+- PR #17 is non-draft and clean with no configured CI checks or review comments; Workpad comment is complete.

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,2 @@
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,0 +1,102 @@
+// Package config loads the API configuration from the environment.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/joho/godotenv"
+)
+
+const (
+	defaultAppEnv     = "development"
+	defaultAppVersion = "0.1.0"
+	defaultPort       = "8080"
+	defaultAPIBaseURL = "http://localhost:8080"
+)
+
+// Config contains the settings used by the API and its dependencies.
+// Values are intentionally kept as strings because they originate in the
+// environment and are passed to the HTTP and database clients unchanged.
+type Config struct {
+	AppEnv            string
+	AppVersion        string
+	Port              string
+	APIBaseURL        string
+	DatabaseURL       string
+	TestDatabaseURL   string
+	SupabaseURL       string
+	SupabaseAnonKey   string
+	SupabaseJWTSecret string
+}
+
+// Load reads .env when it exists, then builds and validates the application
+// configuration. Existing environment variables take precedence over .env.
+func Load() (*Config, error) {
+	if err := loadDotEnv(".env"); err != nil {
+		return nil, err
+	}
+
+	return fromEnvironment()
+}
+
+// LoadFrom reads configuration from the supplied dotenv file. It is useful
+// for commands that run from a directory other than the repository root and
+// for callers that need to select a specific environment file.
+func LoadFrom(path string) (*Config, error) {
+	if err := loadDotEnv(path); err != nil {
+		return nil, err
+	}
+
+	return fromEnvironment()
+}
+
+func loadDotEnv(path string) error {
+	err := godotenv.Load(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+func fromEnvironment() (*Config, error) {
+	port := getEnv("PORT", defaultPort)
+
+	cfg := &Config{
+		AppEnv:            getEnv("APP_ENV", defaultAppEnv),
+		AppVersion:        getEnv("APP_VERSION", defaultAppVersion),
+		Port:              port,
+		APIBaseURL:        getEnv("API_BASE_URL", defaultAPIBaseURL),
+		DatabaseURL:       strings.TrimSpace(os.Getenv("DATABASE_URL")),
+		TestDatabaseURL:   strings.TrimSpace(os.Getenv("TEST_DATABASE_URL")),
+		SupabaseURL:       strings.TrimSpace(os.Getenv("SUPABASE_URL")),
+		SupabaseAnonKey:   strings.TrimSpace(os.Getenv("SUPABASE_ANON_KEY")),
+		SupabaseJWTSecret: strings.TrimSpace(os.Getenv("SUPABASE_JWT_SECRET")),
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok && strings.TrimSpace(value) != "" {
+		return strings.TrimSpace(value)
+	}
+	return fallback
+}
+
+// Validate checks the configuration required to start the API.
+func (c Config) Validate() error {
+	if strings.TrimSpace(c.DatabaseURL) == "" {
+		return fmt.Errorf("configuration error: DATABASE_URL is required")
+	}
+	if strings.TrimSpace(c.Port) == "" {
+		return fmt.Errorf("configuration error: PORT must not be empty")
+	}
+	return nil
+}

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadFromDotEnv(t *testing.T) {
+	for _, key := range []string{"APP_ENV", "APP_VERSION", "PORT", "API_BASE_URL", "DATABASE_URL", "TEST_DATABASE_URL"} {
+		unsetEnv(t, key)
+	}
+
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("APP_ENV=test\nPORT=9090\nDATABASE_URL=postgres://example\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom() error = %v", err)
+	}
+	if cfg.AppEnv != "test" || cfg.Port != "9090" || cfg.DatabaseURL != "postgres://example" {
+		t.Fatalf("LoadFrom() = %#v", cfg)
+	}
+	if cfg.AppVersion != defaultAppVersion || cfg.APIBaseURL != defaultAPIBaseURL {
+		t.Fatalf("defaults not applied: %#v", cfg)
+	}
+}
+
+func TestEnvironmentOverridesDotEnv(t *testing.T) {
+	t.Setenv("PORT", "7070")
+	t.Setenv("DATABASE_URL", "postgres://environment")
+
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("PORT=9090\nDATABASE_URL=postgres://file\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom() error = %v", err)
+	}
+	if cfg.Port != "7070" || cfg.DatabaseURL != "postgres://environment" {
+		t.Fatalf("environment did not override dotenv: %#v", cfg)
+	}
+}
+
+func TestLoadRequiresDatabaseURL(t *testing.T) {
+	unsetEnv(t, "DATABASE_URL")
+
+	_, err := LoadFrom(filepath.Join(t.TempDir(), "missing.env"))
+	if err == nil || err.Error() != "configuration error: DATABASE_URL is required" {
+		t.Fatalf("LoadFrom() error = %v", err)
+	}
+}
+
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	previous, existed := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if existed {
+			_ = os.Setenv(key, previous)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}
+
+func TestConfigValidateRejectsEmptyPort(t *testing.T) {
+	err := (Config{DatabaseURL: "postgres://example"}).Validate()
+	if err == nil || err.Error() != "configuration error: PORT must not be empty" {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #1

Adds dotenv-backed typed backend configuration with defaults and validation. Adds the Go module checksum required for clean test execution.

Validation:
- `go test ./backend/...`
- `git diff --check`
- `true`