### PR TITLE
feat: add initial database migration

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -22,3 +22,10 @@
 - Local Go 1.26 cannot honor the repository's Go 1.27 directive because toolchain checksum-cache access is restricted. Disposable Detent temp copy with only `go.mod` set to 1.26 passes `GOSUMDB=off go test ./...`.
 - Repository gate `true`, `gofmt -d`, and `git diff --check` pass. CI has one `Validate` job running `git diff --check`; no CI checks are currently configured beyond that.
 - Workpad comment on issue #2 is complete. PR #18 is open, non-draft, references `Fixes #2`, and has no actionable review comments; keep the issue in its Detent-managed worker lane for promotion.
+
+## Initial database migration
+
+- Added `backend/migrations/00001_initial_schema.sql` using Goose Up/Down markers.
+- The initial schema creates a reversible `health_checks` table with an identity-like `BIGSERIAL` key, status, timestamp, and non-empty status constraint.
+- Validation: disposable Go 1.26-compatible copy `GOTOOLCHAIN=local GOSUMDB=off go test ./...` passes; `git diff --check` and configured gate `true` pass.
+- Goose CLI is not installed, and `goose validate` is not a supported Goose command; local Docker/PostgreSQL is unavailable, so migration up/down remains to be verified when the database service is available.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -26,6 +26,6 @@
 ## Initial database migration
 
 - Added `backend/migrations/00001_initial_schema.sql` using Goose Up/Down markers.
-- The initial schema creates a reversible `health_checks` table with an identity-like `BIGSERIAL` key, status, timestamp, and non-empty status constraint.
-- Validation: disposable Go 1.26-compatible copy `GOTOOLCHAIN=local GOSUMDB=off go test ./...` passes; `git diff --check` and configured gate `true` pass.
-- Goose CLI is not installed, and `goose validate` is not a supported Goose command; local Docker/PostgreSQL is unavailable, so migration up/down remains to be verified when the database service is available.
+- The initial schema creates a reversible `health_checks` table with a UUID v7 primary key, status, timestamp, and non-empty status constraint. PostgreSQL 16 compatibility is provided by the schema-local `miniclass_uuid_v7()` function.
+- Rework validation: `git diff --check` passes; Docker PostgreSQL smoke testing is unavailable because the Docker daemon is not running.
+- Goose CLI is not installed; the repository gate remains `true` and backend tests should be run with `GOTOOLCHAIN=local GOSUMDB=off` on the available Go 1.26 toolchain.

--- a/backend/migrations/00001_initial_schema.sql
+++ b/backend/migrations/00001_initial_schema.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+
+CREATE TABLE health_checks (
+    id BIGSERIAL PRIMARY KEY,
+    status TEXT NOT NULL DEFAULT 'healthy',
+    checked_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT health_checks_status_check CHECK (status <> '')
+);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS health_checks;

--- a/backend/migrations/00001_initial_schema.sql
+++ b/backend/migrations/00001_initial_schema.sql
@@ -1,7 +1,36 @@
 -- +goose Up
 
+-- PostgreSQL 16 does not provide uuidv7(), so keep generation local to the
+-- schema while preserving the UUID v7 layout for every generated ID.
+CREATE FUNCTION miniclass_uuid_v7() RETURNS UUID
+LANGUAGE SQL
+VOLATILE
+AS $$
+    WITH random_value AS (
+        SELECT md5(random()::TEXT || clock_timestamp()::TEXT) AS hex
+    ), timestamp_value AS (
+        SELECT lpad(
+            to_hex(floor(extract(EPOCH FROM clock_timestamp()) * 1000)::BIGINT),
+            12,
+            '0'
+        ) AS hex
+    )
+    SELECT (
+        timestamp_value.hex
+        || '7'
+        || substr(random_value.hex, 14, 3)
+        || substr(
+            '89ab',
+            (get_byte(decode(substr(random_value.hex, 17, 2), 'hex'), 0) % 4) + 1,
+            1
+        )
+        || substr(random_value.hex, 18)
+    )::UUID
+    FROM random_value, timestamp_value;
+$$;
+
 CREATE TABLE health_checks (
-    id BIGSERIAL PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT miniclass_uuid_v7(),
     status TEXT NOT NULL DEFAULT 'healthy',
     checked_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT health_checks_status_check CHECK (status <> '')
@@ -10,3 +39,4 @@ CREATE TABLE health_checks (
 -- +goose Down
 
 DROP TABLE IF EXISTS health_checks;
+DROP FUNCTION IF EXISTS miniclass_uuid_v7();


### PR DESCRIPTION
Fixes #3

Adds the initial reversible Goose migration at `backend/migrations/00001_initial_schema.sql`.

The up migration creates a PostgreSQL 16-compatible UUID v7 generator and a `health_checks` table whose primary key defaults to a generated UUID v7, plus status and timestamp fields. The down migration drops the table and helper function safely.

Validation:
- `GOTOOLCHAIN=local GOSUMDB=off go test ./...` in a disposable Go 1.26-compatible copy — passed.
- `git diff --check` — passed.
- `true` — passed.
- PR CI `Validate` — passed on head `eafb6c6`.
- Live Goose up/down could not run because the Docker daemon is unavailable in this worker.