### PR TITLE
feat: add migration and seed commands

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -35,3 +35,4 @@
 - Added `backend/cmd/migrate/main.go` using Goose and pgx stdlib; supports `up`, `down`, and `status`, defaulting to `up`, with credential-safe errors.
 - Added `backend/cmd/seed/main.go` and `backend/scripts/seed.sql`; Make `migrate-up`/`migrate-down` now use the command wrapper and `seed` already invokes its command.
 - Focused disposable-copy validation: `GOTOOLCHAIN=local GOSUMDB=off go test -mod=mod ./...`, builds, and missing-`DATABASE_URL` smoke checks pass. Repository gate is `true`; live PostgreSQL execution was not available.
+- Issue #3 remains open, but its migration PR is the dependency that supplies the `health_checks` table consumed by the seed SQL.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -29,3 +29,9 @@
 - The initial schema creates a reversible `health_checks` table with a UUID v7 primary key, status, timestamp, and non-empty status constraint. PostgreSQL 16 compatibility is provided by the schema-local `miniclass_uuid_v7()` function.
 - Rework validation: `git diff --check` passes; Docker PostgreSQL smoke testing is unavailable because the Docker daemon is not running.
 - Goose CLI is not installed; the repository gate remains `true` and backend tests should be run with `GOTOOLCHAIN=local GOSUMDB=off` on the available Go 1.26 toolchain.
+
+## Migration and seed commands (#7)
+
+- Added `backend/cmd/migrate/main.go` using Goose and pgx stdlib; supports `up`, `down`, and `status`, defaulting to `up`, with credential-safe errors.
+- Added `backend/cmd/seed/main.go` and `backend/scripts/seed.sql`; Make `migrate-up`/`migrate-down` now use the command wrapper and `seed` already invokes its command.
+- Focused disposable-copy validation: `GOTOOLCHAIN=local GOSUMDB=off go test -mod=mod ./...`, builds, and missing-`DATABASE_URL` smoke checks pass. Repository gate is `true`; live PostgreSQL execution was not available.

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -24,10 +24,10 @@ build: ## Build the API binary
 	go build -o bin/api ./cmd/api
 
 migrate-up: ## Run all pending migrations
-	goose -dir migrations postgres "$(DATABASE_URL)" up
+	go run ./cmd/migrate up
 
 migrate-down: ## Rollback last migration
-	goose -dir migrations postgres "$(DATABASE_URL)" down
+	go run ./cmd/migrate down
 
 migrate-create: ## Create a new migration (usage: make migrate-create NAME=create_users)
 	@if [ -z "$(NAME)" ]; then echo "Error: NAME is required. Usage: make migrate-create NAME=your_migration_name"; exit 1; fi

--- a/backend/cmd/migrate/main.go
+++ b/backend/cmd/migrate/main.go
@@ -1,0 +1,55 @@
+// Command migrate applies or rolls back Goose migrations.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/pressly/goose/v3"
+)
+
+const migrationDir = "migrations"
+
+func main() {
+	if err := run(context.Background(), os.Args[1:], os.Getenv("DATABASE_URL")); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string, databaseURL string) error {
+	command := "up"
+	if len(args) > 1 {
+		return errors.New("migration command accepts at most one action: up, down, or status")
+	}
+	if len(args) == 1 {
+		command = strings.ToLower(strings.TrimSpace(args[0]))
+	}
+	if command != "up" && command != "down" && command != "status" {
+		return fmt.Errorf("unsupported migration action %q; use up, down, or status", command)
+	}
+	if strings.TrimSpace(databaseURL) == "" {
+		return errors.New("migration failed: DATABASE_URL is required")
+	}
+
+	db, err := sql.Open("pgx", databaseURL)
+	if err != nil {
+		return fmt.Errorf("migration failed: open database: %w", err)
+	}
+	defer db.Close()
+
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("migration failed: database connection: %w", err)
+	}
+	if err := goose.RunContext(ctx, command, db, migrationDir); err != nil {
+		return fmt.Errorf("migration failed: %w", err)
+	}
+
+	fmt.Printf("Migration %s completed successfully.\n", command)
+	return nil
+}

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -1,0 +1,57 @@
+// Command seed loads the development seed SQL into PostgreSQL.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+const seedFile = "scripts/seed.sql"
+
+func main() {
+	if err := run(context.Background(), os.Getenv("DATABASE_URL")); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, databaseURL string) error {
+	if strings.TrimSpace(databaseURL) == "" {
+		return errors.New("seed failed: DATABASE_URL is required")
+	}
+
+	sqlPath := filepath.Join(sourceDir(), "..", "..", seedFile)
+	script, err := os.ReadFile(sqlPath)
+	if err != nil {
+		return fmt.Errorf("seed failed: read %s: %w", seedFile, err)
+	}
+
+	db, err := sql.Open("pgx", databaseURL)
+	if err != nil {
+		return fmt.Errorf("seed failed: open database: %w", err)
+	}
+	defer db.Close()
+
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("seed failed: database connection: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, string(script)); err != nil {
+		return fmt.Errorf("seed failed: execute %s: %w", seedFile, err)
+	}
+
+	fmt.Println("Seed data loaded successfully.")
+	return nil
+}
+
+func sourceDir() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Dir(filename)
+}

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -28,3 +28,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/pressly/goose/v3 v3.19.2 h1:z1yuD41jS4iaqLkyjkzGkKBz4rgyz/BYtCyMMGHlgzQ=
+github.com/pressly/goose/v3 v3.19.2/go.mod h1:BHkf3LzSBmO8E5FTMPupUYIpMTIh/ZuQVy+YTfhZLD4=

--- a/backend/scripts/seed.sql
+++ b/backend/scripts/seed.sql
@@ -1,0 +1,3 @@
+-- Development seed data. The initial migration provides health_checks.
+INSERT INTO health_checks (status)
+VALUES ('seeded');


### PR DESCRIPTION
Fixes #7

## Summary
- add Goose migration command with up/down/status actions
- add PostgreSQL seed command and development seed SQL
- route Makefile migration targets through the command wrapper

## Validation
- disposable Go 1.26 copy: `GOTOOLCHAIN=local GOSUMDB=off go test -mod=mod ./...`
- command builds and missing-`DATABASE_URL` smoke checks
- `git diff --check`
- repository gate: `true`

Live PostgreSQL migration/seed execution was not available in this worker.