### PR TITLE
feat: add API health-check endpoint

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -50,3 +50,14 @@
 - Issue #1 dependency is closed and its project item is Done; issue #4 is In Progress during this rework pass.
 - Rework review: PR #19 remains open and non-draft, references `Fixes #4`, has green `Validate` CI, and has no human, bot, or inline review feedback; no source correction was required.
 - Rebased the PR branch onto `origin/main` at `600a705` and added the three missing Goose indirect module content checksums to `backend/go.sum`; focused and full backend tests pass without `-mod=mod` using the disposable Go 1.26 modfile.
+
+## API health-check endpoint (#5)
+
+- Issue #5 depends on #4 (HTTP server and middleware) and #2 (database ping); #2 is closed, but #4 remains open.
+- PR #19 for #4 is open, non-draft, conflicting, and has no review comments or CI results; issue #4 remains in its worker-owned review lane, so #5 remains blocked until that dependency reaches a terminal state.
+- The current branch is based on `origin/main`; no source changes were made for #5 because the health route must register into the pending router.
+- The native dependency listing confirms #4 blocks #5; the issue body's `Depends on: #4` remains as a redundant fallback declaration.
+- Recheck on 2026-08-23: issue #4 is still OPEN and PR #19 is still OPEN/non-draft with `mergeStateStatus=DIRTY`/`mergeable=CONFLICTING`; PR head is `7ff5a690524ff3e27386b6897fb3cae7e757b727`, and the native `blocked_by` relation is present. `HEAD` and `origin/main` are both `45318ceb0a52f73dc83692d0a80308ba854c999d`; neither contains `backend/internal/api`. No implementation or validation for #5 can proceed without importing unmerged server code.
+- Final recheck on 2026-08-23: #4 remains OPEN and PR #19 remains non-draft/conflicting at the same head; GitHub's dependency endpoint confirms #4 blocks #5. `HEAD` and `origin/main` remain `45318ceb0a52f73dc83692d0a80308ba854c999d`, with no `backend/internal/api`; no source or focused validation was added for #5.
+- Current recheck on 2026-08-23: #4 is still OPEN; PR #19 is still OPEN/non-draft with `mergeStateStatus=DIRTY` and `mergeable=CONFLICTING` at `7ff5a690524ff3e27386b6897fb3cae7e757b727`. The native `blocked_by` relation from #5 to #4 remains present. `HEAD` and `origin/main` are both `45318ceb0a52f73dc83692d0a80308ba854c999d`; `backend/internal/api` is still absent. No implementation or focused handler validation can proceed until #4 merges or reaches a terminal state.
+- Rework resumed on 2026-08-23 after #4 merged as PR #19. The project item is `In Progress`; the branch was rebased onto `origin/main` at `ac9b09a`. Implement the handler against the merged API package, then run focused and full backend validation before opening the #5 PR.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -58,3 +58,4 @@
 - Focused tests cover healthy, failed, and missing database dependencies plus router registration.
 - The project item is `In Progress`; #4 is terminal after PR #19 merged, and this branch is based on `origin/main` at `ac9b09a`.
 - Validation: disposable Detent-temp Go 1.26 copy passed `GOTOOLCHAIN=local GOSUMDB=off go test ./internal/api/handlers/...` and `go test ./...`; `gofmt -d`, `git diff --check`, and repository gate `true` pass locally. The checked-in module requires Go 1.27, unavailable in this worker.
+- PR #23 is open, non-draft, mergeable, references `Fixes #5`, has no review comments, and has green `Validate` CI.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -40,7 +40,7 @@
 ## Backend HTTP server and middleware
 
 - Added `backend/internal/api` with `NewServer`, `NewServerWithConfig`, `NewRouter`, explicit middleware ordering, CORS, structured request logging, panic recovery, JSON content type, and JSON 404/405 errors.
-- API root is available at `/api` and `/api/`; feature routes such as health remain for subsequent issues.
+- API root is available at `/api` and `/api/`; the health route is registered at `/api/health`.
 - Focused validation: `cd backend && go test ./internal/api/...` passes.
 - Full backend validation: `cd backend && go test ./...` passes.
 - Repository validation gate: `true` passes; CI's declared `Validate` check runs `git diff --check`.
@@ -53,11 +53,8 @@
 
 ## API health-check endpoint (#5)
 
-- Issue #5 depends on #4 (HTTP server and middleware) and #2 (database ping); #2 is closed, but #4 remains open.
-- PR #19 for #4 is open, non-draft, conflicting, and has no review comments or CI results; issue #4 remains in its worker-owned review lane, so #5 remains blocked until that dependency reaches a terminal state.
-- The current branch is based on `origin/main`; no source changes were made for #5 because the health route must register into the pending router.
-- The native dependency listing confirms #4 blocks #5; the issue body's `Depends on: #4` remains as a redundant fallback declaration.
-- Recheck on 2026-08-23: issue #4 is still OPEN and PR #19 is still OPEN/non-draft with `mergeStateStatus=DIRTY`/`mergeable=CONFLICTING`; PR head is `7ff5a690524ff3e27386b6897fb3cae7e757b727`, and the native `blocked_by` relation is present. `HEAD` and `origin/main` are both `45318ceb0a52f73dc83692d0a80308ba854c999d`; neither contains `backend/internal/api`. No implementation or validation for #5 can proceed without importing unmerged server code.
-- Final recheck on 2026-08-23: #4 remains OPEN and PR #19 remains non-draft/conflicting at the same head; GitHub's dependency endpoint confirms #4 blocks #5. `HEAD` and `origin/main` remain `45318ceb0a52f73dc83692d0a80308ba854c999d`, with no `backend/internal/api`; no source or focused validation was added for #5.
-- Current recheck on 2026-08-23: #4 is still OPEN; PR #19 is still OPEN/non-draft with `mergeStateStatus=DIRTY` and `mergeable=CONFLICTING` at `7ff5a690524ff3e27386b6897fb3cae7e757b727`. The native `blocked_by` relation from #5 to #4 remains present. `HEAD` and `origin/main` are both `45318ceb0a52f73dc83692d0a80308ba854c999d`; `backend/internal/api` is still absent. No implementation or focused handler validation can proceed until #4 merges or reaches a terminal state.
-- Rework resumed on 2026-08-23 after #4 merged as PR #19. The project item is `In Progress`; the branch was rebased onto `origin/main` at `ac9b09a`. Implement the handler against the merged API package, then run focused and full backend validation before opening the #5 PR.
+- Added `backend/internal/api/handlers/health.go` with a `DatabasePinger` interface, documented response fields, RFC3339 UTC timestamps, and HTTP 503 failure handling.
+- Registered `GET /api/health` in `NewRouter`; `NewServer` accepts the database and version through `WithDatabase` and `WithVersion`, while `NewServerWithConfig` supplies the configured version.
+- Focused tests cover healthy, failed, and missing database dependencies plus router registration.
+- The project item is `In Progress`; #4 is terminal after PR #19 merged, and this branch is based on `origin/main` at `ac9b09a`.
+- Validation: disposable Detent-temp Go 1.26 copy passed `GOTOOLCHAIN=local GOSUMDB=off go test ./internal/api/handlers/...` and `go test ./...`; `gofmt -d`, `git diff --check`, and repository gate `true` pass locally. The checked-in module requires Go 1.27, unavailable in this worker.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -59,3 +59,4 @@
 - The project item is `In Progress`; #4 is terminal after PR #19 merged, and this branch is based on `origin/main` at `ac9b09a`.
 - Validation: disposable Detent-temp Go 1.26 copy passed `GOTOOLCHAIN=local GOSUMDB=off go test ./internal/api/handlers/...` and `go test ./...`; `gofmt -d`, `git diff --check`, and repository gate `true` pass locally. The checked-in module requires Go 1.27, unavailable in this worker.
 - PR #23 is open, non-draft, mergeable, references `Fixes #5`, has no review comments, and has green `Validate` CI.
+- Rework pass reconfirmed the acceptance criteria and found no actionable human, bot, or inline review feedback. Focused and full backend tests, `gofmt -d`, `git diff --check`, and `true` passed again from a Detent temporary Go 1.26 copy; no source correction was needed.

--- a/backend/internal/api/handlers/health.go
+++ b/backend/internal/api/handlers/health.go
@@ -1,0 +1,71 @@
+// Package handlers contains HTTP handlers for the API.
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+const (
+	statusHealthy   = "healthy"
+	statusUnhealthy = "unhealthy"
+	databaseReady   = "connected"
+	databaseDown    = "disconnected"
+)
+
+// DatabasePinger is the database capability required by the health endpoint.
+// db.DB satisfies this interface while tests can provide a small fake.
+type DatabasePinger interface {
+	PingDB(context.Context) error
+}
+
+// HealthResponse is the stable JSON contract returned by the health endpoint.
+type HealthResponse struct {
+	Status    string `json:"status"`
+	Timestamp string `json:"timestamp"`
+	Database  string `json:"database"`
+	Version   string `json:"version"`
+	Error     string `json:"error,omitempty"`
+}
+
+// HealthHandler reports API and database readiness.
+type HealthHandler struct {
+	database DatabasePinger
+	version  string
+	now      func() time.Time
+}
+
+// NewHealthHandler creates a health endpoint using the supplied database
+// dependency and application version.
+func NewHealthHandler(database DatabasePinger, version string) *HealthHandler {
+	return &HealthHandler{
+		database: database,
+		version:  version,
+		now:      time.Now,
+	}
+}
+
+// ServeHTTP writes the health response. Database failures are intentionally
+// reported as service-unavailable responses without exposing driver errors.
+func (h *HealthHandler) ServeHTTP(w http.ResponseWriter, request *http.Request) {
+	response := HealthResponse{
+		Status:    statusHealthy,
+		Timestamp: h.now().UTC().Format(time.RFC3339),
+		Database:  databaseReady,
+		Version:   h.version,
+	}
+	statusCode := http.StatusOK
+
+	if h.database == nil || h.database.PingDB(request.Context()) != nil {
+		response.Status = statusUnhealthy
+		response.Database = databaseDown
+		response.Error = "database unavailable"
+		statusCode = http.StatusServiceUnavailable
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(response)
+}

--- a/backend/internal/api/handlers/health_test.go
+++ b/backend/internal/api/handlers/health_test.go
@@ -1,0 +1,95 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type fakeDatabase struct {
+	err    error
+	called bool
+}
+
+func (f *fakeDatabase) PingDB(context.Context) error {
+	f.called = true
+	return f.err
+}
+
+func TestHealthHandlerHealthy(t *testing.T) {
+	database := &fakeDatabase{}
+	handler := NewHealthHandler(database, "1.2.3")
+	handler.now = func() time.Time {
+		return time.Date(2026, time.August, 23, 17, 0, 0, 0, time.FixedZone("PDT", -7*60*60))
+	}
+
+	recording := httptest.NewRecorder()
+	handler.ServeHTTP(recording, httptest.NewRequest(http.MethodGet, "/api/health", nil))
+
+	if recording.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recording.Code, http.StatusOK)
+	}
+	if recording.Header().Get("Content-Type") != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", recording.Header().Get("Content-Type"))
+	}
+
+	var response HealthResponse
+	decodeHealthResponse(t, recording, &response)
+	if response != (HealthResponse{
+		Status:    statusHealthy,
+		Timestamp: "2026-08-24T00:00:00Z",
+		Database:  databaseReady,
+		Version:   "1.2.3",
+	}) {
+		t.Fatalf("response = %#v", response)
+	}
+	if !database.called {
+		t.Fatal("health handler did not ping the database")
+	}
+}
+
+func TestHealthHandlerDatabaseFailure(t *testing.T) {
+	database := &fakeDatabase{err: errors.New("connection refused")}
+	handler := NewHealthHandler(database, "1.2.3")
+	handler.now = func() time.Time { return time.Date(2026, time.August, 23, 17, 0, 0, 0, time.UTC) }
+
+	recording := httptest.NewRecorder()
+	handler.ServeHTTP(recording, httptest.NewRequest(http.MethodGet, "/api/health", nil))
+
+	if recording.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recording.Code, http.StatusServiceUnavailable)
+	}
+
+	var response HealthResponse
+	decodeHealthResponse(t, recording, &response)
+	if response.Status != statusUnhealthy || response.Database != databaseDown {
+		t.Fatalf("response status/database = %q/%q", response.Status, response.Database)
+	}
+	if response.Error != "database unavailable" {
+		t.Fatalf("response error = %q", response.Error)
+	}
+	if response.Version != "1.2.3" || response.Timestamp != "2026-08-23T17:00:00Z" {
+		t.Fatalf("response metadata = %#v", response)
+	}
+}
+
+func TestHealthHandlerWithoutDatabaseIsUnavailable(t *testing.T) {
+	handler := NewHealthHandler(nil, "1.2.3")
+	recording := httptest.NewRecorder()
+	handler.ServeHTTP(recording, httptest.NewRequest(http.MethodGet, "/api/health", nil))
+
+	if recording.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recording.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func decodeHealthResponse(t *testing.T, recording *httptest.ResponseRecorder, response *HealthResponse) {
+	t.Helper()
+	if err := json.NewDecoder(recording.Body).Decode(response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+}

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/chrismott/miniclass/internal/api/handlers"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
@@ -15,7 +16,9 @@ const apiBasePath = "/api"
 // RouterOptions configures the HTTP router independently of process startup.
 type RouterOptions struct {
 	AllowedOrigins []string
+	Database       handlers.DatabasePinger
 	Logger         *slog.Logger
+	Version        string
 }
 
 // NewRouter builds the complete API router and middleware chain.
@@ -53,6 +56,7 @@ func NewRouter(options RouterOptions) chi.Router {
 		apiRouter.NotFound(jsonNotFound)
 		apiRouter.MethodNotAllowed(jsonMethodNotAllowed)
 		apiRouter.Get("/", apiRoot)
+		apiRouter.Get("/health", handlers.NewHealthHandler(options.Database, options.Version).ServeHTTP)
 	})
 	router.Get(apiBasePath, apiRoot)
 

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -6,20 +6,26 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/chrismott/miniclass/internal/api/handlers"
 	"github.com/chrismott/miniclass/internal/config"
 )
 
-const defaultServerAddress = ":8080"
+const (
+	defaultServerAddress = ":8080"
+	defaultServerVersion = "0.1.0"
+)
 
 // ServerOptions controls construction of a Server without starting a process.
 type ServerOptions struct {
 	Address           string
 	AllowedOrigins    []string
+	Database          handlers.DatabasePinger
 	Logger            *slog.Logger
 	ReadTimeout       time.Duration
 	ReadHeaderTimeout time.Duration
 	WriteTimeout      time.Duration
 	IdleTimeout       time.Duration
+	Version           string
 }
 
 // Server owns the HTTP handler and server settings used by the API process.
@@ -34,6 +40,7 @@ type Server struct {
 func NewServer(options ...ServerOption) *Server {
 	settings := ServerOptions{
 		Address:           defaultServerAddress,
+		Version:           defaultServerVersion,
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       15 * time.Second,
 		WriteTimeout:      15 * time.Second,
@@ -53,7 +60,9 @@ func NewServer(options ...ServerOption) *Server {
 
 	router := NewRouter(RouterOptions{
 		AllowedOrigins: settings.AllowedOrigins,
+		Database:       settings.Database,
 		Logger:         settings.Logger,
+		Version:        settings.Version,
 	})
 	httpServer := &http.Server{
 		Addr:              settings.Address,
@@ -70,7 +79,7 @@ func NewServer(options ...ServerOption) *Server {
 // NewServerWithConfig constructs a server using the configured application
 // port while preserving the same independent construction behavior.
 func NewServerWithConfig(cfg config.Config, options ...ServerOption) *Server {
-	options = append([]ServerOption{WithAddress(":" + cfg.Port)}, options...)
+	options = append([]ServerOption{WithAddress(":" + cfg.Port), WithVersion(cfg.AppVersion)}, options...)
 	return NewServer(options...)
 }
 
@@ -86,6 +95,16 @@ func WithAddress(address string) ServerOption {
 // the development default of allowing all origins.
 func WithAllowedOrigins(origins ...string) ServerOption {
 	return func(options *ServerOptions) { options.AllowedOrigins = origins }
+}
+
+// WithDatabase sets the dependency checked by the health endpoint.
+func WithDatabase(database handlers.DatabasePinger) ServerOption {
+	return func(options *ServerOptions) { options.Database = database }
+}
+
+// WithVersion sets the application version reported by the health endpoint.
+func WithVersion(version string) ServerOption {
+	return func(options *ServerOptions) { options.Version = version }
 }
 
 // WithLogger sets the structured logger used by request and panic middleware.

--- a/backend/internal/api/server_test.go
+++ b/backend/internal/api/server_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -11,6 +12,10 @@ import (
 
 	"github.com/chrismott/miniclass/internal/config"
 )
+
+type routeHealthDatabase struct{}
+
+func (routeHealthDatabase) PingDB(context.Context) error { return nil }
 
 func TestNewServerConstructsWithoutStartingProcess(t *testing.T) {
 	server := NewServer(
@@ -94,6 +99,27 @@ func TestRouterReturnsJSONForUnsupportedRequests(t *testing.T) {
 				t.Fatalf("error response = %#v, want message %q", response, test.message)
 			}
 		})
+	}
+}
+
+func TestRouterServesHealthEndpoint(t *testing.T) {
+	router := NewRouter(RouterOptions{
+		Database: routeHealthDatabase{},
+		Version:  "1.2.3",
+	})
+	recording := httptest.NewRecorder()
+	router.ServeHTTP(recording, httptest.NewRequest(http.MethodGet, "/api/health", nil))
+
+	if recording.Code != http.StatusOK {
+		t.Fatalf("GET /api/health status = %d, want %d", recording.Code, http.StatusOK)
+	}
+
+	var response map[string]string
+	if err := json.NewDecoder(recording.Body).Decode(&response); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	if response["status"] != "healthy" || response["database"] != "connected" || response["version"] != "1.2.3" {
+		t.Fatalf("health response = %#v", response)
 	}
 }
 


### PR DESCRIPTION
Fixes #5

Adds `GET /api/health` to the merged Chi API router.

Behavior:
- Healthy database: HTTP 200 with `status`, UTC `timestamp`, `database`, and `version`.
- Missing or failed database: HTTP 503 with an unhealthy status and safe JSON error.
- Server construction accepts the database pinger and configured application version.

Validation:
- `cd backend && go test ./internal/api/handlers/...` (passed in disposable Go 1.26 module copy)
- `cd backend && go test ./...` (passed in disposable Go 1.26 module copy)
- `gofmt -d`
- `git diff --check`
- `true`

CI stage:
- Validate: `git diff --check`
