### PR TITLE
feat: wire API entry point and graceful shutdown

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -28,6 +28,7 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 - Added `backend/migrations/00001_initial_schema.sql` using Goose Up/Down markers.
 - The initial schema creates a reversible `health_checks` table with a UUID v7 primary key, status, timestamp, and non-empty status constraint. PostgreSQL 16 compatibility is provided by the schema-local `miniclass_uuid_v7()` function.
 - Rework validation: `git diff --check` passes; Docker PostgreSQL smoke testing is unavailable because the Docker daemon is not running.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -22,3 +22,11 @@
 - Local Go 1.26 cannot honor the repository's Go 1.27 directive because toolchain checksum-cache access is restricted. Disposable Detent temp copy with only `go.mod` set to 1.26 passes `GOSUMDB=off go test ./...`.
 - Repository gate `true`, `gofmt -d`, and `git diff --check` pass. CI has one `Validate` job running `git diff --check`; no CI checks are currently configured beyond that.
 - Workpad comment on issue #2 is complete. PR #18 is open, non-draft, references `Fixes #2`, and has no actionable review comments; keep the issue in its Detent-managed worker lane for promotion.
+
+## API entry point blocker
+
+- Rechecked 2026-08-23: issue #6 remains based on `origin/main` (`45318ce`) with no source changes or PR.
+- PR #19 for required issue #4 remains open, non-draft, and conflicting (`mergeStateStatus=DIRTY`, `mergeable=CONFLICTING`); its implementation exists only on the unmerged PR head, not on `origin/main`.
+- Issue #5 remains open and also waits on #4, so the API route contract is not available on this branch.
+- The native dependency endpoint is available but requires numeric issue IDs; the #6 → #4 relation was re-attempted and the legacy `Depends on: #4` declaration remains in the issue body.
+- Re-check after #4 merges or reaches a terminal state. Do not copy the dependency commit into this issue.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -28,5 +28,5 @@
 - Rechecked 2026-08-23 during Rework: `HEAD` is `39762da`; fetched remote `main` is `600a705` in `FETCH_HEAD`. Updating the shared `origin/main` remote-tracking ref was not permitted in this managed worktree.
 - The fetched `main` tree still has no `backend/internal/api`, so issue #6 has no safe implementation base and no PR.
 - Native dependencies for #6 list issues #4 and #5 as open blockers; issues #1 and #2 are closed. Issue #4's PR #19 remains open, non-draft, and conflicting (`mergeStateStatus=DIRTY`, `mergeable=CONFLICTING`), with the implementation only on that unmerged PR head.
-- The issue #6 Workpad was updated with `status: blocked`, typed dependency predicates, and no human action required. No source changes, commit, push, or PR were made for this attempt.
+- The issue #6 Workpad was updated with `status: blocked`, typed dependency predicates, and no human action required. No source changes or PR were made; handoff-note commit `92aeec6` was pushed.
 - Re-check after #4 and #5 reach terminal states. Do not copy the dependency commit into this issue.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -71,3 +71,10 @@
 - Native dependencies #1, #2, #4, and #5 are terminal. Issue #6 has no PR or source implementation yet.
 - Implement `backend/cmd/api/main.go` with configuration loading, verified database startup, configured HTTP server startup, signal-triggered graceful shutdown, and resource cleanup.
 - Validation plan: focused API/config/db tests, full backend tests, startup/shutdown smoke test, `gofmt -d`, `git diff --check`, and `true`.
+
+## API entry point implementation
+
+- Added `backend/cmd/api/main.go`; it loads config, creates the ping-verified pgx database, constructs `api.Server`, logs address/environment/version, handles SIGINT/SIGTERM, applies a 10-second shutdown timeout, and defers database cleanup.
+- Added lifecycle tests for graceful context cancellation and listen failures in `backend/cmd/api/main_test.go`.
+- Direct Go commands cannot use the checked-in Go 1.27 directive because the worker cannot access the toolchain checksum cache. Disposable `$TMPDIR` copies with a Go 1.26 directive passed focused tests, `go test ./...`, `go build ./cmd/api`, and the missing-`DATABASE_URL` startup smoke test.
+- Final local checks: `gofmt -d`, `git diff --check`, and repository gate `true` pass.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -25,6 +25,7 @@
 
 ## Initial database migration
 
+<<<<<<< HEAD
 - Added `backend/migrations/00001_initial_schema.sql` using Goose Up/Down markers.
 - The initial schema creates a reversible `health_checks` table with a UUID v7 primary key, status, timestamp, and non-empty status constraint. PostgreSQL 16 compatibility is provided by the schema-local `miniclass_uuid_v7()` function.
 - Rework validation: `git diff --check` passes; Docker PostgreSQL smoke testing is unavailable because the Docker daemon is not running.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -60,3 +60,10 @@
 - Validation: disposable Detent-temp Go 1.26 copy passed `GOTOOLCHAIN=local GOSUMDB=off go test ./internal/api/handlers/...` and `go test ./...`; `gofmt -d`, `git diff --check`, and repository gate `true` pass locally. The checked-in module requires Go 1.27, unavailable in this worker.
 - PR #23 is open, non-draft, mergeable, references `Fixes #5`, has no review comments, and has green `Validate` CI.
 - Rework pass reconfirmed the acceptance criteria and found no actionable human, bot, or inline review feedback. Focused and full backend tests, `gofmt -d`, `git diff --check`, and `true` passed again from a Detent temporary Go 1.26 copy; no source correction was needed.
+
+## API entry point (#6)
+
+- Issue #5 and PR #23 merged into `main`; the current base is `origin/main` at `1b4f608` and includes the complete API/server/health contracts.
+- Native dependencies #1, #2, #4, and #5 are terminal. Issue #6 has no PR or source implementation yet.
+- Implement `backend/cmd/api/main.go` with configuration loading, verified database startup, configured HTTP server startup, signal-triggered graceful shutdown, and resource cleanup.
+- Validation plan: focused API/config/db tests, full backend tests, startup/shutdown smoke test, `gofmt -d`, `git diff --check`, and `true`.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -26,6 +26,7 @@
 ## Initial database migration
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 - Added `backend/migrations/00001_initial_schema.sql` using Goose Up/Down markers.
 - The initial schema creates a reversible `health_checks` table with a UUID v7 primary key, status, timestamp, and non-empty status constraint. PostgreSQL 16 compatibility is provided by the schema-local `miniclass_uuid_v7()` function.
 - Rework validation: `git diff --check` passes; Docker PostgreSQL smoke testing is unavailable because the Docker daemon is not running.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -25,8 +25,8 @@
 
 ## API entry point blocker
 
-- Rechecked 2026-08-23: `HEAD` is `b875cda` and `origin/main` is `45318ce`; issue #6 has no source changes or PR.
-- `backend/internal/api` is absent on this base. PR #19 for required issue #4 remains open, non-draft, and conflicting (`mergeStateStatus=DIRTY`, `mergeable=CONFLICTING`); its implementation exists only on the unmerged PR head.
-- Issue #5 remains open and also waits on #4, so the API route and health-handler contracts are not available here.
-- GitHub's dependency endpoint previously returned 404 for #6, so the issue body's legacy `Depends on: #4` declaration remains the machine-readable fallback.
-- Re-check after #4 merges or reaches a terminal state. Do not copy the dependency commit into this issue.
+- Rechecked 2026-08-23 during Rework: `HEAD` is `39762da`; fetched remote `main` is `600a705` in `FETCH_HEAD`. Updating the shared `origin/main` remote-tracking ref was not permitted in this managed worktree.
+- The fetched `main` tree still has no `backend/internal/api`, so issue #6 has no safe implementation base and no PR.
+- Native dependencies for #6 list issues #4 and #5 as open blockers; issues #1 and #2 are closed. Issue #4's PR #19 remains open, non-draft, and conflicting (`mergeStateStatus=DIRTY`, `mergeable=CONFLICTING`), with the implementation only on that unmerged PR head.
+- The issue #6 Workpad was updated with `status: blocked`, typed dependency predicates, and no human action required. No source changes, commit, push, or PR were made for this attempt.
+- Re-check after #4 and #5 reach terminal states. Do not copy the dependency commit into this issue.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -25,8 +25,8 @@
 
 ## API entry point blocker
 
-- Rechecked 2026-08-23: `HEAD` is `c3ddb9f` and `origin/main` is `45318ce`; issue #6 has no source changes or PR.
+- Rechecked 2026-08-23: `HEAD` is `b875cda` and `origin/main` is `45318ce`; issue #6 has no source changes or PR.
 - `backend/internal/api` is absent on this base. PR #19 for required issue #4 remains open, non-draft, and conflicting (`mergeStateStatus=DIRTY`, `mergeable=CONFLICTING`); its implementation exists only on the unmerged PR head.
 - Issue #5 remains open and also waits on #4, so the API route and health-handler contracts are not available here.
-- GitHub's dependency endpoint returned 404 for #6, so the issue body's legacy `Depends on: #4` declaration remains the machine-readable fallback.
+- GitHub's dependency endpoint previously returned 404 for #6, so the issue body's legacy `Depends on: #4` declaration remains the machine-readable fallback.
 - Re-check after #4 merges or reaches a terminal state. Do not copy the dependency commit into this issue.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -27,6 +27,7 @@
 
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 - Added `backend/migrations/00001_initial_schema.sql` using Goose Up/Down markers.
 - The initial schema creates a reversible `health_checks` table with a UUID v7 primary key, status, timestamp, and non-empty status constraint. PostgreSQL 16 compatibility is provided by the schema-local `miniclass_uuid_v7()` function.
 - Rework validation: `git diff --check` passes; Docker PostgreSQL smoke testing is unavailable because the Docker daemon is not running.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -25,8 +25,9 @@
 
 ## API entry point blocker
 
-- Rechecked 2026-08-23 during Rework: `HEAD` is `39762da`; fetched remote `main` is `600a705` in `FETCH_HEAD`. Updating the shared `origin/main` remote-tracking ref was not permitted in this managed worktree.
-- The fetched `main` tree still has no `backend/internal/api`, so issue #6 has no safe implementation base and no PR.
-- Native dependencies for #6 list issues #4 and #5 as open blockers; issues #1 and #2 are closed. Issue #4's PR #19 remains open, non-draft, and conflicting (`mergeStateStatus=DIRTY`, `mergeable=CONFLICTING`), with the implementation only on that unmerged PR head.
-- The issue #6 Workpad was updated with `status: blocked`, typed dependency predicates, and no human action required. No source changes or PR were made; handoff-note commit `92aeec6` was pushed.
-- Re-check after #4 and #5 reach terminal states. Do not copy the dependency commit into this issue.
+- Rechecked 2026-08-23 during Rework: fetched `main` is `ac9b09a`, which includes the merged API server/middleware package from issue #4.
+- Issue #5 remains open. Its health-handler implementation is only on clean, non-draft PR #23, so the #6 entry point has no complete merged API contract yet.
+- Native dependencies for #6 are #1, #2, #4, and #5; #1, #2, and #4 are closed, while #5 remains open.
+- The issue #6 Workpad was updated with `status: blocked`, a typed dependency predicate for `christophergm/miniclass#5`, and `human_action: null`.
+- The current worktree has no source changes for #6 and no PR. Existing local commits are handoff-note/documentation work only; do not copy the unmerged dependency commit into this issue.
+- Re-check after #5 reaches a terminal state, then rebase or merge current `main` and implement the entry point.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -25,8 +25,8 @@
 
 ## API entry point blocker
 
-- Rechecked 2026-08-23: issue #6 remains based on `origin/main` (`45318ce`) with no source changes or PR.
-- PR #19 for required issue #4 remains open, non-draft, and conflicting (`mergeStateStatus=DIRTY`, `mergeable=CONFLICTING`); its implementation exists only on the unmerged PR head, not on `origin/main`.
-- Issue #5 remains open and also waits on #4, so the API route contract is not available on this branch.
-- The native dependency endpoint is available but requires numeric issue IDs; the #6 → #4 relation was re-attempted and the legacy `Depends on: #4` declaration remains in the issue body.
+- Rechecked 2026-08-23: `HEAD` is `c3ddb9f` and `origin/main` is `45318ce`; issue #6 has no source changes or PR.
+- `backend/internal/api` is absent on this base. PR #19 for required issue #4 remains open, non-draft, and conflicting (`mergeStateStatus=DIRTY`, `mergeable=CONFLICTING`); its implementation exists only on the unmerged PR head.
+- Issue #5 remains open and also waits on #4, so the API route and health-handler contracts are not available here.
+- GitHub's dependency endpoint returned 404 for #6, so the issue body's legacy `Depends on: #4` declaration remains the machine-readable fallback.
 - Re-check after #4 merges or reaches a terminal state. Do not copy the dependency commit into this issue.

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -1,0 +1,101 @@
+// Command api starts the MiniClass HTTP API.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/chrismott/miniclass/internal/api"
+	"github.com/chrismott/miniclass/internal/config"
+	"github.com/chrismott/miniclass/internal/db"
+)
+
+const shutdownTimeout = 10 * time.Second
+
+type httpServer interface {
+	ListenAndServe() error
+	Shutdown(context.Context) error
+}
+
+func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	if err := run(context.Background(), logger); err != nil {
+		logger.Error("API server stopped with error", slog.Any("error", err))
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	signalContext, stopSignals := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load API configuration: %w", err)
+	}
+
+	database, err := db.New(signalContext, cfg)
+	if err != nil {
+		return fmt.Errorf("start database: %w", err)
+	}
+	defer database.Close()
+
+	server := api.NewServerWithConfig(
+		*cfg,
+		api.WithDatabase(database),
+		api.WithLogger(logger),
+	)
+	return serve(signalContext, cfg, server.HTTPServer, logger)
+}
+
+func serve(ctx context.Context, cfg *config.Config, server httpServer, logger *slog.Logger) error {
+	if cfg == nil {
+		return errors.New("serve API: configuration is nil")
+	}
+	if server == nil {
+		return errors.New("serve API: HTTP server is nil")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	serverErrors := make(chan error, 1)
+	go func() {
+		serverErrors <- server.ListenAndServe()
+	}()
+
+	address := ":" + cfg.Port
+	logger.Info("API server listening",
+		slog.String("address", address),
+		slog.String("environment", cfg.AppEnv),
+		slog.String("version", cfg.AppVersion),
+	)
+
+	select {
+	case err := <-serverErrors:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return fmt.Errorf("serve API: %w", err)
+	case <-ctx.Done():
+		shutdownContext, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+
+		logger.Info("shutting down API server", slog.String("reason", ctx.Err().Error()))
+		if err := server.Shutdown(shutdownContext); err != nil {
+			return fmt.Errorf("shutdown API server: %w", err)
+		}
+		return nil
+	}
+}

--- a/backend/cmd/api/main_test.go
+++ b/backend/cmd/api/main_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/chrismott/miniclass/internal/config"
+)
+
+type fakeHTTPServer struct {
+	listen      chan struct{}
+	shutdown    chan struct{}
+	shutdownErr error
+}
+
+func (f *fakeHTTPServer) ListenAndServe() error {
+	<-f.listen
+	return http.ErrServerClosed
+}
+
+func (f *fakeHTTPServer) Shutdown(context.Context) error {
+	close(f.shutdown)
+	close(f.listen)
+	return f.shutdownErr
+}
+
+func TestServeGracefullyShutsDownOnContextCancellation(t *testing.T) {
+	server := &fakeHTTPServer{listen: make(chan struct{}), shutdown: make(chan struct{})}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- serve(ctx, &config.Config{AppEnv: "test", AppVersion: "1.2.3", Port: "8080"}, server, testLogger())
+	}()
+
+	cancel()
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("serve() error = %v", err)
+		}
+	case <-server.shutdown:
+		if err := <-result; err != nil {
+			t.Fatalf("serve() error = %v", err)
+		}
+	}
+}
+
+func TestServeReturnsListenFailure(t *testing.T) {
+	wantErr := errors.New("listen failed")
+	server := &listenErrorServer{err: wantErr}
+
+	err := serve(context.Background(), &config.Config{AppEnv: "test", AppVersion: "1.2.3", Port: "8080"}, server, testLogger())
+	if !strings.Contains(err.Error(), "serve API: listen failed") {
+		t.Fatalf("serve() error = %v", err)
+	}
+}
+
+type listenErrorServer struct {
+	err error
+}
+
+func (s *listenErrorServer) ListenAndServe() error { return s.err }
+
+func (*listenErrorServer) Shutdown(context.Context) error { return nil }
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+}


### PR DESCRIPTION
Fixes #6

## Summary
- add the `backend/cmd/api` process entry point
- load and validate configuration before creating the database pool
- start the configured Chi HTTP server with address/environment/version logging
- handle SIGINT/SIGTERM with bounded graceful shutdown and deferred database cleanup
- add lifecycle tests for shutdown and listen failures

## Validation
- `cd backend && go test ./cmd/api ./internal/api/... ./internal/config/... ./internal/db/...` (passed in disposable Go 1.26 copy)
- `cd backend && go test ./...` (passed in disposable Go 1.26 copy)
- `cd backend && go build ./cmd/api` (passed in disposable Go 1.26 copy)
- missing-`DATABASE_URL` `go run ./cmd/api` smoke test (actionable failure, exit 1)
- `gofmt -d`, `git diff --check`, and `true`

## CI stage
- Validate: `git diff --check`
