### PR TITLE
feat: implement typed frontend API client

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -8,3 +8,5 @@
 - Issue #5/PR #23 and all native dependencies for #6 are terminal; current base is `origin/main` at `1b4f608`.
 - Go 1.27 is unavailable in this worker because its toolchain checksum cache is restricted. Disposable copies under `$TMPDIR` with a Go 1.26 directive passed focused tests, `go test ./...`, `go build ./cmd/api`, and the missing-`DATABASE_URL` startup smoke test.
 - Final local checks: `gofmt -d`, `git diff --check`, and repository gate `true` pass. Live PostgreSQL startup/shutdown was not available.
+- Issue #10 adds `frontend/src/lib/api.ts`: `ApiClient.getHealth()` reads `VITE_API_URL`, validates the health contract, and normalizes HTTP/network/decode failures as `ApiError`; tests use the injectable `fetch` option.
+- Issue #10 validation: `cd frontend && npm test -- --run`, `npm run build`, and `npm run lint` pass. `npm ci` required an isolated cache under `$TMPDIR` because the shared npm cache was root-owned.

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ApiClient, type HealthResponse } from './api'
+
+type Fetch = typeof globalThis.fetch
+
+const healthyResponse: HealthResponse = {
+  status: 'healthy',
+  timestamp: '2026-08-24T00:00:00Z',
+  database: 'connected',
+  version: '0.1.0',
+}
+
+function response(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  })
+}
+
+describe('ApiClient', () => {
+  it('gets and decodes the health response from the configured API URL', async () => {
+    const fetch = vi.fn<Parameters<Fetch>, ReturnType<Fetch>>().mockResolvedValue(response(healthyResponse))
+    const client = new ApiClient({ baseUrl: 'https://api.example.test/', fetch })
+
+    await expect(client.getHealth()).resolves.toEqual(healthyResponse)
+    expect(fetch).toHaveBeenCalledWith('https://api.example.test/api/health', {
+      headers: { Accept: 'application/json' },
+    })
+  })
+
+  it('normalizes HTTP failures', async () => {
+    const fetch = vi.fn<Parameters<Fetch>, ReturnType<Fetch>>().mockResolvedValue(
+      response({ error: 'database unavailable' }, { status: 503, statusText: 'Service Unavailable' }),
+    )
+    const client = new ApiClient({ fetch })
+
+    await expect(client.getHealth()).rejects.toMatchObject({
+      kind: 'http',
+      message: 'database unavailable',
+      status: 503,
+    })
+  })
+
+  it('normalizes network and decoding failures', async () => {
+    const networkFetch = vi.fn<Parameters<Fetch>, ReturnType<Fetch>>().mockRejectedValue(new Error('offline'))
+    const decodeFetch = vi.fn<Parameters<Fetch>, ReturnType<Fetch>>().mockResolvedValue(new Response('not-json', { status: 200 }))
+
+    await expect(new ApiClient({ fetch: networkFetch }).getHealth()).rejects.toMatchObject({ kind: 'network' })
+    await expect(new ApiClient({ fetch: decodeFetch }).getHealth()).rejects.toMatchObject({ kind: 'decode', status: 200 })
+  })
+
+  it('rejects a successful response with the wrong shape', async () => {
+    const fetch = vi.fn<Parameters<Fetch>, ReturnType<Fetch>>().mockResolvedValue(response({ status: 'ok' }))
+
+    await expect(new ApiClient({ fetch }).getHealth()).rejects.toMatchObject({ kind: 'decode', status: 200 })
+  })
+})

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,98 @@
+export type HealthResponse = {
+  status: 'healthy' | 'unhealthy'
+  timestamp: string
+  database: 'connected' | 'disconnected'
+  version: string
+  error?: string
+}
+
+export type ApiErrorKind = 'http' | 'network' | 'decode'
+
+export class ApiError extends Error {
+  readonly kind: ApiErrorKind
+  readonly status?: number
+
+  constructor(kind: ApiErrorKind, message: string, status?: number) {
+    super(message)
+    this.name = 'ApiError'
+    this.kind = kind
+    this.status = status
+  }
+}
+
+export type ApiClientOptions = {
+  baseUrl?: string
+  fetch?: typeof globalThis.fetch
+}
+
+const configuredBaseUrl = import.meta.env.VITE_API_URL ?? ''
+
+function joinUrl(baseUrl: string, path: string) {
+  return `${baseUrl.replace(/\/$/, '')}${path}`
+}
+
+function isHealthResponse(value: unknown): value is HealthResponse {
+  if (typeof value !== 'object' || value === null) return false
+
+  const response = value as Record<string, unknown>
+  return (
+    (response.status === 'healthy' || response.status === 'unhealthy') &&
+    typeof response.timestamp === 'string' &&
+    (response.database === 'connected' || response.database === 'disconnected') &&
+    typeof response.version === 'string' &&
+    (response.error === undefined || typeof response.error === 'string')
+  )
+}
+
+export class ApiClient {
+  private readonly baseUrl: string
+  private readonly request: typeof globalThis.fetch
+
+  constructor(options: ApiClientOptions = {}) {
+    this.baseUrl = options.baseUrl ?? configuredBaseUrl
+    this.request = options.fetch ?? globalThis.fetch.bind(globalThis)
+  }
+
+  async getHealth(): Promise<HealthResponse> {
+    return this.get<HealthResponse>('/api/health', isHealthResponse)
+  }
+
+  private async get<T>(path: string, decode: (value: unknown) => value is T): Promise<T> {
+    let response: Response
+    try {
+      response = await this.request(joinUrl(this.baseUrl, path), {
+        headers: { Accept: 'application/json' },
+      })
+    } catch {
+      throw new ApiError('network', 'Unable to reach the API')
+    }
+
+    if (!response.ok) {
+      let message = `The API request failed with status ${response.status}`
+      try {
+        const payload: unknown = await response.json()
+        if (typeof payload === 'object' && payload !== null && 'error' in payload && typeof payload.error === 'string') {
+          message = payload.error
+        }
+      } catch {
+        // Keep the normalized HTTP error when an error response is not JSON.
+      }
+      throw new ApiError('http', message, response.status)
+    }
+
+    let payload: unknown
+    try {
+      payload = await response.json()
+    } catch {
+      throw new ApiError('decode', 'The API returned invalid JSON', response.status)
+    }
+
+    if (!decode(payload)) {
+      throw new ApiError('decode', 'The API returned an unexpected response', response.status)
+    }
+
+    return payload
+  }
+}
+
+export const apiClient = new ApiClient()

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary
- add a typed fetch client for the backend health endpoint
- read the API base URL from `VITE_API_URL`
- normalize network, HTTP, and response decoding failures with `ApiError`
- add focused Vitest coverage using the injectable fetch seam

Fixes #10

## Validation
- `cd frontend && npm test -- --run`
- `cd frontend && npm run build`
- `cd frontend && npm run lint`
- `git diff --check`
- `true`