### PR TITLE
test: add backend health integration test

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -7,6 +7,9 @@
 - API entry point: `backend/cmd/api/main.go` loads config, starts the verified database and HTTP server, logs address/environment/version, handles SIGINT/SIGTERM with a 10-second graceful-shutdown timeout, and defers database cleanup.
 - Current base: `origin/main` at `bd867a1`, with migrations, health endpoint, HTTP server, and API entry point merged.
 - Integration test target: `backend/tests/integration`; `backend/Makefile` target `test` runs `go test -v ./tests/integration/... -count=1`.
+- Health integration test: `backend/tests/integration/health_test.go` requires `TEST_DATABASE_URL`, creates a unique schema, applies Goose migrations, uses the real pgx-backed API health handler, asserts direct connectivity and `/api/health`, and drops the schema during cleanup.
+- README documents the Docker Compose `miniclass_test` prerequisite; the Makefile `.env` include is optional so `make test` works with exported variables in a clean checkout.
 - Project CI quality gate: `Validate` runs `git diff --check`; repository validation gate is `true`.
 - Go 1.27 may be unavailable in this worker because its toolchain checksum cache is restricted; prior disposable Go 1.26 copies passed backend tests with `GOTOOLCHAIN=local GOSUMDB=off`.
+- Validation: disposable Go 1.26 copy passed `make test`, `go test ./...`, and `go build ./...`; live PostgreSQL execution was unavailable because the Docker daemon is not running.
 - Issue #8 Workpad: https://github.com/christophergm/miniclass/issues/8#issuecomment-5386372050

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -4,7 +4,9 @@
 - Backend config: `backend/internal/config` loads dotenv values, applies defaults, and requires `DATABASE_URL`.
 - Backend database: `backend/internal/db` creates and pings the pgx pool and closes it idempotently.
 - Backend API: `backend/internal/api` provides the Chi router, middleware, `NewServerWithConfig`, `/api`, and `/api/health`.
-- Issue #6 entry point: `backend/cmd/api/main.go` loads config, starts the verified database and HTTP server, logs address/environment/version, handles SIGINT/SIGTERM with a 10-second graceful-shutdown timeout, and defers database cleanup. Lifecycle tests are in `backend/cmd/api/main_test.go`.
-- Issue #5/PR #23 and all native dependencies for #6 are terminal; current base is `origin/main` at `1b4f608`.
-- Go 1.27 is unavailable in this worker because its toolchain checksum cache is restricted. Disposable copies under `$TMPDIR` with a Go 1.26 directive passed focused tests, `go test ./...`, `go build ./cmd/api`, and the missing-`DATABASE_URL` startup smoke test.
-- Final local checks: `gofmt -d`, `git diff --check`, and repository gate `true` pass. Live PostgreSQL startup/shutdown was not available.
+- API entry point: `backend/cmd/api/main.go` loads config, starts the verified database and HTTP server, logs address/environment/version, handles SIGINT/SIGTERM with a 10-second graceful-shutdown timeout, and defers database cleanup.
+- Current base: `origin/main` at `bd867a1`, with migrations, health endpoint, HTTP server, and API entry point merged.
+- Integration test target: `backend/tests/integration`; `backend/Makefile` target `test` runs `go test -v ./tests/integration/... -count=1`.
+- Project CI quality gate: `Validate` runs `git diff --check`; repository validation gate is `true`.
+- Go 1.27 may be unavailable in this worker because its toolchain checksum cache is restricted; prior disposable Go 1.26 copies passed backend tests with `GOTOOLCHAIN=local GOSUMDB=off`.
+- Issue #8 Workpad: https://github.com/christophergm/miniclass/issues/8#issuecomment-5386372050

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -12,4 +12,5 @@
 - Project CI quality gate: `Validate` runs `git diff --check`; repository validation gate is `true`.
 - Go 1.27 may be unavailable in this worker because its toolchain checksum cache is restricted; prior disposable Go 1.26 copies passed backend tests with `GOTOOLCHAIN=local GOSUMDB=off`.
 - Validation: disposable Go 1.26 copy passed `make test`, `go test ./...`, and `go build ./...`; live PostgreSQL execution was unavailable because the Docker daemon is not running.
+- PR #26 is open, non-draft, references `Fixes #8`, and its current-head `Validate` check passed; no review comments are present.
 - Issue #8 Workpad: https://github.com/christophergm/miniclass/issues/8#issuecomment-5386372050

--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ replacement, or `npm run build` to verify the production bundle.
 
 ### Development Commands
 
+#### Backend integration test
+
+The PostgreSQL health integration test requires an isolated test database. Start
+the local PostgreSQL service, then set `TEST_DATABASE_URL` to the
+`miniclass_test` database created by Docker Compose:
+
+```bash
+docker compose up -d postgres
+export TEST_DATABASE_URL='postgres://miniclass:miniclass_dev_password@localhost:5432/miniclass_test?sslmode=disable'
+cd backend
+make test
+```
+
+Each test run creates a unique schema, applies the migrations, and drops that
+schema during cleanup. Do not point `TEST_DATABASE_URL` at a development or
+production database.
+
 **Backend:**
 ```bash
 cd backend

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help dev build test migrate-up migrate-down migrate-create seed reset-db sqlc install-tools
 
 # Load environment variables
-include ../.env
+-include ../.env
 export
 
 help: ## Show this help message

--- a/backend/tests/integration/health_test.go
+++ b/backend/tests/integration/health_test.go
@@ -1,0 +1,122 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chrismott/miniclass/internal/api"
+	"github.com/chrismott/miniclass/internal/api/handlers"
+	"github.com/chrismott/miniclass/internal/db"
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/pressly/goose/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthIntegration(t *testing.T) {
+	testDatabaseURL := strings.TrimSpace(os.Getenv("TEST_DATABASE_URL"))
+	if testDatabaseURL == "" {
+		t.Skip("TEST_DATABASE_URL is required for the PostgreSQL integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	adminPool, err := pgxpool.New(ctx, testDatabaseURL)
+	require.NoError(t, err)
+	if err != nil {
+		return
+	}
+	require.NoError(t, adminPool.Ping(ctx))
+	t.Cleanup(adminPool.Close)
+
+	schemaName := fmt.Sprintf("miniclass_test_%d", time.Now().UnixNano())
+	_, err = adminPool.Exec(ctx, "CREATE SCHEMA "+schemaName)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, cleanupErr := adminPool.Exec(context.Background(), "DROP SCHEMA IF EXISTS "+schemaName+" CASCADE")
+		require.NoError(t, cleanupErr)
+	})
+
+	schemaURL, err := withSearchPath(testDatabaseURL, schemaName)
+	require.NoError(t, err)
+
+	gooseDB, err := goose.OpenDBWithDriver("postgres", schemaURL)
+	require.NoError(t, err)
+	if err != nil {
+		return
+	}
+	t.Cleanup(func() { require.NoError(t, gooseDB.Close()) })
+	require.NoError(t, gooseDB.PingContext(ctx))
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	if !ok {
+		return
+	}
+	migrationsDir := filepath.Join(filepath.Dir(currentFile), "..", "..", "migrations")
+	require.NoError(t, goose.Up(gooseDB, migrationsDir))
+
+	database, err := db.NewFromURL(ctx, schemaURL)
+	require.NoError(t, err)
+	if err != nil {
+		return
+	}
+	t.Cleanup(database.Close)
+	require.NoError(t, database.PingDB(ctx))
+
+	var migrated bool
+	require.NoError(t, database.Pool().QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.tables
+			WHERE table_schema = current_schema()
+			  AND table_name = 'health_checks'
+		)`).Scan(&migrated))
+	require.True(t, migrated, "health_checks migration was not applied")
+
+	server := api.NewServer(
+		api.WithAddress("test"),
+		api.WithDatabase(database),
+		api.WithVersion("integration-test"),
+	)
+	httpServer := httptest.NewServer(server.Handler())
+	t.Cleanup(httpServer.Close)
+
+	response, err := http.Get(httpServer.URL + "/api/health")
+	require.NoError(t, err)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	var health handlers.HealthResponse
+	require.NoError(t, json.NewDecoder(response.Body).Decode(&health))
+	require.Equal(t, "healthy", health.Status)
+	require.Equal(t, "connected", health.Database)
+	require.Equal(t, "integration-test", health.Version)
+	require.NotEmpty(t, health.Timestamp)
+}
+
+func withSearchPath(databaseURL, schemaName string) (string, error) {
+	parsed, err := url.Parse(databaseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse test database URL: %w", err)
+	}
+
+	query := parsed.Query()
+	query.Set("options", "-csearch_path="+schemaName)
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
+}


### PR DESCRIPTION
Fixes #8

## Summary
- add a PostgreSQL-backed health integration test using a unique per-run schema
- apply Goose migrations before asserting direct database connectivity and `GET /api/health`
- clean up the isolated schema after the test and document Docker/test-database prerequisites
- allow the backend Makefile to run without a checked-in `.env` file

## Validation
- disposable Go 1.26 copy with `GOTOOLCHAIN=local GOSUMDB=off make test`
- disposable Go 1.26 copy with `GOTOOLCHAIN=local GOSUMDB=off go test ./...`
- disposable Go 1.26 copy with `GOTOOLCHAIN=local GOSUMDB=off go build ./...`
- `gofmt -d`, `git diff --check`, and repository gate `true`
- live PostgreSQL execution unavailable in this worker because the Docker daemon is not running

## CI stage
- Validate: `git diff --check`