### PR TITLE
test: add full-stack local smoke test

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -38,3 +38,10 @@
 - Regression coverage: `frontend/src/App.test.tsx` verifies the root overview and health component are rendered.
 - Validation: `cd frontend && npm run test -- --run` (9 tests), `npm run lint`, `npm run build`, repository gate `true`, and `git diff --check` pass.
 - No skill draft created; the change used the existing frontend patterns and did not expose a reusable non-obvious procedure.
+
+## Full-stack local smoke test (#13)
+
+- Current `origin/main` contains the merged migration, seed, backend API entrypoint and health route, backend integration test, typed frontend API client, and frontend health page needed to execute the smoke test.
+- Dependency #8 is closed through merged PR #26. Dependency #12 remains open administratively, but the required frontend implementation is merged in PR #21 and present on current `main`.
+- Add the smoke harness and documentation now that dependency implementations are available.
+- Project CI contract: `Validate` runs `git diff --check`; local repository gate is `true`.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -43,5 +43,9 @@
 
 - Current `origin/main` contains the merged migration, seed, backend API entrypoint and health route, backend integration test, typed frontend API client, and frontend health page needed to execute the smoke test.
 - Dependency #8 is closed through merged PR #26. Dependency #12 remains open administratively, but the required frontend implementation is merged in PR #21 and present on current `main`.
-- Add the smoke harness and documentation now that dependency implementations are available.
+- `scripts/smoke-test.sh` starts PostgreSQL/Adminer, applies migrations, starts backend/frontend processes, checks `/api/health` and `/health`, prints the browser check, and preserves logs under `TMPDIR`.
+- README now documents prerequisites, service URLs, the smoke command, the manual browser verification, Adminer, and failure diagnosis. `.env.example` uses the backend origin for `VITE_API_URL` because the frontend client appends `/api/health`.
+- Frontend validation passes: `npm run test -- --run` (8 tests), `npm run lint`, and `npm run build`.
+- Backend validation passes in a disposable `TMPDIR` copy with Go 1.27 lowered to 1.26: `GOTOOLCHAIN=local GOSUMDB=off go test ./...` (integration test skips without `TEST_DATABASE_URL`).
+- The documented smoke command was attempted with `.env.example`; it stopped at `docker compose up` because the local Docker daemon is unavailable. No live database/browser result is claimed.
 - Project CI contract: `Validate` runs `git diff --check`; local repository gate is `true`.

--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ API_BASE_URL=http://localhost:8080
 
 # Frontend
 VITE_PORT=5173
-VITE_API_URL=http://localhost:8080/api
+VITE_API_URL=http://localhost:8080
 
 # Database
 POSTGRES_HOST=localhost

--- a/README.md
+++ b/README.md
@@ -225,6 +225,41 @@ Expected response:
 }
 ```
 
+## Full-stack smoke test
+
+The smoke test starts the local PostgreSQL and Adminer services, applies
+migrations, starts the API and frontend, and checks the API and frontend HTTP
+surfaces:
+
+```bash
+cp .env.example .env        # first run only
+cd frontend && npm install  # first run only
+cd ..
+./scripts/smoke-test.sh
+```
+
+The script keeps backend, frontend, migration, and Compose output in a
+temporary directory under `TMPDIR` and prints the directory on success. On
+failure it prints the last lines of each log and the database service logs.
+After the automated checks pass, open
+[http://localhost:5173/health](http://localhost:5173/health) and confirm that
+the page says **All systems operational**, shows **Connected**, and displays
+the API version. The API response is also available at
+[http://localhost:8080/api/health](http://localhost:8080/api/health), and
+Adminer is at [http://localhost:8081](http://localhost:8081) with `postgres` as
+the server name.
+
+For diagnosis, inspect the printed log directory first. API startup or health
+failures are in `backend.log` and `migrations.log`; frontend startup or browser
+failures are in `frontend.log`; PostgreSQL readiness and container failures are
+in `postgres-ready.log` and `compose-up.log`. Common causes are Docker not
+running, a port already in use, a stale database volume, or `DATABASE_URL` not
+matching the Compose credentials. Stop local containers after the check with:
+
+```bash
+docker compose down
+```
+
 ## Production Deployment
 
 - Backend: Render

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
+LOG_DIR="${SMOKE_LOG_DIR:-${TMPDIR:-/tmp}/miniclass-smoke-$(date +%Y%m%d-%H%M%S)}"
+TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-60}"
+
+backend_pid=""
+frontend_pid=""
+compose_available=0
+
+die() {
+  echo "Smoke test failed: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "'$1' is required"
+}
+
+cleanup() {
+  status=$?
+
+  if [[ "$status" -ne 0 ]]; then
+    echo >&2
+    echo "Smoke-test logs: $LOG_DIR" >&2
+    for log_file in "$LOG_DIR"/*.log; do
+      [[ -f "$log_file" ]] || continue
+      echo >&2
+      echo "--- $(basename "$log_file") ---" >&2
+      tail -n 40 "$log_file" >&2 || true
+    done
+    if [[ "$compose_available" -eq 1 ]]; then
+      echo >&2
+      echo "--- docker compose logs ---" >&2
+      docker compose --env-file "$ENV_FILE" logs --no-color --tail=40 postgres adminer >&2 || true
+    fi
+  else
+    echo "Smoke test passed. Logs: $LOG_DIR"
+  fi
+
+  for pid in "$backend_pid" "$frontend_pid"; do
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+
+  exit "$status"
+}
+trap cleanup EXIT
+
+[[ -f "$ENV_FILE" ]] || die "missing $ENV_FILE; run 'cp .env.example .env' first"
+
+require_command docker
+require_command curl
+require_command go
+require_command npm
+docker compose version >/dev/null 2>&1 || die "Docker Compose is required"
+compose_available=1
+
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
+POSTGRES_USER="${POSTGRES_USER:-miniclass}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-miniclass_dev_password}"
+POSTGRES_DB="${POSTGRES_DB:-miniclass}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+PORT="${PORT:-8080}"
+VITE_PORT="${VITE_PORT:-5173}"
+DATABASE_URL="${DATABASE_URL:-postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=disable}"
+API_BASE_URL="${API_BASE_URL:-http://localhost:${PORT}}"
+API_BASE_URL="${API_BASE_URL%/}"
+API_BASE_URL="${API_BASE_URL%/api}"
+FRONTEND_URL="http://localhost:${VITE_PORT}"
+
+export DATABASE_URL PORT API_BASE_URL
+# The client appends /api/health, so this value is the backend origin.
+export VITE_API_URL="$API_BASE_URL"
+
+mkdir -p "$LOG_DIR"
+
+echo "Starting PostgreSQL and Adminer..."
+docker compose --env-file "$ENV_FILE" up -d postgres adminer >"$LOG_DIR/compose-up.log" 2>&1
+
+echo "Waiting for PostgreSQL..."
+for _ in $(seq 1 "$TIMEOUT_SECONDS"); do
+  if docker compose --env-file "$ENV_FILE" exec -T postgres pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" >"$LOG_DIR/postgres-ready.log" 2>&1; then
+    break
+  fi
+  sleep 1
+done
+docker compose --env-file "$ENV_FILE" exec -T postgres pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" >"$LOG_DIR/postgres-ready.log" 2>&1 \
+  || die "PostgreSQL did not become ready within ${TIMEOUT_SECONDS}s"
+
+echo "Applying database migrations..."
+(cd "$ROOT_DIR/backend" && go run ./cmd/migrate up) >"$LOG_DIR/migrations.log" 2>&1 \
+  || die "database migrations failed"
+
+echo "Starting backend at $API_BASE_URL..."
+(cd "$ROOT_DIR/backend" && exec go run ./cmd/api) >"$LOG_DIR/backend.log" 2>&1 &
+backend_pid=$!
+
+echo "Waiting for backend health..."
+for _ in $(seq 1 "$TIMEOUT_SECONDS"); do
+  if curl --fail --silent --show-error "$API_BASE_URL/api/health" >"$LOG_DIR/api-health.json" 2>"$LOG_DIR/api-health.err"; then
+    break
+  fi
+  sleep 1
+done
+
+health_response="$(cat "$LOG_DIR/api-health.json" 2>/dev/null || true)"
+printf '%s' "$health_response" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"' \
+  || die "GET $API_BASE_URL/api/health did not report a healthy API"
+printf '%s' "$health_response" | grep -Eq '"database"[[:space:]]*:[[:space:]]*"connected"' \
+  || die "GET $API_BASE_URL/api/health did not report a connected database"
+echo "Backend health: $health_response"
+
+echo "Starting frontend at $FRONTEND_URL..."
+(cd "$ROOT_DIR/frontend" && exec npm run dev -- --host 127.0.0.1) >"$LOG_DIR/frontend.log" 2>&1 &
+frontend_pid=$!
+
+echo "Waiting for frontend route..."
+for _ in $(seq 1 "$TIMEOUT_SECONDS"); do
+  if curl --fail --silent --show-error "$FRONTEND_URL/health" >"$LOG_DIR/frontend-health.html" 2>"$LOG_DIR/frontend-health.err"; then
+    break
+  fi
+  sleep 1
+done
+curl --fail --silent --show-error "$FRONTEND_URL/health" >"$LOG_DIR/frontend-health.html" 2>"$LOG_DIR/frontend-health.err" \
+  || die "frontend did not serve $FRONTEND_URL/health"
+
+echo
+echo "Automated checks passed:"
+echo "  - PostgreSQL is ready and migrations are applied"
+echo "  - $API_BASE_URL/api/health reports healthy/connected"
+echo "  - $FRONTEND_URL/health is served by Vite"
+echo
+echo "Manual browser check: open $FRONTEND_URL/health and confirm"
+echo "  'All systems operational', 'Connected', and the current API version are visible."
+echo "Adminer: http://localhost:${ADMINER_PORT:-8081} (server: postgres)"


### PR DESCRIPTION
Fixes #13

## Summary
- add `scripts/smoke-test.sh` to start local PostgreSQL/Adminer, apply migrations, start API/frontend, and check `/api/health` plus the frontend `/health` route
- add explicit browser-visible health verification and log/URL troubleshooting guidance to the README
- correct `.env.example` so `VITE_API_URL` is the backend origin expected by the frontend API client

## Validation
- `cd frontend && npm run test -- --run` — 8 tests passed
- `cd frontend && npm run lint` — passed
- `cd frontend && npm run build` — passed
- disposable `TMPDIR` backend copy with Go 1.26 directive adjustment: `GOTOOLCHAIN=local GOSUMDB=off go test ./...` — passed; integration test skips without `TEST_DATABASE_URL`
- `bash -n scripts/smoke-test.sh`, `gofmt -d`, `git diff --check`, and `true` — passed
- `ENV_FILE=.env.example SMOKE_TIMEOUT_SECONDS=2 ./scripts/smoke-test.sh` — attempted; stopped at Compose because the local Docker daemon is not running, with failure logs emitted as designed

## CI stage
- Validate: `git diff --check`
