### PR TITLE
ci: make quality gates reproducible

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -6,6 +6,7 @@
 - `.github/workflows/ci.yml` publishes `Backend tests`, `Frontend tests`, `Frontend build`, `Frontend lint`, and `Repository formatting`; backend CI supplies PostgreSQL and `TEST_DATABASE_URL`.
 - `WORKFLOW.md` and `README.md` document the local commands and exact CI check names.
 - Validation: frontend `npm ci`, 9 tests, build, lint, YAML parse, and `git diff --check` pass. Local backend execution could not start because only Go 1.26 is installed and the restricted host cannot download Go 1.27; CI uses `actions/setup-go` from `backend/go.mod`.
+- First CI backend run exposed a Goose parsing failure for the dollar-quoted UUID function; migration `00001_initial_schema.sql` now wraps that function in Goose statement-boundary directives.
 - Open item: commit/push, open PR with `Fixes #14`, inspect current-head CI/reviews, then update the Workpad.
 
 - Issue #9 adds the initial React/TypeScript frontend shell under `frontend/src`.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -1,5 +1,13 @@
 # Detent handoff notes
 
+## Issue #14 quality gates
+
+- `backend/Makefile` target `test` now runs `go test -v ./... -count=1`, including unit and integration packages.
+- `.github/workflows/ci.yml` publishes `Backend tests`, `Frontend tests`, `Frontend build`, `Frontend lint`, and `Repository formatting`; backend CI supplies PostgreSQL and `TEST_DATABASE_URL`.
+- `WORKFLOW.md` and `README.md` document the local commands and exact CI check names.
+- Validation: frontend `npm ci`, 9 tests, build, lint, YAML parse, and `git diff --check` pass. Local backend execution could not start because only Go 1.26 is installed and the restricted host cannot download Go 1.27; CI uses `actions/setup-go` from `backend/go.mod`.
+- Open item: commit/push, open PR with `Fixes #14`, inspect current-head CI/reviews, then update the Workpad.
+
 - Issue #9 adds the initial React/TypeScript frontend shell under `frontend/src`.
 - Entry point: `frontend/src/main.tsx`; router and layout: `frontend/src/App.tsx`; global styling: `frontend/src/index.css`.
 - Vite entry document is `frontend/index.html`; `BrowserRouter` serves `/` plus placeholder routes for `/classes`, `/assignments`, `/students`, and `/settings`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,100 @@ permissions:
   contents: read
 
 jobs:
-  validate:
-    name: Validate
+  backend:
+    name: Backend tests
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: miniclass
+          POSTGRES_PASSWORD: miniclass_dev_password
+          POSTGRES_DB: miniclass_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U miniclass -d miniclass_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      TEST_DATABASE_URL: postgres://miniclass:miniclass_dev_password@localhost:5432/miniclass_test?sslmode=disable
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Validate repository formatting
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+
+      - name: Run backend tests
+        working-directory: backend
+        run: make test
+
+  frontend-test:
+    name: Frontend tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Run frontend tests
+        working-directory: frontend
+        run: npm run test -- --run
+
+  frontend-build:
+    name: Frontend build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
+  frontend-lint:
+    name: Frontend lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Lint frontend
+        working-directory: frontend
+        run: npm run lint
+
+  formatting:
+    name: Repository formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Check diff formatting
         run: git diff --check

--- a/README.md
+++ b/README.md
@@ -171,6 +171,20 @@ To run multiple instances in parallel:
 
 ## Testing
 
+The reproducible quality gates are:
+
+```bash
+cd backend && make test
+cd frontend && npm ci && npm run test -- --run
+cd frontend && npm ci && npm run build
+cd frontend && npm ci && npm run lint
+git diff --check
+```
+
+CI runs the backend integration test against PostgreSQL and publishes separate
+checks for backend tests, frontend tests, frontend build, frontend lint, and
+repository formatting.
+
 **Backend Integration Tests:**
 ```bash
 cd backend

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -14,10 +14,11 @@ Replace these placeholders with the project's required stage categories and
 the project-specific local command and CI check name that satisfy each one. Add
 or remove categories to match the project.
 
-- `<required-stage-category>`: local command `<project-command>`; CI check
-  `<project-check-name>`
-- `<required-stage-category>`: local command `<project-command>`; CI check
-  `<project-check-name>`
+- Backend tests: local command `cd backend && make test`; CI check `Backend tests`
+- Frontend tests: local command `cd frontend && npm ci && npm run test -- --run`; CI check `Frontend tests`
+- Frontend build: local command `cd frontend && npm ci && npm run build`; CI check `Frontend build`
+- Frontend lint: local command `cd frontend && npm ci && npm run lint`; CI check `Frontend lint`
+- Repository formatting: local command `git diff --check`; CI check `Repository formatting`
 
 Treat this list as part of the project contract. Whenever you touch CI
 configuration or perform a review, verify that every declared stage exists,

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -50,9 +50,9 @@ reset-db: ## Drop, recreate, migrate, and seed database
 sqlc: ## Generate sqlc code from queries
 	sqlc generate
 
-test: ## Run integration tests
-	@echo "Running integration tests..."
-	go test -v ./tests/integration/... -count=1
+test: ## Run all backend unit and integration tests
+	@echo "Running backend tests..."
+	go test -v ./... -count=1
 
 test-coverage: ## Run tests with coverage report
 	@echo "Running tests with coverage..."

--- a/backend/migrations/00001_initial_schema.sql
+++ b/backend/migrations/00001_initial_schema.sql
@@ -2,6 +2,7 @@
 
 -- PostgreSQL 16 does not provide uuidv7(), so keep generation local to the
 -- schema while preserving the UUID v7 layout for every generated ID.
+-- +goose StatementBegin
 CREATE FUNCTION miniclass_uuid_v7() RETURNS UUID
 LANGUAGE SQL
 VOLATILE
@@ -28,6 +29,7 @@ AS $$
     )::UUID
     FROM random_value, timestamp_value;
 $$;
+-- +goose StatementEnd
 
 CREATE TABLE health_checks (
     id UUID PRIMARY KEY DEFAULT miniclass_uuid_v7(),


### PR DESCRIPTION
Fixes #14

## Summary
- run the complete backend test suite through `make test`
- add reproducible CI jobs for backend tests, frontend tests/build/lint, and formatting
- document the local quality gates and CI check names

## Validation
- `npm ci && npm run test -- --run` (9 tests)
- `npm run build`
- `npm run lint`
- `git diff --check`
- workflow YAML parse
- backend local run requires Go 1.27, which is provisioned by CI