### PR TITLE
chore: update PostgreSQL to 18

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -66,3 +66,10 @@
 - Current schema only has `health_checks`; there are no teacher/class/student/assignment tables or fixtures yet.
 - Dependencies #7, #13, and #14 are closed. Validate with `true`, `git diff --check`, frontend checks, and backend tests where the installed Go toolchain permits.
 - Validation: `true`, `git diff --check`, `sh -n scripts/smoke-test.sh`, reset confirmation guard, frontend `npm ci`, 9 tests, lint, and build pass. Backend `go test ./... -count=1` is unavailable locally because Go 1.26 is installed while `backend/go.mod` requires Go 1.27.
+
+## Issue #31 PostgreSQL 18 upgrade
+
+- Local Compose uses `postgres:18-alpine`; CI's backend service uses `postgres:18`.
+- `STRUCTURE.md` now documents PostgreSQL 18. The initial migration uses PostgreSQL 18's built-in `uuidv7()` and removes the PostgreSQL 16 compatibility function.
+- Validation: disposable-TMPDIR backend `GOTOOLCHAIN=local GOSUMDB=off go test -v ./... -count=1` passes (integration test skips without `TEST_DATABASE_URL`); frontend `npm ci`, 9 tests, build, lint, Compose config, and `git diff --check` pass. Exact `cd backend && make test` cannot run because Go 1.27 is not installed locally.
+- Open item: commit/push, open PR with `Fixes #31`, inspect current-head CI/reviews, and update the Workpad.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -72,4 +72,4 @@
 - Local Compose uses `postgres:18-alpine`; CI's backend service uses `postgres:18`.
 - `STRUCTURE.md` now documents PostgreSQL 18. The initial migration uses PostgreSQL 18's built-in `uuidv7()` and removes the PostgreSQL 16 compatibility function.
 - Validation: disposable-TMPDIR backend `GOTOOLCHAIN=local GOSUMDB=off go test -v ./... -count=1` passes (integration test skips without `TEST_DATABASE_URL`); frontend `npm ci`, 9 tests, build, lint, Compose config, and `git diff --check` pass. Exact `cd backend && make test` cannot run because Go 1.27 is not installed locally.
-- Open item: commit/push, open PR with `Fixes #31`, inspect current-head CI/reviews, and update the Workpad.
+- PR #32 is open, non-draft, references `Fixes #31`, and all five current-head CI checks pass with no review comments. The Workpad is ready for the completion declaration.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16
+        image: postgres:18
         env:
           POSTGRES_USER: miniclass
           POSTGRES_PASSWORD: miniclass_dev_password

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -173,7 +173,7 @@ graph TD
 - **Testing:** Go testing + testify
 
 ### Database
-- **Engine:** PostgreSQL 16
+- **Engine:** PostgreSQL 18
 - **Local:** Docker container
 - **Production:** Supabase managed
 - **GUI:** Adminer (port 8081)

--- a/backend/migrations/00001_initial_schema.sql
+++ b/backend/migrations/00001_initial_schema.sql
@@ -1,38 +1,7 @@
 -- +goose Up
 
--- PostgreSQL 16 does not provide uuidv7(), so keep generation local to the
--- schema while preserving the UUID v7 layout for every generated ID.
--- +goose StatementBegin
-CREATE FUNCTION miniclass_uuid_v7() RETURNS UUID
-LANGUAGE SQL
-VOLATILE
-AS $$
-    WITH random_value AS (
-        SELECT md5(random()::TEXT || clock_timestamp()::TEXT) AS hex
-    ), timestamp_value AS (
-        SELECT lpad(
-            to_hex(floor(extract(EPOCH FROM clock_timestamp()) * 1000)::BIGINT),
-            12,
-            '0'
-        ) AS hex
-    )
-    SELECT (
-        timestamp_value.hex
-        || '7'
-        || substr(random_value.hex, 14, 3)
-        || substr(
-            '89ab',
-            (get_byte(decode(substr(random_value.hex, 17, 2), 'hex'), 0) % 4) + 1,
-            1
-        )
-        || substr(random_value.hex, 18)
-    )::UUID
-    FROM random_value, timestamp_value;
-$$;
--- +goose StatementEnd
-
 CREATE TABLE health_checks (
-    id UUID PRIMARY KEY DEFAULT miniclass_uuid_v7(),
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
     status TEXT NOT NULL DEFAULT 'healthy',
     checked_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT health_checks_status_check CHECK (status <> '')
@@ -41,4 +10,3 @@ CREATE TABLE health_checks (
 -- +goose Down
 
 DROP TABLE IF EXISTS health_checks;
-DROP FUNCTION IF EXISTS miniclass_uuid_v7();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     container_name: miniclass-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-miniclass}


### PR DESCRIPTION
## Summary
- update local Compose and CI PostgreSQL images to 18
- use PostgreSQL 18 built-in `uuidv7()` in the initial schema
- update architecture documentation

## Validation
- `cd backend && make test` *(host lacks Go 1.27; equivalent disposable-TMPDIR Go 1.26 run passes, integration test skips without TEST_DATABASE_URL)*
- `cd frontend && npm ci && npm run test -- --run`
- `cd frontend && npm ci && npm run build`
- `cd frontend && npm ci && npm run lint`
- `git diff --check`
- `docker compose config --quiet`

Fixes #31