### PR TITLE
feat: backend quality gates and database roles

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -31,6 +31,25 @@
   Vitest wrapper fails locally with port.addListener incompatibility.
 - No skill draft: the implementation used existing project patterns.
 
+## Issue #37 quality gates, timestamped migrations, and roles
+
+- Existing in-progress changes expanded CI to exactly nine named checks, added race-enabled backend
+  tests, format/vet, pinned golangci-lint v1.64.8, generated-artifact drift, and migration round-trip.
+- `backend/sqlc.yaml` now emits to `internal/db/gen`; generation skips the currently absent
+  `backend/sql/queries` directory. Goose uses `WithAllowMissing`.
+- Added timestamped `20260824090000_database_roles.sql`. Compose bootstrap provisions roles and makes
+  the default database owned by `miniclass_migrator`; CI provisions roles and transfers the test DB.
+  `miniclass_app` is non-superuser, non-CREATEROLE, non-CREATEDB, `nobypassrls`, and has a 10s timeout.
+- Cluster roles are intentionally retained on migration down: rollback revokes per-database grants and
+  restores ownership to `miniclass_migrator`, because a database migration cannot safely drop roles used
+  by another database.
+- Validation: backend `make test` and `make format`/`make lint` pass; PostgreSQL 18 integration and
+  scratch `up/down/up` pass; fresh Compose-style bootstrap migration and role attributes pass; frontend
+  Node-launched Vitest (12), build, and lint pass. Bun's local Vitest wrapper still fails with its known
+  `port.addListener` incompatibility, while CI uses the required Bun command.
+- Open items: update the Workpad, create/push the PR with `Fixes #37`, then inspect current-head CI and
+  review comments before final completion.
+
 ## Issue #14 quality gates
 
 - `backend/Makefile` target `test` now runs `go test -v ./... -count=1`, including unit and integration packages.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -45,8 +45,9 @@
   by another database.
 - Validation: backend `make test` and `make format`/`make lint` pass; PostgreSQL 18 integration and
   scratch `up/down/up` pass; fresh Compose-style bootstrap migration and role attributes pass; frontend
-  Node-launched Vitest (12), build, and lint pass. Bun's local Vitest wrapper still fails with its known
-  `port.addListener` incompatibility, while CI uses the required Bun command.
+  Bun install/test (12), build, and lint pass after the test script was changed to invoke Vitest under
+  Node 24. CI's first run also confirmed the prebuilt golangci-lint binary needed `install-mode: goinstall`
+  to build against the repository's Go 1.26 target.
 - Open items: update the Workpad, create/push the PR with `Fixes #37`, then inspect current-head CI and
   review comments before final completion.
 

--- a/.detent/skills/postgres-role-migrations.md
+++ b/.detent/skills/postgres-role-migrations.md
@@ -1,0 +1,15 @@
+---
+name: postgres-role-migrations
+description: Safely bootstrap and roll back PostgreSQL migrator and app roles across databases.
+when_to_use: When a migration creates cluster-scoped PostgreSQL roles and must support both fresh bootstrap and per-database round trips.
+---
+
+Create roles in a privileged bootstrap script and repeat the guarded creation in the migration so
+pre-provisioned migrator connections do not attempt `CREATE ROLE` without `CREATEROLE`. Normalize role
+attributes only when the current role is privileged. Give the migrator database/schema ownership and
+grant the app role only schema usage, DML, required sequence usage, and function execution.
+
+Do not drop cluster roles from a database down migration: another database may depend on their grants
+or owned objects. Revoke this database's privileges, transfer its objects back to the migrator, and
+retain the roles. Round-trip tests should provision a scratch database owned by the migrator, run up
+as migrator, down as an admin, and up again as migrator.

--- a/.env.example
+++ b/.env.example
@@ -18,9 +18,11 @@ POSTGRES_PASSWORD=miniclass_dev_password
 POSTGRES_DB=miniclass
 POSTGRES_TEST_DB=miniclass_test
 
-# Database URL for migrations and app
-DATABASE_URL=postgres://miniclass:miniclass_dev_password@localhost:5432/miniclass?sslmode=disable
-TEST_DATABASE_URL=postgres://miniclass:miniclass_dev_password@localhost:5432/miniclass_test?sslmode=disable
+# Database URLs: migrations/tests use the migrator role; the API uses the app role.
+DATABASE_URL=postgres://miniclass_migrator:miniclass_migrator_dev_password@localhost:5432/miniclass?sslmode=disable
+TEST_DATABASE_URL=postgres://miniclass_migrator:miniclass_migrator_dev_password@localhost:5432/miniclass_test?sslmode=disable
+TEST_APP_DATABASE_URL=postgres://miniclass_app:miniclass_app_dev_password@localhost:5432/miniclass_test?sslmode=disable
+POSTGRES_ADMIN_DATABASE_URL=postgres://miniclass:miniclass_dev_password@localhost:5432/postgres?sslmode=disable
 
 # Supabase (leave empty for local dev, populate for production)
 SUPABASE_URL=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  backend:
+  backend-tests:
     name: Backend tests
     runs-on: ubuntu-latest
     services:
@@ -29,19 +29,105 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      TEST_DATABASE_URL: postgres://miniclass:miniclass_dev_password@localhost:5432/miniclass_test?sslmode=disable
+      POSTGRES_ADMIN_DATABASE_URL: postgres://miniclass:miniclass_dev_password@localhost:5432/postgres?sslmode=disable
+      TEST_DATABASE_URL: postgres://miniclass_migrator:miniclass_migrator_dev_password@localhost:5432/miniclass_test?sslmode=disable
+      TEST_APP_DATABASE_URL: postgres://miniclass_app:miniclass_app_dev_password@localhost:5432/miniclass_test?sslmode=disable
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: backend/go.mod
-
+      - name: Provision database roles
+        run: |
+          psql "$POSTGRES_ADMIN_DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/scripts/init-roles.sql
+          psql "$POSTGRES_ADMIN_DATABASE_URL" -v ON_ERROR_STOP=1 -c "alter database miniclass_test owner to miniclass_migrator"
       - name: Run backend tests
         working-directory: backend
         run: make test
+
+  backend-lint:
+    name: Backend lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+      - name: Run golangci-lint v1.64.8
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.8
+          working-directory: backend
+
+  backend-format:
+    name: Backend format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+      - name: Check format and vet
+        working-directory: backend
+        run: make format
+
+  generated-code-drift:
+    name: Generated code drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+      - name: Install sqlc
+        run: go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.27.0
+      - name: Regenerate backend artifacts
+        working-directory: backend
+        run: make generate
+      - name: Reject generated drift
+        run: git diff --exit-code
+
+  migration-round-trip:
+    name: Migration round-trip
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: miniclass
+          POSTGRES_PASSWORD: miniclass_dev_password
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U miniclass -d postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      POSTGRES_ADMIN_DATABASE_URL: postgres://miniclass:miniclass_dev_password@localhost:5432/postgres?sslmode=disable
+      MIGRATION_ROUNDTRIP_DATABASE_URL: postgres://miniclass_migrator:miniclass_migrator_dev_password@localhost:5432/miniclass_migration_roundtrip?sslmode=disable
+      MIGRATION_ROUNDTRIP_ADMIN_DATABASE_URL: postgres://miniclass:miniclass_dev_password@localhost:5432/miniclass_migration_roundtrip?sslmode=disable
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+      - name: Provision database roles
+        run: psql "$POSTGRES_ADMIN_DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/scripts/init-roles.sql
+      - name: Run migration round-trip
+        working-directory: backend
+        run: ./scripts/migration-round-trip.sh
 
   frontend-test:
     name: Frontend tests
@@ -56,7 +142,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
       - name: Install frontend dependencies
         working-directory: frontend
         run: bun install --frozen-lockfile
@@ -77,7 +163,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
       - name: Install frontend dependencies
         working-directory: frontend
         run: bun install --frozen-lockfile
@@ -98,7 +184,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
       - name: Install frontend dependencies
         working-directory: frontend
         run: bun install --frozen-lockfile
@@ -106,7 +192,7 @@ jobs:
         working-directory: frontend
         run: bun run lint
 
-  formatting:
+  repository-formatting:
     name: Repository formatting
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64.8
+          install-mode: goinstall
           working-directory: backend
 
   backend-format:

--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ the local PostgreSQL service, then set `TEST_DATABASE_URL` to the
 
 ```bash
 docker compose up -d postgres
-export TEST_DATABASE_URL='postgres://miniclass:miniclass_dev_password@localhost:5432/miniclass_test?sslmode=disable'
+export TEST_DATABASE_URL='postgres://miniclass_migrator:miniclass_migrator_dev_password@localhost:5432/miniclass_test?sslmode=disable'
+export TEST_APP_DATABASE_URL='postgres://miniclass_app:miniclass_app_dev_password@localhost:5432/miniclass_test?sslmode=disable'
 cd backend
 make test
 ```
@@ -225,15 +226,20 @@ The reproducible quality gates are:
 
 ```bash
 cd backend && make test
+cd backend && make lint
+cd backend && make format
+cd backend && make generate && git diff --exit-code
+cd backend && ./scripts/migration-round-trip.sh
 cd frontend && bun install --frozen-lockfile && bun run test -- --run
 cd frontend && bun install --frozen-lockfile && bun run build
 cd frontend && bun install --frozen-lockfile && bun run lint
 git diff --check
 ```
 
-CI runs the backend integration test against PostgreSQL and publishes separate
-checks for backend tests, frontend tests, frontend build, frontend lint, and
-repository formatting.
+CI runs the backend integration test against PostgreSQL and publishes exactly
+nine checks: Backend tests, Backend lint, Backend format, Generated code drift,
+Migration round-trip, Frontend tests, Frontend build, Frontend lint, and
+Repository formatting.
 
 **Backend Integration Tests:**
 ```bash

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -17,6 +17,10 @@ round-trip checks; whichever change adds a check updates this table in the same
 pull request.
 
 - Backend tests: local command `cd backend && make test`; CI check `Backend tests`
+- Backend lint: local command `cd backend && make lint`; CI check `Backend lint`
+- Backend format: local command `cd backend && make format`; CI check `Backend format`
+- Generated code drift: local command `cd backend && make generate && git diff --exit-code`; CI check `Generated code drift`
+- Migration round-trip: local command `cd backend && ./scripts/migration-round-trip.sh`; CI check `Migration round-trip`
 - Frontend tests: local command `cd frontend && bun install --frozen-lockfile && bun run test -- --run`; CI check `Frontend tests`
 - Frontend build: local command `cd frontend && bun install --frozen-lockfile && bun run build`; CI check `Frontend build`
 - Frontend lint: local command `cd frontend && bun install --frozen-lockfile && bun run lint`; CI check `Frontend lint`

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,0 +1,15 @@
+linters:
+  enable:
+    - bodyclose
+    - depguard
+    - sqlclosecheck
+
+linters-settings:
+  depguard:
+    rules:
+      main:
+        list-mode: lax
+        files:
+          - "$all"
+        allow:
+          - "$gostd"

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,8 @@
-.PHONY: help dev build test migrate-up migrate-down migrate-create seed reset-db sqlc install-tools
+.PHONY: help dev build test format lint generate migrate-up migrate-down migrate-create seed reset-db sqlc install-tools
+
+GOLANGCI_LINT_VERSION := v1.64.8
+SQLC_VERSION := v1.27.0
+GOOSE_VERSION := v3.19.2
 
 # Load environment variables
 -include ../.env
@@ -13,8 +17,9 @@ help: ## Show this help message
 install-tools: ## Install required Go tools
 	@echo "Installing development tools..."
 	go install github.com/air-verse/air@latest
-	go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
-	go install github.com/pressly/goose/v3/cmd/goose@latest
+	go install github.com/sqlc-dev/sqlc/cmd/sqlc@$(SQLC_VERSION)
+	go install github.com/pressly/goose/v3/cmd/goose@$(GOOSE_VERSION)
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	@echo "Tools installed!"
 
 dev: ## Run API server with hot reload (requires air)
@@ -48,12 +53,30 @@ reset-db: ## Drop, recreate, migrate, and seed the local database (requires RESE
 	$(MAKE) seed
 	@echo "Database reset complete!"
 
-sqlc: ## Generate sqlc code from queries
-	sqlc generate
-
 test: ## Run all backend unit and integration tests
 	@echo "Running backend tests..."
-	go test -v ./... -count=1
+	go test -race -v ./... -count=1
+
+format: ## Verify Go formatting and run the Go vet analyzer
+	@files="$$(gofmt -l .)"; \
+	if [ -n "$$files" ]; then \
+		echo "Unformatted Go files:"; \
+		echo "$$files"; \
+		exit 1; \
+	fi
+	go vet ./...
+
+lint: ## Run the pinned golangci-lint configuration
+	@command -v golangci-lint >/dev/null || { echo "golangci-lint $(GOLANGCI_LINT_VERSION) is required; run make install-tools"; exit 1; }
+	@golangci-lint version | grep -F "$(GOLANGCI_LINT_VERSION)" >/dev/null || { echo "golangci-lint $(GOLANGCI_LINT_VERSION) is required"; golangci-lint version; exit 1; }
+	golangci-lint run
+
+sqlc: ## Generate sqlc code from queries
+	@if [ -d sql/queries ]; then sqlc generate; else echo "No sql/queries directory; sqlc generation skipped."; fi
+
+generate: ## Regenerate all committed backend artifacts
+	$(MAKE) sqlc
+	go generate ./...
 
 test-coverage: ## Run tests with coverage report
 	@echo "Running tests with coverage..."

--- a/backend/cmd/migrate/main.go
+++ b/backend/cmd/migrate/main.go
@@ -46,7 +46,7 @@ func run(ctx context.Context, args []string, databaseURL string) error {
 	if err := db.PingContext(ctx); err != nil {
 		return fmt.Errorf("migration failed: database connection: %w", err)
 	}
-	if err := goose.RunContext(ctx, command, db, migrationDir); err != nil {
+	if err := goose.RunWithOptionsContext(ctx, command, db, migrationDir, nil, goose.WithAllowMissing()); err != nil {
 		return fmt.Errorf("migration failed: %w", err)
 	}
 

--- a/backend/migrations/20260824090000_database_roles.sql
+++ b/backend/migrations/20260824090000_database_roles.sql
@@ -1,0 +1,108 @@
+-- +goose Up
+
+-- Roles are cluster-scoped, so this migration is safe on databases that were
+-- initialized by Compose as well as on an existing PostgreSQL cluster.
+-- +goose StatementBegin
+do $$
+begin
+    if not exists (select 1 from pg_roles where rolname = 'miniclass_migrator') then
+        begin
+            create role miniclass_migrator login password 'miniclass_migrator_dev_password';
+        exception
+            when duplicate_object then null;
+        end;
+    end if;
+end
+$$;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+do $$
+begin
+    if not exists (select 1 from pg_roles where rolname = 'miniclass_app') then
+        begin
+            create role miniclass_app login password 'miniclass_app_dev_password';
+        exception
+            when duplicate_object then null;
+        end;
+    end if;
+end
+$$;
+-- +goose StatementEnd
+
+-- A pre-provisioned migrator can apply this migration without CREATEROLE. The
+-- bootstrap administrator sets role attributes; a privileged migration run
+-- repeats them so drift is corrected.
+-- +goose StatementBegin
+do $$
+begin
+    if (select rolsuper or rolcreaterole from pg_roles where rolname = current_user) then
+        alter role miniclass_migrator
+            nosuperuser nocreatedb nocreaterole inherit noreplication nobypassrls;
+        alter role miniclass_app
+            nosuperuser nocreatedb nocreaterole noinherit noreplication nobypassrls;
+        alter role miniclass_app set statement_timeout = '10s';
+    end if;
+end
+$$;
+-- +goose StatementEnd
+
+revoke create on schema public from public;
+grant usage on schema public to miniclass_app;
+
+-- The migrator owns the schema objects and is the only role that can create or
+-- alter them. Existing objects are transferred so down migrations also work
+-- when the command is run through the migrator URL.
+alter schema public owner to miniclass_migrator;
+alter table health_checks owner to miniclass_migrator;
+alter sequence public.xid_serial owner to miniclass_migrator;
+alter domain public.xid20 owner to miniclass_migrator;
+alter function public.xid_encode(integer[]) owner to miniclass_migrator;
+alter function public.xid(timestamptz) owner to miniclass_migrator;
+alter function public.xid_decode(public.xid20) owner to miniclass_migrator;
+alter function public.xid_time(public.xid20) owner to miniclass_migrator;
+alter function public.xid_machine(public.xid20) owner to miniclass_migrator;
+alter function public.xid_pid(public.xid20) owner to miniclass_migrator;
+alter function public.xid_counter(public.xid20) owner to miniclass_migrator;
+
+grant select, insert, update, delete on all tables in schema public to miniclass_app;
+grant usage, select, update on all sequences in schema public to miniclass_app;
+grant execute on function public.xid_encode(integer[]) to miniclass_app;
+grant execute on function public.xid(timestamptz) to miniclass_app;
+grant execute on function public.xid_decode(public.xid20) to miniclass_app;
+grant execute on function public.xid_time(public.xid20) to miniclass_app;
+grant execute on function public.xid_machine(public.xid20) to miniclass_app;
+grant execute on function public.xid_pid(public.xid20) to miniclass_app;
+grant execute on function public.xid_counter(public.xid20) to miniclass_app;
+
+alter default privileges for role miniclass_migrator in schema public
+    grant select, insert, update, delete on tables to miniclass_app;
+alter default privileges for role miniclass_migrator in schema public
+    grant usage, select, update on sequences to miniclass_app;
+
+-- +goose Down
+
+alter default privileges for role miniclass_migrator in schema public
+    revoke select, insert, update, delete on tables from miniclass_app;
+alter default privileges for role miniclass_migrator in schema public
+    revoke usage, select, update on sequences from miniclass_app;
+revoke all privileges on all tables in schema public from miniclass_app;
+revoke all privileges on all sequences in schema public from miniclass_app;
+revoke all privileges on all functions in schema public from miniclass_app;
+revoke all privileges on schema public from miniclass_app;
+drop owned by miniclass_app;
+
+-- Roles are cluster-scoped and may be used by another database on the same
+-- PostgreSQL cluster. A database rollback therefore removes this database's
+-- grants and ownership changes but intentionally leaves the roles in place.
+alter table health_checks owner to miniclass_migrator;
+alter sequence public.xid_serial owner to miniclass_migrator;
+alter domain public.xid20 owner to miniclass_migrator;
+alter function public.xid_encode(integer[]) owner to miniclass_migrator;
+alter function public.xid(timestamptz) owner to miniclass_migrator;
+alter function public.xid_decode(public.xid20) owner to miniclass_migrator;
+alter function public.xid_time(public.xid20) owner to miniclass_migrator;
+alter function public.xid_machine(public.xid20) owner to miniclass_migrator;
+alter function public.xid_pid(public.xid20) owner to miniclass_migrator;
+alter function public.xid_counter(public.xid20) owner to miniclass_migrator;
+alter schema public owner to miniclass_migrator;

--- a/backend/scripts/init-database.sql
+++ b/backend/scripts/init-database.sql
@@ -1,0 +1,4 @@
+-- The default database is created before these scripts run. Make the
+-- migrator its owner so local migrations can enforce schema ownership while
+-- the API still connects with the non-DDL app role.
+select format('alter database %I owner to miniclass_migrator', current_database()) \gexec

--- a/backend/scripts/init-roles.sql
+++ b/backend/scripts/init-roles.sql
@@ -1,0 +1,29 @@
+-- Local and CI bootstrap roles. The migration repeats this provision defensively
+-- for databases whose cluster initialization scripts were not run.
+do $$
+begin
+    if not exists (select 1 from pg_roles where rolname = 'miniclass_migrator') then
+        begin
+            create role miniclass_migrator login password 'miniclass_migrator_dev_password';
+        exception
+            when duplicate_object then null;
+        end;
+    end if;
+end
+$$;
+
+do $$
+begin
+    if not exists (select 1 from pg_roles where rolname = 'miniclass_app') then
+        begin
+            create role miniclass_app login password 'miniclass_app_dev_password';
+        exception
+            when duplicate_object then null;
+        end;
+    end if;
+end
+$$;
+
+alter role miniclass_app
+    nosuperuser nocreatedb nocreaterole noinherit noreplication nobypassrls;
+alter role miniclass_app set statement_timeout = '10s';

--- a/backend/scripts/init-test-db.sql
+++ b/backend/scripts/init-test-db.sql
@@ -1,4 +1,10 @@
--- Create test database
--- This runs during postgres container initialization
+-- Create the test database after init-roles.sql has provisioned its owner.
+-- This runs during postgres container initialization.
 
-CREATE DATABASE miniclass_test;
+create database miniclass_test owner miniclass_migrator;
+alter database miniclass_test owner to miniclass_migrator;
+
+\connect miniclass_test
+
+revoke create on schema public from public;
+grant usage on schema public to miniclass_app;

--- a/backend/scripts/migration-round-trip.sh
+++ b/backend/scripts/migration-round-trip.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+: "${POSTGRES_ADMIN_DATABASE_URL:?POSTGRES_ADMIN_DATABASE_URL is required}"
+: "${MIGRATION_ROUNDTRIP_DATABASE_URL:?MIGRATION_ROUNDTRIP_DATABASE_URL is required}"
+: "${MIGRATION_ROUNDTRIP_ADMIN_DATABASE_URL:?MIGRATION_ROUNDTRIP_ADMIN_DATABASE_URL is required}"
+
+database_name=miniclass_migration_roundtrip
+cleanup() {
+    psql "$POSTGRES_ADMIN_DATABASE_URL" -v ON_ERROR_STOP=1 \
+        -c "drop database if exists $database_name with (force)" >/dev/null
+}
+trap cleanup EXIT
+
+psql "$POSTGRES_ADMIN_DATABASE_URL" -v ON_ERROR_STOP=1 \
+    -c "drop database if exists $database_name with (force)" \
+    -c "create database $database_name owner miniclass_migrator"
+
+echo "Applying migrations"
+DATABASE_URL="$MIGRATION_ROUNDTRIP_DATABASE_URL" go run ./cmd/migrate up
+echo "Rolling migrations back"
+DATABASE_URL="$MIGRATION_ROUNDTRIP_ADMIN_DATABASE_URL" go run ./cmd/migrate down
+echo "Reapplying migrations"
+DATABASE_URL="$MIGRATION_ROUNDTRIP_DATABASE_URL" go run ./cmd/migrate up

--- a/backend/sqlc.yaml
+++ b/backend/sqlc.yaml
@@ -6,7 +6,7 @@ sql:
     gen:
       go:
         package: "db"
-        out: "internal/db"
+        out: "internal/db/gen"
         emit_json_tags: true
         emit_prepared_queries: false
         emit_interface: false

--- a/backend/tests/integration/health_test.go
+++ b/backend/tests/integration/health_test.go
@@ -65,7 +65,7 @@ func TestHealthIntegration(t *testing.T) {
 		return
 	}
 	migrationsDir := filepath.Join(filepath.Dir(currentFile), "..", "..", "migrations")
-	require.NoError(t, goose.Up(gooseDB, migrationsDir))
+	require.NoError(t, goose.Up(gooseDB, migrationsDir, goose.WithAllowMissing()))
 
 	database, err := db.NewFromURL(ctx, schemaURL)
 	require.NoError(t, err)

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,7 +15,9 @@ services:
       # PostgreSQL 18 changed the data directory layout. Mount /var/lib/postgresql rather than
       # /var/lib/postgresql/data so that in-place upgrades with `pg_upgrade --link` remain possible.
       - postgres_data:/var/lib/postgresql
-      - ./backend/scripts/init-test-db.sql:/docker-entrypoint-initdb.d/init-test-db.sql
+      - ./backend/scripts/init-roles.sql:/docker-entrypoint-initdb.d/00-init-roles.sql
+      - ./backend/scripts/init-database.sql:/docker-entrypoint-initdb.d/01-init-database.sql
+      - ./backend/scripts/init-test-db.sql:/docker-entrypoint-initdb.d/02-init-test-db.sql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-miniclass}"]
       interval: 5s

--- a/detent.yaml
+++ b/detent.yaml
@@ -155,7 +155,16 @@ gate:
     kind: command
     run: "true"
     require_automated_review: false
-    required_status_checks: []
+    required_status_checks:
+        - Backend tests
+        - Backend lint
+        - Backend format
+        - Generated code drift
+        - Migration round-trip
+        - Frontend tests
+        - Frontend build
+        - Frontend lint
+        - Repository formatting
     ci_failure_action: rework
     transient_ci_retry_limit: 2
     validator:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "build": "bunx --bun tsc && bunx --bun vite build",
     "lint": "bunx --bun eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "bunx --bun vite preview",
-    "test": "bunx --bun vitest run"
+    "test": "vitest run"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.28.4",


### PR DESCRIPTION
## Summary

- Adds exactly nine CI checks, including race-enabled backend tests, pinned golangci-lint, format/vet, generated-code drift, and PostgreSQL migration round-trip validation.
- Switches Goose invocation to timestamp-aware `--allow-missing` behavior and moves sqlc output to `backend/internal/db/gen`.
- Adds timestamped database-role provisioning for `miniclass_migrator` and `miniclass_app`, including Compose/CI bootstrap, app-role restrictions, default privileges, and 10-second statement timeout.

## Specification

Implements SPEC §9.2 and ADR 0007 (tenancy enforcement and data access) / ADR 0010 (schema, generated code, and migration conventions).

Fixes #37

## Validation

- `cd backend && make test`
- `cd backend && make format`
- `cd backend && make lint`
- `cd backend && make generate`
- PostgreSQL 18 fresh bootstrap and scratch `up → down → up`
- Frontend tests/build/lint and `git diff --check`