### PR TITLE
chore: enforce CI checks in Detent gate

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -5,7 +5,8 @@
 - Dependency #37 is closed through merged PR #43, and `origin/main` publishes exactly the nine required check names.
 - `detent.yaml` now requires all nine exact CI check names and uses `git diff --check` as the local command gate.
 - Detent docs (`docs/concepts.md` and `docs/merge-train.md`) confirm command gates require the configured local command plus green current-head required CI and the quiet period; this is recorded in the PR description.
-- Open items: validate config and repository gate, commit/push, open the PR with `Fixes #38`, inspect current-head CI/reviews, and update the Workpad.
+- PR #44 is open, non-draft, references `Fixes #38`, and has no reviews or actionable comments. Current-head CI passed all nine checks on run `32708716582`; slowest checks were Generated code drift (1m21s), Backend tests (1m09s), and Backend lint (1m02s).
+- Final local validation: YAML parse, exact workflow-name comparison, `git diff --check`, and `true` all passed. No skill draft: this was a routine one-file configuration change.
 
 ## Issue #35 XID identifiers
 

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -1,5 +1,12 @@
 # Detent handoff notes
 
+## Issue #38 Detent merge gate
+
+- Dependency #37 is closed through merged PR #43, and `origin/main` publishes exactly the nine required check names.
+- `detent.yaml` now requires all nine exact CI check names and uses `git diff --check` as the local command gate.
+- Detent docs (`docs/concepts.md` and `docs/merge-train.md`) confirm command gates require the configured local command plus green current-head required CI and the quiet period; this is recorded in the PR description.
+- Open items: validate config and repository gate, commit/push, open the PR with `Fixes #38`, inspect current-head CI/reviews, and update the Workpad.
+
 ## Issue #35 XID identifiers
 
 - Added reversible backend/migrations/00002_xid.sql with the public.xid20

--- a/detent.yaml
+++ b/detent.yaml
@@ -153,7 +153,7 @@ codex:
 #       default: true
 gate:
     kind: command
-    run: "true"
+    run: "git diff --check"
     require_automated_review: false
     required_status_checks:
         - Backend tests


### PR DESCRIPTION
Fixes #38

## What this implements

**Spec:** SPEC §5.2 — preserve the warn/do-not-block organiser workflow while making the release gate explicit.

**ADR:** none; this is a Detent project configuration change.

The merge gate now requires the nine exact CI check names published by `.github/workflows/ci.yml` and runs `git diff --check` as its local command gate. `require_automated_review` and `validator.enabled` are unchanged.

Detent documentation was consulted: `docs/concepts.md` and `docs/merge-train.md` establish that a command gate uses the configured local command in addition to green current-head required CI and the configured quiet period. Required status checks are therefore the release-blocking CI enforcement, while `gate.run` remains local verification.

## Validation

- YAML parse of `detent.yaml`
- Exact nine-name comparison against `.github/workflows/ci.yml`
- `git diff --check`
- `true`
