### PR TITLE
Harden real-IP extraction behind trusted proxies

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -1,5 +1,28 @@
 # Detent handoff notes
 
+## Issue #46 trusted proxy Real-IP extraction
+
+- Replaced deprecated unconditional `chi/middleware.RealIP` with `internal/api/realip.go`.
+  `TRUSTED_PROXY_CIDRS` is a comma-separated CIDR setting; empty configuration ignores
+  X-Forwarded-For and X-Real-IP. The immediate TCP peer must be trusted, and XFF is merged,
+  walked right-to-left, and fail-closed on malformed entries. Effective `RemoteAddr` mutation
+  remains for downstream request behavior and logging semantics.
+- Wired the setting through `config.Config`, `NewServerWithConfig`, `ServerOptions`, and
+  `RouterOptions`; documented it in `.env.example` and README. Added focused tests for direct,
+  trusted, multi-header, X-Real-IP, untrusted, malformed, and invalid-config cases.
+- Validation passed: focused API/config tests; backend `make test` (integration test skipped because
+  this worker has no `TEST_DATABASE_URL`), `make lint`, `make format`, `make generate && git diff
+  --exit-code`, and `make generated-code-drift`; PostgreSQL 18 disposable migration up/down/up
+  sequence; frozen Bun frontend tests (8), build, and lint; `git diff --check`.
+- The migration script's host `psql` prerequisite is absent in this worker, so its exact wrapper
+  was attempted and then its equivalent database sequence was run with the container's PostgreSQL
+  client; the disposable database was removed after verification.
+- PR #49 is open, non-draft, references `Fixes #46`, cites SPEC §20.1, and has no review or inline
+  comments. The nine required current-head CI checks passed; the slowest were Generated code drift
+  (83s), Backend lint (66s), Backend tests (60s), and Migration round-trip (50s). Latest main CI is
+  complete and successful; no post-merge main run is active.
+- Final handoff: update the persistent Workpad to `complete`; Detent owns the completion-lane transition.
+
 ## Issue #38 Detent merge gate
 
 - Dependency #37 is closed through merged PR #43, and `origin/main` publishes exactly the nine required check names.

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ APP_VERSION=0.1.0
 # Backend API
 PORT=8080
 API_BASE_URL=http://localhost:8080
+# Comma-separated CIDRs for reverse proxies allowed to supply client IP headers.
+# Leave empty when the API is directly exposed.
+TRUSTED_PROXY_CIDRS=
 
 # Frontend
 VITE_PORT=5173

--- a/README.md
+++ b/README.md
@@ -208,6 +208,11 @@ All ports are configurable via `.env` so that parallel worktrees can run simulta
 | PostgreSQL | 5432 | `POSTGRES_PORT` |
 | Adminer | 8081 | `ADMINER_PORT` |
 
+For deployments behind a reverse proxy, set `TRUSTED_PROXY_CIDRS` to a
+comma-separated list of the proxy networks. Forwarded client-IP headers are
+ignored unless the connecting peer belongs to one of those networks; leave it
+empty when the API is directly exposed.
+
 ## Parallel Development (Multiple Worktrees)
 
 To run multiple instances in parallel:

--- a/backend/internal/api/realip.go
+++ b/backend/internal/api/realip.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+// TrustedProxyRealIP updates RemoteAddr only when the immediate peer is in a
+// configured trusted proxy network. Forwarded addresses are then walked from
+// right to left, so the first address outside the trusted networks is used.
+// Invalid forwarding data leaves RemoteAddr unchanged.
+func TrustedProxyRealIP(trustedProxyCIDRs ...string) func(http.Handler) http.Handler {
+	prefixes := parseTrustedProxyCIDRs(trustedProxyCIDRs)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if isTrustedProxy(r.RemoteAddr, prefixes) {
+				if clientIP, ok := forwardedClientIP(r, prefixes); ok {
+					r.RemoteAddr = clientIP.String()
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func parseTrustedProxyCIDRs(cidrs []string) []netip.Prefix {
+	prefixes := make([]netip.Prefix, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		prefix, err := netip.ParsePrefix(strings.TrimSpace(cidr))
+		if err == nil {
+			prefixes = append(prefixes, prefix)
+		}
+	}
+	return prefixes
+}
+
+func isTrustedProxy(remoteAddr string, prefixes []netip.Prefix) bool {
+	addr, ok := parseRemoteAddr(remoteAddr)
+	if !ok {
+		return false
+	}
+	return addressInPrefixes(addr, prefixes)
+}
+
+func parseRemoteAddr(remoteAddr string) (netip.Addr, bool) {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil || addr.Zone() != "" {
+		return netip.Addr{}, false
+	}
+	return addr.Unmap(), true
+}
+
+func forwardedClientIP(r *http.Request, prefixes []netip.Prefix) (netip.Addr, bool) {
+	if values := r.Header.Values("X-Forwarded-For"); len(values) > 0 {
+		return rightmostUntrustedForwardedIP(values, prefixes)
+	}
+	if values := r.Header.Values("X-Real-IP"); len(values) > 0 {
+		return parseForwardedIP(values[len(values)-1])
+	}
+	return netip.Addr{}, false
+}
+
+func rightmostUntrustedForwardedIP(values []string, prefixes []netip.Prefix) (netip.Addr, bool) {
+	for valueIndex := len(values) - 1; valueIndex >= 0; valueIndex-- {
+		entries := strings.Split(values[valueIndex], ",")
+		for entryIndex := len(entries) - 1; entryIndex >= 0; entryIndex-- {
+			addr, ok := parseForwardedIP(entries[entryIndex])
+			if !ok {
+				return netip.Addr{}, false
+			}
+			if !addressInPrefixes(addr, prefixes) {
+				return addr, true
+			}
+		}
+	}
+	return netip.Addr{}, false
+}
+
+func parseForwardedIP(value string) (netip.Addr, bool) {
+	addr, err := netip.ParseAddr(strings.TrimSpace(value))
+	if err != nil || addr.Zone() != "" {
+		return netip.Addr{}, false
+	}
+	return addr.Unmap(), true
+}
+
+func addressInPrefixes(addr netip.Addr, prefixes []netip.Prefix) bool {
+	for _, prefix := range prefixes {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/api/realip_test.go
+++ b/backend/internal/api/realip_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTrustedProxyRealIP(t *testing.T) {
+	const originalRemoteAddr = "203.0.113.20:4321"
+
+	tests := []struct {
+		name          string
+		remoteAddr    string
+		trustedCIDRs  []string
+		xForwardedFor []string
+		xRealIP       []string
+		wantRemote    string
+	}{
+		{
+			name:          "direct request ignores forwarded headers",
+			remoteAddr:    originalRemoteAddr,
+			xForwardedFor: []string{"198.51.100.10"},
+			wantRemote:    originalRemoteAddr,
+		},
+		{
+			name:          "trusted proxy uses rightmost untrusted address",
+			remoteAddr:    "10.0.0.8:443",
+			trustedCIDRs:  []string{"10.0.0.0/8"},
+			xForwardedFor: []string{"198.51.100.10, 10.0.0.9"},
+			wantRemote:    "198.51.100.10",
+		},
+		{
+			name:          "duplicate forwarded headers are merged",
+			remoteAddr:    "10.0.0.8:443",
+			trustedCIDRs:  []string{"10.0.0.0/8"},
+			xForwardedFor: []string{"127.0.0.1", "198.51.100.10, 10.0.0.9"},
+			wantRemote:    "198.51.100.10",
+		},
+		{
+			name:         "trusted proxy falls back to real IP header",
+			remoteAddr:   "10.0.0.8:443",
+			trustedCIDRs: []string{"10.0.0.0/8"},
+			xRealIP:      []string{"198.51.100.10"},
+			wantRemote:   "198.51.100.10",
+		},
+		{
+			name:         "untrusted peer cannot use real IP header",
+			remoteAddr:   originalRemoteAddr,
+			trustedCIDRs: []string{"10.0.0.0/8"},
+			xRealIP:      []string{"198.51.100.10"},
+			wantRemote:   originalRemoteAddr,
+		},
+		{
+			name:          "malformed forwarded chain fails closed",
+			remoteAddr:    "10.0.0.8:443",
+			trustedCIDRs:  []string{"10.0.0.0/8"},
+			xForwardedFor: []string{"198.51.100.10, malformed"},
+			wantRemote:    "10.0.0.8:443",
+		},
+		{
+			name:          "invalid proxy configuration fails closed",
+			remoteAddr:    "10.0.0.8:443",
+			trustedCIDRs:  []string{"not-a-cidr"},
+			xForwardedFor: []string{"198.51.100.10"},
+			wantRemote:    "10.0.0.8:443",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var gotRemote string
+			handler := TrustedProxyRealIP(test.trustedCIDRs...)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				gotRemote = r.RemoteAddr
+			}))
+			request := httptest.NewRequest(http.MethodGet, "/", nil)
+			request.RemoteAddr = test.remoteAddr
+			for _, value := range test.xForwardedFor {
+				request.Header.Add("X-Forwarded-For", value)
+			}
+			for _, value := range test.xRealIP {
+				request.Header.Add("X-Real-IP", value)
+			}
+
+			handler.ServeHTTP(httptest.NewRecorder(), request)
+			if gotRemote != test.wantRemote {
+				t.Fatalf("RemoteAddr = %q, want %q", gotRemote, test.wantRemote)
+			}
+		})
+	}
+}

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -18,10 +18,11 @@ const apiBasePath = "/api"
 
 // RouterOptions configures the HTTP router independently of process startup.
 type RouterOptions struct {
-	AllowedOrigins []string
-	Database       handlers.DatabasePinger
-	Logger         *slog.Logger
-	Version        string
+	AllowedOrigins    []string
+	Database          handlers.DatabasePinger
+	Logger            *slog.Logger
+	TrustedProxyCIDRs []string
+	Version           string
 }
 
 // NewRouter builds the complete API router and middleware chain. Routes are
@@ -48,10 +49,7 @@ func newRouter(options RouterOptions) (chi.Router, huma.API) {
 
 	router.Use(
 		middleware.RequestID,
-		// Real-IP extraction is part of the existing API middleware contract.
-		// Trusted-proxy configuration is a separate hardening concern.
-		//nolint:staticcheck // retain the required real-IP middleware behavior.
-		middleware.RealIP,
+		TrustedProxyRealIP(options.TrustedProxyCIDRs...),
 		RequestLogger(logger),
 		Recoverer(logger),
 		cors.Handler(cors.Options{

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -21,6 +21,7 @@ type ServerOptions struct {
 	AllowedOrigins    []string
 	Database          handlers.DatabasePinger
 	Logger            *slog.Logger
+	TrustedProxyCIDRs []string
 	ReadTimeout       time.Duration
 	ReadHeaderTimeout time.Duration
 	WriteTimeout      time.Duration
@@ -59,10 +60,11 @@ func NewServer(options ...ServerOption) *Server {
 	}
 
 	router := NewRouter(RouterOptions{
-		AllowedOrigins: settings.AllowedOrigins,
-		Database:       settings.Database,
-		Logger:         settings.Logger,
-		Version:        settings.Version,
+		AllowedOrigins:    settings.AllowedOrigins,
+		Database:          settings.Database,
+		Logger:            settings.Logger,
+		TrustedProxyCIDRs: settings.TrustedProxyCIDRs,
+		Version:           settings.Version,
 	})
 	httpServer := &http.Server{
 		Addr:              settings.Address,
@@ -79,7 +81,11 @@ func NewServer(options ...ServerOption) *Server {
 // NewServerWithConfig constructs a server using the configured application
 // port while preserving the same independent construction behavior.
 func NewServerWithConfig(cfg config.Config, options ...ServerOption) *Server {
-	options = append([]ServerOption{WithAddress(":" + cfg.Port), WithVersion(cfg.AppVersion)}, options...)
+	options = append([]ServerOption{
+		WithAddress(":" + cfg.Port),
+		WithTrustedProxyCIDRs(cfg.TrustedProxyCIDRs...),
+		WithVersion(cfg.AppVersion),
+	}, options...)
 	return NewServer(options...)
 }
 
@@ -110,6 +116,12 @@ func WithVersion(version string) ServerOption {
 // WithLogger sets the structured logger used by request and panic middleware.
 func WithLogger(logger *slog.Logger) ServerOption {
 	return func(options *ServerOptions) { options.Logger = logger }
+}
+
+// WithTrustedProxyCIDRs configures the proxy networks allowed to supply
+// forwarding headers for the effective request address.
+func WithTrustedProxyCIDRs(cidrs ...string) ServerOption {
+	return func(options *ServerOptions) { options.TrustedProxyCIDRs = cidrs }
 }
 
 // Handler returns the router for callers that need an http.Handler without

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net/netip"
 	"os"
 	"strings"
 
@@ -25,6 +26,7 @@ type Config struct {
 	AppVersion        string
 	Port              string
 	APIBaseURL        string
+	TrustedProxyCIDRs []string
 	DatabaseURL       string
 	TestDatabaseURL   string
 	SupabaseURL       string
@@ -69,6 +71,7 @@ func fromEnvironment() (*Config, error) {
 		AppVersion:        getEnv("APP_VERSION", defaultAppVersion),
 		Port:              port,
 		APIBaseURL:        getEnv("API_BASE_URL", defaultAPIBaseURL),
+		TrustedProxyCIDRs: getListEnv("TRUSTED_PROXY_CIDRS"),
 		DatabaseURL:       strings.TrimSpace(os.Getenv("DATABASE_URL")),
 		TestDatabaseURL:   strings.TrimSpace(os.Getenv("TEST_DATABASE_URL")),
 		SupabaseURL:       strings.TrimSpace(os.Getenv("SUPABASE_URL")),
@@ -90,6 +93,23 @@ func getEnv(key, fallback string) string {
 	return fallback
 }
 
+func getListEnv(key string) []string {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return nil
+	}
+
+	values := strings.Split(value, ",")
+	result := make([]string, 0, len(values))
+	for _, item := range values {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
 // Validate checks the configuration required to start the API.
 func (c Config) Validate() error {
 	if strings.TrimSpace(c.DatabaseURL) == "" {
@@ -97,6 +117,11 @@ func (c Config) Validate() error {
 	}
 	if strings.TrimSpace(c.Port) == "" {
 		return fmt.Errorf("configuration error: PORT must not be empty")
+	}
+	for _, cidr := range c.TrustedProxyCIDRs {
+		if _, err := netip.ParsePrefix(cidr); err != nil {
+			return fmt.Errorf("configuration error: TRUSTED_PROXY_CIDRS contains invalid CIDR %q", cidr)
+		}
 	}
 	return nil
 }

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestLoadFromDotEnv(t *testing.T) {
-	for _, key := range []string{"APP_ENV", "APP_VERSION", "PORT", "API_BASE_URL", "DATABASE_URL", "TEST_DATABASE_URL"} {
+	for _, key := range []string{"APP_ENV", "APP_VERSION", "PORT", "API_BASE_URL", "TRUSTED_PROXY_CIDRS", "DATABASE_URL", "TEST_DATABASE_URL"} {
 		unsetEnv(t, key)
 	}
 
@@ -75,4 +75,39 @@ func TestConfigValidateRejectsEmptyPort(t *testing.T) {
 	if err == nil || err.Error() != "configuration error: PORT must not be empty" {
 		t.Fatalf("Validate() error = %v", err)
 	}
+}
+
+func TestLoadReadsTrustedProxyCIDRs(t *testing.T) {
+	unsetEnv(t, "TRUSTED_PROXY_CIDRS")
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("DATABASE_URL=postgres://example\nTRUSTED_PROXY_CIDRS=10.0.0.0/8, 192.0.2.10/32\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom() error = %v", err)
+	}
+	if got, want := cfg.TrustedProxyCIDRs, []string{"10.0.0.0/8", "192.0.2.10/32"}; !equalStrings(got, want) {
+		t.Fatalf("TrustedProxyCIDRs = %#v, want %#v", got, want)
+	}
+}
+
+func TestConfigValidateRejectsInvalidTrustedProxyCIDR(t *testing.T) {
+	err := (Config{DatabaseURL: "postgres://example", Port: "8080", TrustedProxyCIDRs: []string{"not-a-cidr"}}).Validate()
+	if err == nil || err.Error() != `configuration error: TRUSTED_PROXY_CIDRS contains invalid CIDR "not-a-cidr"` {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary

- Add `TRUSTED_PROXY_CIDRS` configuration and thread it through server/router construction.
- Replace deprecated unconditional `chi/middleware.RealIP` with trusted-peer, right-to-left X-Forwarded-For/X-Real-IP extraction that fails closed on malformed input.
- Preserve `RemoteAddr` mutation so request logging and downstream behavior continue to use the effective client address.

Implements the auditability and request-history context required by SPEC §20.1.

## Validation

- `cd backend && make test`
- `cd backend && make lint`
- `cd backend && make format`
- `cd backend && make generate && git diff --exit-code`
- `cd backend && make generated-code-drift`
- PostgreSQL 18 disposable migration up/down/up round trip
- Frozen Bun frontend tests (8), build, and lint
- `git diff --check`

Fixes #46