### PR TITLE
feat: add authentication middleware and /api/me

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -255,7 +255,10 @@
 - `internal/data/identity` remains imported only by `internal/identity`; auth/API use contracts from
   `internal/auth`. Generated sqlc identity queries and `openapi.json` are committed; no migration was
   needed because identity tables already exist.
-- Focused unit tests, API HTTP tests, `go test ./...`, `make lint`, `make format`, OpenAPI generation,
-  and `git diff --check` pass. PostgreSQL integration tests use the two-pool harness and skip here
-  without `TEST_DATABASE_URL`/`TEST_APP_DATABASE_URL`; full gate, PR, CI, and Workpad final handoff
-  remain open.
+- Focused unit tests, API HTTP tests, `make test`, `make lint`, `make format`, OpenAPI/generated-code
+  drift, frozen Bun frontend tests/build/lint, PostgreSQL 18 migration round-trip, and `git diff --check`
+  pass. PostgreSQL integration tests use the two-pool harness and skip here without
+  `TEST_DATABASE_URL`/`TEST_APP_DATABASE_URL`; CI supplies both.
+- PR #73 is open, non-draft, mergeable, cites SPEC §§6.6/9.3/9.4 and ADRs 0008/0009, and has no review
+  or inline comments. The final complete-tree CI run passed all nine required checks; Workpad completion
+  declaration remains the final handoff.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -242,3 +242,20 @@
 - Focused and full backend race tests pass with PostgreSQL 18 and both roles; backend lint, format/vet,
   pinned sqlc generation, generated-code drift, migration round-trip, frozen Bun tests/build/lint,
   and `git diff --check` pass. PR and current-head CI remain open items.
+
+## Issue #52 authentication, capabilities, and `/api/me`
+
+- Added `internal/auth` with ES256/RS256-pinned JWT verification, 30s `iss`/`aud`/`exp`/`nbf`
+  validation, local static-key and Supabase cached-JWKS implementations, rate-limited unknown-kid
+  refresh, `Principal`, and the complete SPEC §6.6 capability matrix.
+- Huma operations use `x-required-capability` metadata plus bearer security declarations; global
+  middleware authenticates, resolves one local membership, then checks capability. `/api/me` and
+  `/api/auth/claim` are implemented; claim requires verified email matching the invitation and
+  atomically consumes the bearer. `cmd/devtoken` mints local tokens without Supabase credentials.
+- `internal/data/identity` remains imported only by `internal/identity`; auth/API use contracts from
+  `internal/auth`. Generated sqlc identity queries and `openapi.json` are committed; no migration was
+  needed because identity tables already exist.
+- Focused unit tests, API HTTP tests, `go test ./...`, `make lint`, `make format`, OpenAPI generation,
+  and `git diff --check` pass. PostgreSQL integration tests use the two-pool harness and skip here
+  without `TEST_DATABASE_URL`/`TEST_APP_DATABASE_URL`; full gate, PR, CI, and Workpad final handoff
+  remain open.

--- a/.env.example
+++ b/.env.example
@@ -32,5 +32,14 @@ SUPABASE_URL=
 SUPABASE_ANON_KEY=
 SUPABASE_JWT_SECRET=
 
+# API bearer-token verification. Local uses an ES256/RS256 public key; use
+# cmd/devtoken with the matching private key to mint a development token.
+AUTH_PROVIDER=local
+AUTH_ISSUER=http://localhost:8080
+AUTH_AUDIENCE=authenticated
+AUTH_LOCAL_PUBLIC_KEY=
+AUTH_LOCAL_PRIVATE_KEY=
+AUTH_LOCAL_KEY_ID=local
+
 # Optional: Database GUI
 ADMINER_PORT=8081

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -13,8 +13,10 @@ import (
 	"time"
 
 	"github.com/chrismott/miniclass/internal/api"
+	"github.com/chrismott/miniclass/internal/auth"
 	"github.com/chrismott/miniclass/internal/config"
 	"github.com/chrismott/miniclass/internal/data"
+	"github.com/chrismott/miniclass/internal/identity"
 )
 
 const shutdownTimeout = 10 * time.Second
@@ -50,10 +52,16 @@ func run(ctx context.Context, logger *slog.Logger) error {
 		return fmt.Errorf("start database: %w", err)
 	}
 	defer database.Close()
+	verifier, err := auth.NewFromConfig(*cfg)
+	if err != nil {
+		return fmt.Errorf("configure authentication: %w", err)
+	}
 
 	server := api.NewServerWithConfig(
 		*cfg,
 		api.WithDatabase(database),
+		api.WithIdentity(identity.NewStore(database)),
+		api.WithVerifier(verifier),
 		api.WithLogger(logger),
 	)
 	return serve(signalContext, cfg, server.HTTPServer, logger)

--- a/backend/cmd/devtoken/main.go
+++ b/backend/cmd/devtoken/main.go
@@ -1,0 +1,64 @@
+// Command devtoken mints a locally signed bearer token for development and
+// integration tests. It never contacts Supabase.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/chrismott/miniclass/internal/auth"
+)
+
+func main() {
+	var (
+		subject       = flag.String("subject", "", "provider subject")
+		email         = flag.String("email", "", "verified email")
+		issuer        = flag.String("issuer", envOr("AUTH_ISSUER", "http://localhost:8080"), "JWT issuer")
+		audience      = flag.String("audience", envOr("AUTH_AUDIENCE", "authenticated"), "JWT audience")
+		keyPEM        = flag.String("private-key", os.Getenv("AUTH_LOCAL_PRIVATE_KEY"), "PEM private key")
+		keyPath       = flag.String("private-key-file", os.Getenv("AUTH_LOCAL_PRIVATE_KEY_FILE"), "file containing PEM private key")
+		keyID         = flag.String("key-id", envOr("AUTH_LOCAL_KEY_ID", "local"), "JWT key id")
+		lifetime      = flag.Duration("lifetime", 5*time.Minute, "token lifetime")
+		emailVerified = flag.Bool("email-verified", true, "include email_verified=true")
+	)
+	flag.Parse()
+
+	if strings.TrimSpace(*keyPath) != "" {
+		value, err := os.ReadFile(*keyPath)
+		if err != nil {
+			fatal(err)
+		}
+		*keyPEM = string(value)
+	}
+	if strings.TrimSpace(*keyPEM) == "" {
+		fatal(errors.New("a private key is required via --private-key or --private-key-file"))
+	}
+	key, err := auth.ParsePrivateKeyPEM(*keyPEM)
+	if err != nil {
+		fatal(err)
+	}
+	token, err := auth.MintLocalToken(auth.TokenInput{
+		Subject: *subject, Email: *email, EmailVerified: *emailVerified,
+		Issuer: *issuer, Audience: *audience, KeyID: *keyID, Lifetime: *lifetime,
+	}, key)
+	if err != nil {
+		fatal(err)
+	}
+	fmt.Println(token)
+}
+
+func envOr(name, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func fatal(err error) {
+	_, _ = fmt.Fprintf(os.Stderr, "devtoken: %v\n", err)
+	os.Exit(1)
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/danielgtaylor/huma/v2 v2.39.1
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-chi/cors v1.2.1
+	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/joho/godotenv v1.5.1
 	github.com/pressly/goose/v3 v3.19.2

--- a/backend/internal/api/auth_test.go
+++ b/backend/internal/api/auth_test.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/chrismott/miniclass/internal/api/problems"
+	"github.com/chrismott/miniclass/internal/auth"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthenticatedMeEndpointReturnsResolvedPrincipal(t *testing.T) {
+	verifier, resolver, token := testAuth(t)
+	router := NewRouter(RouterOptions{Verifier: verifier, Identity: resolver})
+	request := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	request.Header.Set("Authorization", "Bearer "+token)
+	recording := httptest.NewRecorder()
+	router.ServeHTTP(recording, request)
+
+	require.Equal(t, http.StatusOK, recording.Code)
+	var response struct {
+		Principal struct {
+			ID    string `json:"id"`
+			Email string `json:"email"`
+		} `json:"principal"`
+		Organization struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"organization"`
+		Role string `json:"role"`
+	}
+	require.NoError(t, json.NewDecoder(recording.Body).Decode(&response))
+	require.Equal(t, "user-test", response.Principal.ID)
+	require.Equal(t, "organizer@example.test", response.Principal.Email)
+	require.Equal(t, "org-test", response.Organization.ID)
+	require.Equal(t, "Synthetic Academy", response.Organization.Name)
+	require.Equal(t, "owner", response.Role)
+}
+
+func TestAuthenticationAndMembershipFailuresUseDistinctProblems(t *testing.T) {
+	verifier, resolver, token := testAuth(t)
+	router := NewRouter(RouterOptions{Verifier: verifier, Identity: resolver})
+	recording := httptest.NewRecorder()
+	router.ServeHTTP(recording, httptest.NewRequest(http.MethodGet, "/api/me", nil))
+	require.Equal(t, http.StatusUnauthorized, recording.Code)
+	var unauth huma.ErrorModel
+	require.NoError(t, json.NewDecoder(recording.Body).Decode(&unauth))
+	require.Equal(t, string(problems.AuthenticationRequired), unauth.Type)
+
+	for _, test := range []struct {
+		name     string
+		resolver auth.AccountResolver
+		status   int
+		problem  problems.Slug
+	}{
+		{name: "no organization", resolver: errorResolver{err: auth.ErrNoOrganization}, status: http.StatusForbidden, problem: problems.NoOrganization},
+		{name: "multiple organizations", resolver: errorResolver{err: auth.ErrMultipleOrganizations}, status: http.StatusConflict, problem: problems.MultipleOrganizations},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			router := NewRouter(RouterOptions{Verifier: verifier, Identity: test.resolver})
+			request := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+			request.Header.Set("Authorization", "Bearer "+token)
+			recording := httptest.NewRecorder()
+			router.ServeHTTP(recording, request)
+			require.Equal(t, test.status, recording.Code)
+			var problemResponse huma.ErrorModel
+			require.NoError(t, json.NewDecoder(recording.Body).Decode(&problemResponse))
+			require.Equal(t, string(test.problem), problemResponse.Type)
+		})
+	}
+}
+
+type errorResolver struct{ err error }
+
+func (r errorResolver) ResolveAccount(context.Context, string) (auth.Account, error) {
+	return auth.Account{}, r.err
+}
+
+type testClaimer struct {
+	called bool
+	input  auth.InvitationClaimInput
+}
+
+func (c *testClaimer) ClaimAdminInvitation(_ context.Context, input auth.InvitationClaimInput) (auth.Account, error) {
+	c.called = true
+	c.input = input
+	return auth.Account{
+		User:       auth.AccountUser{ID: "claimed-user", ProviderSubject: input.ProviderSubject, Email: input.Email},
+		Membership: auth.AccountMembership{OrganizationID: "claimed-org", OrganizationName: "Claimed Academy", Role: "owner"},
+	}, nil
+}
+
+func TestInvitationClaimAllowsAnUnresolvedVerifiedSubject(t *testing.T) {
+	verifier, _, token := testAuth(t)
+	claimer := &testClaimer{}
+	router := NewRouter(RouterOptions{
+		Verifier: verifier, Identity: errorResolver{err: auth.ErrNoOrganization}, Claimer: claimer,
+	})
+	request := httptest.NewRequest(http.MethodPost, "/api/auth/claim", strings.NewReader(`{"token":"invitation-token"}`))
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Content-Type", "application/json")
+	recording := httptest.NewRecorder()
+	router.ServeHTTP(recording, request)
+
+	require.Equal(t, http.StatusOK, recording.Code)
+	require.True(t, claimer.called)
+	require.Equal(t, "invitation-token", claimer.input.Bearer)
+	require.True(t, claimer.input.EmailVerified)
+}
+
+func TestEveryRegisteredOperationDeclaresCapabilityMetadata(t *testing.T) {
+	document := NewOpenAPI(RouterOptions{})
+	encoded, err := json.Marshal(document)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &raw))
+	paths := raw["paths"].(map[string]any)
+	for path, value := range paths {
+		operations := value.(map[string]any)
+		for method, operation := range operations {
+			if method == "parameters" {
+				continue
+			}
+			op := operation.(map[string]any)
+			require.NotEmpty(t, op[auth.RequiredCapabilityExtension], "%s %s has no required capability", method, path)
+			require.NotEmpty(t, op["security"], "%s %s has no bearer security declaration", method, path)
+		}
+	}
+}
+
+func TestCrossOrganizationResourceAccessMapsToNotFound(t *testing.T) {
+	verifier, resolver, token := testAuth(t)
+	type resourceInput struct {
+		OrganizationID string `path:"organizationID"`
+	}
+	type resourceBody struct {
+		ID string `json:"id"`
+	}
+	type resourceOutput struct {
+		Body resourceBody
+	}
+	resourceRouter := chi.NewRouter()
+	resourceAPI := humachi.New(resourceRouter, huma.DefaultConfig("resource test", "test"))
+	resourceAPI.UseMiddleware(auth.Middleware(verifier, resolver, writeAuthError))
+	registerOperation(resourceAPI, huma.Operation{
+		OperationID: "get-test-resource-real",
+		Method:      http.MethodGet,
+		Path:        "/api/resources/{organizationID}",
+	}, auth.CapabilityAuthenticated, false, func(ctx context.Context, input *resourceInput) (*resourceOutput, error) {
+		principal, ok := auth.PrincipalFromContext(ctx)
+		if !ok {
+			return nil, problems.New(http.StatusInternalServerError, problems.AuthenticationUnavailable, "principal missing")
+		}
+		account := principal.(auth.AccountPrincipal)
+		if input.OrganizationID != string(account.OrganizationID) {
+			return nil, problems.New(http.StatusNotFound, problems.ResourceNotFound, "resource not found")
+		}
+		return &resourceOutput{Body: resourceBody{ID: input.OrganizationID}}, nil
+	})
+	request := httptest.NewRequest(http.MethodGet, "/api/resources/foreign-org", nil)
+	request.Header.Set("Authorization", "Bearer "+token)
+	recording := httptest.NewRecorder()
+	resourceRouter.ServeHTTP(recording, request)
+	require.Equal(t, http.StatusNotFound, recording.Code)
+	var response huma.ErrorModel
+	require.NoError(t, json.NewDecoder(recording.Body).Decode(&response))
+	require.Equal(t, string(problems.ResourceNotFound), response.Type)
+}

--- a/backend/internal/api/handlers/me.go
+++ b/backend/internal/api/handlers/me.go
@@ -1,0 +1,113 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/chrismott/miniclass/internal/api/problems"
+	"github.com/chrismott/miniclass/internal/auth"
+)
+
+// MeResponse is the authenticated account envelope. Organization and role
+// are resolved server-side and never accepted from a URL or request body.
+type MeResponse struct {
+	Principal    MePrincipal    `json:"principal" doc:"The authenticated application principal."`
+	Organization MeOrganization `json:"organization" doc:"The one organization resolved for the principal."`
+	Role         string         `json:"role" doc:"The resolved organization role."`
+}
+
+type MePrincipal struct {
+	ID    string `json:"id" doc:"Opaque application user identifier."`
+	Email string `json:"email" doc:"Verified provider email."`
+}
+
+type MeOrganization struct {
+	ID   string `json:"id" doc:"Opaque organization identifier."`
+	Name string `json:"name" doc:"Organization display name."`
+}
+
+type MeOutput struct {
+	Body MeResponse
+}
+
+// MeHandler returns the local principal resolved by authentication middleware.
+type MeHandler struct{}
+
+func (MeHandler) Handle(ctx context.Context, _ *struct{}) (*MeOutput, error) {
+	principal, ok := auth.PrincipalFromContext(ctx)
+	if !ok {
+		return nil, problems.New(http.StatusInternalServerError, problems.AuthenticationUnavailable, "resolved principal is missing")
+	}
+	account, ok := principal.(auth.AccountPrincipal)
+	if !ok {
+		return nil, problems.New(http.StatusInternalServerError, problems.AuthenticationUnavailable, "account principal has an unsupported type")
+	}
+	return &MeOutput{Body: MeResponse{
+		Principal:    MePrincipal{ID: string(account.UserID), Email: account.Email},
+		Organization: MeOrganization{ID: string(account.OrganizationID), Name: account.Organization},
+		Role:         string(account.Role),
+	}}, nil
+}
+
+// InvitationClaimer is the identity service operation needed by the claim
+// endpoint. Keeping it as an interface makes the HTTP mapping unit-testable.
+type InvitationClaimer = auth.InvitationClaimer
+
+type ClaimInvitationInput struct {
+	Body struct {
+		Token string `json:"token" minLength:"1" doc:"The one-time admin invitation bearer value."`
+	}
+}
+
+type ClaimInvitationOutput struct {
+	Body MeResponse
+}
+
+// ClaimInvitationHandler consumes an invitation only after authentication
+// middleware has verified the subject and email claims.
+type ClaimInvitationHandler struct {
+	claimer InvitationClaimer
+}
+
+func NewClaimInvitationHandler(claimer InvitationClaimer) *ClaimInvitationHandler {
+	return &ClaimInvitationHandler{claimer: claimer}
+}
+
+func (h *ClaimInvitationHandler) Handle(ctx context.Context, input *ClaimInvitationInput) (*ClaimInvitationOutput, error) {
+	if h == nil || h.claimer == nil {
+		return nil, problems.New(http.StatusInternalServerError, problems.AuthenticationUnavailable, "invitation claim is not configured")
+	}
+	verified, ok := auth.IdentityFromContext(ctx)
+	if !ok {
+		return nil, problems.New(http.StatusInternalServerError, problems.AuthenticationUnavailable, "verified identity is missing")
+	}
+	if input == nil || strings.TrimSpace(input.Body.Token) == "" {
+		return nil, problems.New(http.StatusBadRequest, problems.InvitationInvalid, "invitation token is required")
+	}
+	account, err := h.claimer.ClaimAdminInvitation(ctx, auth.InvitationClaimInput{
+		Bearer: input.Body.Token, ProviderSubject: verified.Subject, Email: verified.Email, EmailVerified: verified.EmailVerified,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, auth.ErrInvitationUnverified):
+			return nil, problems.New(http.StatusForbidden, problems.InvitationEmailUnverified, "the provider email is not verified")
+		case errors.Is(err, auth.ErrInvitationEmail):
+			return nil, problems.New(http.StatusForbidden, problems.InvitationEmailMismatch, "the invitation email does not match the verified email")
+		case errors.Is(err, auth.ErrInvitationInvalid):
+			return nil, problems.New(http.StatusForbidden, problems.InvitationInvalid, "the invitation token is invalid or no longer active")
+		default:
+			return nil, problems.New(http.StatusInternalServerError, problems.InternalError, "unable to claim invitation")
+		}
+	}
+	return &ClaimInvitationOutput{Body: accountResponse(account)}, nil
+}
+
+func accountResponse(account auth.Account) MeResponse {
+	return MeResponse{
+		Principal:    MePrincipal{ID: string(account.User.ID), Email: account.User.Email},
+		Organization: MeOrganization{ID: string(account.Membership.OrganizationID), Name: account.Membership.OrganizationName},
+		Role:         account.Membership.Role,
+	}
+}

--- a/backend/internal/api/problems/problems.go
+++ b/backend/internal/api/problems/problems.go
@@ -15,10 +15,21 @@ import (
 type Slug string
 
 const (
-	RouteNotFound       Slug = "route-not-found"
-	MethodNotAllowed    Slug = "method-not-allowed"
-	InternalError       Slug = "internal-error"
-	DatabaseUnavailable Slug = "database-unavailable"
+	RouteNotFound             Slug = "route-not-found"
+	MethodNotAllowed          Slug = "method-not-allowed"
+	InternalError             Slug = "internal-error"
+	DatabaseUnavailable       Slug = "database-unavailable"
+	AuthenticationRequired    Slug = "authentication-required"
+	InvalidToken              Slug = "invalid-token"
+	AuthenticationUnavailable Slug = "authentication-unavailable"
+	NoOrganization            Slug = "no-organization"
+	MultipleOrganizations     Slug = "multiple-organizations"
+	CapabilityRequired        Slug = "capability-required"
+	CapabilityNotDeclared     Slug = "capability-not-declared"
+	InvitationInvalid         Slug = "invitation-invalid"
+	InvitationEmailMismatch   Slug = "invitation-email-mismatch"
+	InvitationEmailUnverified Slug = "invitation-email-unverified"
+	ResourceNotFound          Slug = "resource-not-found"
 )
 
 // Definition describes one registered problem type.
@@ -28,10 +39,21 @@ type Definition struct {
 }
 
 var registry = map[Slug]Definition{
-	RouteNotFound:       {Slug: RouteNotFound, Title: "Route not found"},
-	MethodNotAllowed:    {Slug: MethodNotAllowed, Title: "Method not allowed"},
-	InternalError:       {Slug: InternalError, Title: "Internal server error"},
-	DatabaseUnavailable: {Slug: DatabaseUnavailable, Title: "Database unavailable"},
+	RouteNotFound:             {Slug: RouteNotFound, Title: "Route not found"},
+	MethodNotAllowed:          {Slug: MethodNotAllowed, Title: "Method not allowed"},
+	InternalError:             {Slug: InternalError, Title: "Internal server error"},
+	DatabaseUnavailable:       {Slug: DatabaseUnavailable, Title: "Database unavailable"},
+	AuthenticationRequired:    {Slug: AuthenticationRequired, Title: "Authentication required"},
+	InvalidToken:              {Slug: InvalidToken, Title: "Invalid token"},
+	AuthenticationUnavailable: {Slug: AuthenticationUnavailable, Title: "Authentication unavailable"},
+	NoOrganization:            {Slug: NoOrganization, Title: "No organization"},
+	MultipleOrganizations:     {Slug: MultipleOrganizations, Title: "Multiple organizations"},
+	CapabilityRequired:        {Slug: CapabilityRequired, Title: "Capability required"},
+	CapabilityNotDeclared:     {Slug: CapabilityNotDeclared, Title: "Capability not declared"},
+	InvitationInvalid:         {Slug: InvitationInvalid, Title: "Invitation invalid"},
+	InvitationEmailMismatch:   {Slug: InvitationEmailMismatch, Title: "Invitation email mismatch"},
+	InvitationEmailUnverified: {Slug: InvitationEmailUnverified, Title: "Invitation email is not verified"},
+	ResourceNotFound:          {Slug: ResourceNotFound, Title: "Resource not found"},
 }
 
 // Definitions returns the registry in stable slug order for contract
@@ -67,6 +89,14 @@ func Write(w http.ResponseWriter, problem *huma.ErrorModel) {
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(problem.GetStatus())
 	_ = json.NewEncoder(w).Encode(problem)
+}
+
+// WriteContext is the Huma equivalent used by operation middleware before a
+// handler is invoked.
+func WriteContext(ctx huma.Context, problem *huma.ErrorModel) {
+	ctx.SetHeader("Content-Type", "application/problem+json")
+	ctx.SetStatus(problem.GetStatus())
+	_ = json.NewEncoder(ctx.BodyWriter()).Encode(problem)
 }
 
 // Schema returns the OpenAPI schema for the registered problem-type slugs.

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/chrismott/miniclass/internal/api/handlers"
 	"github.com/chrismott/miniclass/internal/api/problems"
+	"github.com/chrismott/miniclass/internal/auth"
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
 	"github.com/go-chi/chi/v5"
@@ -23,6 +24,9 @@ type RouterOptions struct {
 	Logger            *slog.Logger
 	TrustedProxyCIDRs []string
 	Version           string
+	Identity          auth.AccountResolver
+	Claimer           handlers.InvitationClaimer
+	Verifier          auth.Verifier
 }
 
 // NewRouter builds the complete API router and middleware chain. Routes are
@@ -74,6 +78,7 @@ func newRouter(options RouterOptions) (chi.Router, huma.API) {
 	}
 	options.Version = version
 	api := humachi.New(router, humaConfig(version))
+	api.UseMiddleware(auth.Middleware(options.Verifier, options.Identity, writeAuthError))
 	registerOperations(api, options)
 	addProblemTypesToContract(api.OpenAPI())
 	return router, api
@@ -91,27 +96,60 @@ func humaConfig(version string) huma.Config {
 }
 
 func registerOperations(api huma.API, options RouterOptions) {
-	huma.Register(api, huma.Operation{
+	registerOperation(api, huma.Operation{
 		OperationID: "get-api-root",
 		Method:      http.MethodGet,
 		Path:        apiBasePath,
 		Summary:     "Get API information",
-	}, apiRoot)
-	huma.Register(api, huma.Operation{
+	}, auth.CapabilityAuthenticated, false, apiRoot)
+	registerOperation(api, huma.Operation{
 		OperationID: "get-api-root-trailing-slash",
 		Method:      http.MethodGet,
 		Path:        apiBasePath + "/",
 		Summary:     "Get API information",
-	}, apiRoot)
+	}, auth.CapabilityAuthenticated, false, apiRoot)
 
 	health := handlers.NewHealthHandler(options.Database, options.Version)
-	huma.Register(api, huma.Operation{
+	registerOperation(api, huma.Operation{
 		OperationID: "get-health",
 		Method:      http.MethodGet,
 		Path:        apiBasePath + "/health",
 		Summary:     "Check API and database health",
 		Errors:      []int{http.StatusServiceUnavailable},
-	}, health.Handle)
+	}, auth.CapabilityAuthenticated, false, health.Handle)
+
+	registerOperation(api, huma.Operation{
+		OperationID: "get-me",
+		Method:      http.MethodGet,
+		Path:        apiBasePath + "/me",
+		Summary:     "Get the authenticated principal",
+	}, auth.CapabilityAuthenticated, false, (handlers.MeHandler{}).Handle)
+
+	claim := handlers.NewClaimInvitationHandler(options.Claimer)
+	registerOperation(api, huma.Operation{
+		OperationID: "post-auth-claim-invitation",
+		Method:      http.MethodPost,
+		Path:        apiBasePath + "/auth/claim",
+		Summary:     "Claim an administrator invitation",
+		Errors:      []int{http.StatusBadRequest, http.StatusForbidden},
+	}, auth.CapabilityAuthenticated, true, claim.Handle)
+}
+
+func registerOperation[I, O any](api huma.API, operation huma.Operation, capability auth.Capability, allowUnresolved bool, handler func(context.Context, *I) (*O, error)) {
+	if operation.Extensions == nil {
+		operation.Extensions = map[string]any{}
+	}
+	if operation.Metadata == nil {
+		operation.Metadata = map[string]any{}
+	}
+	operation.Extensions[auth.RequiredCapabilityExtension] = string(capability)
+	operation.Metadata[auth.RequiredCapabilityExtension] = string(capability)
+	if allowUnresolved {
+		operation.Extensions[auth.AllowUnresolvedPrincipalExtension] = true
+		operation.Metadata[auth.AllowUnresolvedPrincipalExtension] = true
+	}
+	operation.Security = []map[string][]string{{"bearerAuth": {}}}
+	huma.Register(api, operation, handler)
 }
 
 type apiRootOutput struct {
@@ -136,6 +174,14 @@ func addProblemTypesToContract(openAPI *huma.OpenAPI) {
 		problemSlugs = append(problemSlugs, string(definition.Slug))
 	}
 	openAPI.Extensions["x-miniclass-problem-types"] = problemSlugs
+	if openAPI.Components != nil {
+		if openAPI.Components.SecuritySchemes == nil {
+			openAPI.Components.SecuritySchemes = map[string]*huma.SecurityScheme{}
+		}
+		openAPI.Components.SecuritySchemes["bearerAuth"] = &huma.SecurityScheme{
+			Type: "http", Scheme: "bearer", BearerFormat: "JWT", Description: "Verified Supabase or local ES256/RS256 bearer token.",
+		}
+	}
 
 	if openAPI.Components == nil || openAPI.Components.Schemas == nil {
 		return
@@ -145,6 +191,25 @@ func addProblemTypesToContract(openAPI *huma.OpenAPI) {
 	if errorSchema, ok := schemas["ErrorModel"]; ok && errorSchema.Properties != nil {
 		errorSchema.Properties["type"] = &huma.Schema{Ref: "#/components/schemas/ProblemType"}
 	}
+}
+
+func writeAuthError(ctx huma.Context, failure auth.Failure) {
+	slug := problems.AuthenticationUnavailable
+	switch failure.Code {
+	case auth.FailureAuthenticationRequired:
+		slug = problems.AuthenticationRequired
+	case auth.FailureInvalidToken:
+		slug = problems.InvalidToken
+	case auth.FailureNoOrganization:
+		slug = problems.NoOrganization
+	case auth.FailureMultipleOrganizations:
+		slug = problems.MultipleOrganizations
+	case auth.FailureCapabilityRequired:
+		slug = problems.CapabilityRequired
+	case auth.FailureMissingCapability:
+		slug = problems.CapabilityNotDeclared
+	}
+	problems.WriteContext(ctx, problems.New(failure.Status, slug, failure.Detail))
 }
 
 func allowedOrigins(origins []string) []string {

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/chrismott/miniclass/internal/api/handlers"
+	"github.com/chrismott/miniclass/internal/auth"
 	"github.com/chrismott/miniclass/internal/config"
+	"github.com/chrismott/miniclass/internal/identity"
 )
 
 const (
@@ -20,6 +22,9 @@ type ServerOptions struct {
 	Address           string
 	AllowedOrigins    []string
 	Database          handlers.DatabasePinger
+	Identity          auth.AccountResolver
+	Claimer           handlers.InvitationClaimer
+	Verifier          auth.Verifier
 	Logger            *slog.Logger
 	TrustedProxyCIDRs []string
 	ReadTimeout       time.Duration
@@ -62,6 +67,9 @@ func NewServer(options ...ServerOption) *Server {
 	router := NewRouter(RouterOptions{
 		AllowedOrigins:    settings.AllowedOrigins,
 		Database:          settings.Database,
+		Identity:          settings.Identity,
+		Claimer:           settings.Claimer,
+		Verifier:          settings.Verifier,
 		Logger:            settings.Logger,
 		TrustedProxyCIDRs: settings.TrustedProxyCIDRs,
 		Version:           settings.Version,
@@ -106,6 +114,30 @@ func WithAllowedOrigins(origins ...string) ServerOption {
 // WithDatabase sets the dependency checked by the health endpoint.
 func WithDatabase(database handlers.DatabasePinger) ServerOption {
 	return func(options *ServerOptions) { options.Database = database }
+}
+
+// WithIdentity supplies the local identity resolver used by authentication.
+func WithIdentity(store *identity.Store) ServerOption {
+	return func(options *ServerOptions) {
+		options.Identity = store
+		options.Claimer = store
+	}
+}
+
+// WithAccountResolver supplies a testable or alternate local membership
+// resolver without exposing generated SQL to the API package.
+func WithAccountResolver(resolver auth.AccountResolver) ServerOption {
+	return func(options *ServerOptions) { options.Identity = resolver }
+}
+
+// WithInvitationClaimer supplies the invitation binding use case.
+func WithInvitationClaimer(claimer handlers.InvitationClaimer) ServerOption {
+	return func(options *ServerOptions) { options.Claimer = claimer }
+}
+
+// WithVerifier supplies the configured bearer-token verifier.
+func WithVerifier(verifier auth.Verifier) ServerOption {
+	return func(options *ServerOptions) { options.Verifier = verifier }
 }
 
 // WithVersion sets the application version reported by the health endpoint.

--- a/backend/internal/api/server_test.go
+++ b/backend/internal/api/server_test.go
@@ -3,6 +3,9 @@ package api
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -10,9 +13,12 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/chrismott/miniclass/internal/api/problems"
+	"github.com/chrismott/miniclass/internal/auth"
 	"github.com/chrismott/miniclass/internal/config"
+	"github.com/chrismott/miniclass/internal/ids"
 	"github.com/danielgtaylor/huma/v2"
 )
 
@@ -21,9 +27,12 @@ type routeHealthDatabase struct{}
 func (routeHealthDatabase) PingDB(context.Context) error { return nil }
 
 func TestNewServerConstructsWithoutStartingProcess(t *testing.T) {
+	verifier, resolver, token := testAuth(t)
 	server := NewServer(
 		WithAddress(":9090"),
 		WithAllowedOrigins("https://classroom.example"),
+		WithVerifier(verifier),
+		WithAccountResolver(resolver),
 	)
 
 	if server.HTTPServer == nil {
@@ -37,6 +46,7 @@ func TestNewServerConstructsWithoutStartingProcess(t *testing.T) {
 	}
 
 	request := httptest.NewRequest(http.MethodGet, "/api/", nil)
+	request.Header.Set("Authorization", "Bearer "+token)
 	request.Header.Set("Origin", "https://classroom.example")
 	recording := httptest.NewRecorder()
 	server.Handler().ServeHTTP(recording, request)
@@ -107,12 +117,17 @@ func TestRouterReturnsJSONForUnsupportedRequests(t *testing.T) {
 }
 
 func TestRouterServesHealthEndpoint(t *testing.T) {
+	verifier, resolver, token := testAuth(t)
 	router := NewRouter(RouterOptions{
 		Database: routeHealthDatabase{},
 		Version:  "1.2.3",
+		Verifier: verifier,
+		Identity: resolver,
 	})
 	recording := httptest.NewRecorder()
-	router.ServeHTTP(recording, httptest.NewRequest(http.MethodGet, "/api/health", nil))
+	request := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	request.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(recording, request)
 
 	if recording.Code != http.StatusOK {
 		t.Fatalf("GET /api/health status = %d, want %d", recording.Code, http.StatusOK)
@@ -134,9 +149,12 @@ func (failingHealthDatabase) PingDB(context.Context) error {
 }
 
 func TestRouterServesHealthFailureAsProblemDetails(t *testing.T) {
-	router := NewRouter(RouterOptions{Database: failingHealthDatabase{}})
+	verifier, resolver, token := testAuth(t)
+	router := NewRouter(RouterOptions{Database: failingHealthDatabase{}, Verifier: verifier, Identity: resolver})
 	recording := httptest.NewRecorder()
-	router.ServeHTTP(recording, httptest.NewRequest(http.MethodGet, "/api/health", nil))
+	request := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	request.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(recording, request)
 
 	if recording.Code != http.StatusServiceUnavailable {
 		t.Fatalf("GET /api/health status = %d, want %d", recording.Code, http.StatusServiceUnavailable)
@@ -157,10 +175,13 @@ func TestRouterServesHealthFailureAsProblemDetails(t *testing.T) {
 func TestRouterLogsCompletedRequests(t *testing.T) {
 	var logs bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logs, nil))
-	router := NewRouter(RouterOptions{Logger: logger})
+	verifier, resolver, token := testAuth(t)
+	router := NewRouter(RouterOptions{Logger: logger, Verifier: verifier, Identity: resolver})
 
 	recording := httptest.NewRecorder()
-	router.ServeHTTP(recording, httptest.NewRequest(http.MethodGet, "/api/", nil))
+	request := httptest.NewRequest(http.MethodGet, "/api/", nil)
+	request.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(recording, request)
 
 	if !strings.Contains(logs.String(), "http request") {
 		t.Fatalf("request log = %q, want request event", logs.String())
@@ -168,6 +189,41 @@ func TestRouterLogsCompletedRequests(t *testing.T) {
 	if !strings.Contains(logs.String(), "status=200") {
 		t.Fatalf("request log = %q, want status", logs.String())
 	}
+}
+
+type testAccountResolver struct {
+	account auth.Account
+}
+
+func (r testAccountResolver) ResolveAccount(context.Context, string) (auth.Account, error) {
+	return r.account, nil
+}
+
+func testAuth(t *testing.T) (auth.Verifier, auth.AccountResolver, string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier, err := auth.NewLocalVerifier(auth.LocalVerifierOptions{
+		Issuer: "https://issuer.test", Audience: "authenticated", PublicKey: &key.PublicKey,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	token, err := auth.MintLocalToken(auth.TokenInput{
+		Subject: "subject-test", Email: "organizer@example.test", EmailVerified: true,
+		Issuer: "https://issuer.test", Audience: "authenticated", Now: now, Lifetime: time.Minute,
+	}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := testAccountResolver{account: auth.Account{
+		User:       auth.AccountUser{ID: ids.XID("user-test"), ProviderSubject: "subject-test", Email: "organizer@example.test"},
+		Membership: auth.AccountMembership{ID: ids.XID("membership-test"), OrganizationID: ids.XID("org-test"), OrganizationName: "Synthetic Academy", Role: "owner"},
+	}}
+	return verifier, resolver, token
 }
 
 func TestOpenAPIContractIsDeterministicAndIncludesProblemTypes(t *testing.T) {

--- a/backend/internal/auth/capabilities.go
+++ b/backend/internal/auth/capabilities.go
@@ -1,0 +1,183 @@
+package auth
+
+import (
+	"sort"
+
+	"github.com/chrismott/miniclass/internal/ids"
+)
+
+// Capability is a closed authorization permission. The first eight values
+// are the §6.6 matrix; Authenticated is the non-domain gate used by identity
+// and operational endpoints.
+type Capability string
+
+const (
+	CapabilityManageAdministrators Capability = "manage_administrators"
+	CapabilityDeletePersonalData   Capability = "delete_personal_data"
+	CapabilityManageSchoolYear     Capability = "manage_school_year"
+	CapabilityManageRoster         Capability = "manage_roster"
+	CapabilityManageCatalog        Capability = "manage_catalog"
+	CapabilityManageAssignments    Capability = "manage_assignments"
+	CapabilityManagePublishing     Capability = "manage_publishing"
+	CapabilityReadAuditLog         Capability = "read_audit_log"
+	CapabilityAuthenticated        Capability = "authenticated"
+)
+
+// OrganizationRole is the role vocabulary used by the identity schema and
+// §6.6. It is kept separate from generated SQL enums.
+type OrganizationRole string
+
+const (
+	RoleOwner         OrganizationRole = "owner"
+	RoleAdministrator OrganizationRole = "administrator"
+	RoleCoordinator   OrganizationRole = "coordinator"
+)
+
+var roleCapabilities = map[OrganizationRole]map[Capability]bool{
+	RoleOwner: {
+		CapabilityManageAdministrators: true,
+		CapabilityDeletePersonalData:   true,
+		CapabilityManageSchoolYear:     true,
+		CapabilityManageRoster:         true,
+		CapabilityManageCatalog:        true,
+		CapabilityManageAssignments:    true,
+		CapabilityManagePublishing:     true,
+		CapabilityReadAuditLog:         true,
+	},
+	RoleAdministrator: {
+		CapabilityManageSchoolYear:  true,
+		CapabilityManageRoster:      true,
+		CapabilityManageCatalog:     true,
+		CapabilityManageAssignments: true,
+		CapabilityManagePublishing:  true,
+		CapabilityReadAuditLog:      true,
+	},
+	RoleCoordinator: {
+		CapabilityManageRoster:      true,
+		CapabilityManageCatalog:     true,
+		CapabilityManageAssignments: true,
+	},
+}
+
+var matrixCapabilities = []Capability{
+	CapabilityManageAdministrators,
+	CapabilityDeletePersonalData,
+	CapabilityManageSchoolYear,
+	CapabilityManageRoster,
+	CapabilityManageCatalog,
+	CapabilityManageAssignments,
+	CapabilityManagePublishing,
+	CapabilityReadAuditLog,
+}
+
+// CapabilityMatrix returns a stable copy of the §6.6 role/capability table.
+func CapabilityMatrix() map[OrganizationRole]map[Capability]bool {
+	result := make(map[OrganizationRole]map[Capability]bool, len(roleCapabilities))
+	for role, capabilities := range roleCapabilities {
+		result[role] = make(map[Capability]bool, len(matrixCapabilities))
+		for _, capability := range matrixCapabilities {
+			result[role][capability] = capabilities[capability]
+		}
+	}
+	return result
+}
+
+// MatrixRoles and MatrixCapabilities expose deterministic vocabulary for
+// table-driven completeness tests and contract tooling.
+func MatrixRoles() []OrganizationRole {
+	return []OrganizationRole{RoleOwner, RoleAdministrator, RoleCoordinator}
+}
+
+func MatrixCapabilities() []Capability {
+	return append([]Capability(nil), matrixCapabilities...)
+}
+
+// HasRoleCapability answers one closed-matrix cell. Unknown roles and
+// capabilities are default-deny.
+func HasRoleCapability(role OrganizationRole, capability Capability) bool {
+	if capability == CapabilityAuthenticated {
+		return role == RoleOwner || role == RoleAdministrator || role == RoleCoordinator
+	}
+	return roleCapabilities[role][capability]
+}
+
+// Principal is the common authorization surface for account and future link
+// principals. Callers ask for capabilities rather than inspecting roles.
+type Principal interface {
+	HasCapability(Capability) bool
+}
+
+// Account is the small identity-domain contract exposed to auth and API
+// callers. The unscoped SQL accessor is adapted to this type by
+// internal/identity and does not cross the package boundary.
+type Account struct {
+	User       AccountUser
+	Membership AccountMembership
+}
+
+type AccountUser struct {
+	ID              ids.XID
+	ProviderSubject string
+	Email           string
+}
+
+type AccountMembership struct {
+	ID               ids.XID
+	OrganizationID   ids.XID
+	OrganizationName string
+	Role             string
+}
+
+// AccountPrincipal is the Phase 1 administrator principal resolved from a
+// verified provider subject and exactly one application membership.
+type AccountPrincipal struct {
+	UserID         ids.XID
+	Subject        string
+	Email          string
+	OrganizationID ids.XID
+	Organization   string
+	Role           OrganizationRole
+}
+
+func (p AccountPrincipal) HasCapability(capability Capability) bool {
+	return HasRoleCapability(p.Role, capability)
+}
+
+func (p AccountPrincipal) PrincipalID() ids.XID         { return p.UserID }
+func (p AccountPrincipal) ProviderSubject() string      { return p.Subject }
+func (p AccountPrincipal) EmailAddress() string         { return p.Email }
+func (p AccountPrincipal) OrganizationName() string     { return p.Organization }
+func (p AccountPrincipal) OrganizationIDValue() ids.XID { return p.OrganizationID }
+func (p AccountPrincipal) RoleName() OrganizationRole   { return p.Role }
+
+// MatrixCells returns every cell in stable order, useful for exhaustive tests.
+func MatrixCells() []struct {
+	Role       OrganizationRole
+	Capability Capability
+	Allowed    bool
+} {
+	result := make([]struct {
+		Role       OrganizationRole
+		Capability Capability
+		Allowed    bool
+	}, 0, len(MatrixRoles())*len(MatrixCapabilities()))
+	roles := MatrixRoles()
+	capabilities := MatrixCapabilities()
+	for _, role := range roles {
+		for _, capability := range capabilities {
+			result = append(result, struct {
+				Role       OrganizationRole
+				Capability Capability
+				Allowed    bool
+			}{Role: role, Capability: capability, Allowed: HasRoleCapability(role, capability)})
+		}
+	}
+	return result
+}
+
+// SortCapabilities is used by diagnostics that report a principal's grants.
+func SortCapabilities(capabilities []Capability) []Capability {
+	result := append([]Capability(nil), capabilities...)
+	sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
+	return result
+}

--- a/backend/internal/auth/config.go
+++ b/backend/internal/auth/config.go
@@ -1,0 +1,55 @@
+package auth
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/chrismott/miniclass/internal/config"
+)
+
+// NewFromConfig builds the configured verifier. The local provider accepts a
+// public key directly or derives it from the configured private key, which is
+// useful for a single-file development environment. Production still refuses
+// the local provider before key parsing.
+func NewFromConfig(cfg config.Config) (Verifier, error) {
+	provider := strings.ToLower(strings.TrimSpace(cfg.AuthProvider))
+	switch provider {
+	case "local":
+		if strings.EqualFold(strings.TrimSpace(cfg.AppEnv), "production") {
+			return nil, ErrLocalProduction
+		}
+		var publicKey any
+		if strings.TrimSpace(cfg.AuthLocalPublicKey) != "" {
+			key, err := ParsePublicKeyPEM(cfg.AuthLocalPublicKey)
+			if err != nil {
+				return nil, fmt.Errorf("configure local verifier: %w", err)
+			}
+			publicKey = key
+		} else if strings.TrimSpace(cfg.AuthLocalPrivateKey) != "" {
+			privateKey, err := ParsePrivateKeyPEM(cfg.AuthLocalPrivateKey)
+			if err != nil {
+				return nil, fmt.Errorf("configure local verifier: %w", err)
+			}
+			switch key := privateKey.(type) {
+			case *ecdsa.PrivateKey:
+				publicKey = &key.PublicKey
+			case *rsa.PrivateKey:
+				publicKey = &key.PublicKey
+			default:
+				return nil, errors.New("configure local verifier: private key is not asymmetric")
+			}
+		} else {
+			return nil, ErrMissingVerifierKey
+		}
+		return NewLocalVerifierForEnvironment(cfg.AppEnv, LocalVerifierOptions{
+			Issuer: cfg.AuthIssuer, Audience: cfg.AuthAudience, PublicKey: publicKey,
+		})
+	case "supabase":
+		return NewSupabaseVerifier(SupabaseVerifierOptions{Issuer: cfg.AuthIssuer, Audience: cfg.AuthAudience})
+	default:
+		return nil, fmt.Errorf("configure verifier: unsupported provider %q", cfg.AuthProvider)
+	}
+}

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -1,0 +1,181 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+type contextKey string
+
+const (
+	// RequiredCapabilityExtension is the Huma/OpenAPI operation metadata key.
+	RequiredCapabilityExtension = "x-required-capability"
+	// AllowUnresolvedPrincipalExtension marks the invitation-claim exception.
+	AllowUnresolvedPrincipalExtension            = "x-allow-unresolved-principal"
+	identityContextKey                contextKey = "miniclass.auth.identity"
+	principalContextKey               contextKey = "miniclass.auth.principal"
+)
+
+var (
+	ErrNoOrganization        = errors.New("account has no organization membership")
+	ErrMultipleOrganizations = errors.New("account has multiple organization memberships")
+	ErrInvitationInvalid     = errors.New("admin invitation is invalid")
+	ErrInvitationEmail       = errors.New("admin invitation email does not match")
+	ErrInvitationUnverified  = errors.New("invitation claim requires a verified email")
+)
+
+// AccountResolver maps an already verified provider subject to local
+// membership. It must not trust organization or role claims from the JWT.
+type AccountResolver interface {
+	ResolveAccount(context.Context, string) (Account, error)
+}
+
+type InvitationClaimInput struct {
+	Bearer          string
+	ProviderSubject string
+	Email           string
+	EmailVerified   bool
+}
+
+type InvitationClaimer interface {
+	ClaimAdminInvitation(context.Context, InvitationClaimInput) (Account, error)
+}
+
+// Failure is a transport-neutral authentication/authorization failure. The
+// API maps Code to its RFC 9457 problem registry.
+type Failure struct {
+	Status int
+	Code   FailureCode
+	Detail string
+}
+
+type FailureCode string
+
+const (
+	FailureAuthenticationRequired FailureCode = "authentication-required"
+	FailureInvalidToken           FailureCode = "invalid-token"
+	FailureAuthUnavailable        FailureCode = "authentication-unavailable"
+	FailureNoOrganization         FailureCode = "no-organization"
+	FailureMultipleOrganizations  FailureCode = "multiple-organizations"
+	FailureCapabilityRequired     FailureCode = "capability-required"
+	FailureMissingCapability      FailureCode = "capability-not-declared"
+)
+
+// ErrorWriter writes a failure using the host framework's error format.
+type ErrorWriter func(huma.Context, Failure)
+
+// Middleware authenticates, resolves the tenant principal, and enforces the
+// capability declared on the matched Huma operation. Huma's operation
+// metadata is the source of the requirement, so a route cannot silently omit
+// its authorization check.
+func Middleware(verifier Verifier, resolver AccountResolver, writeError ErrorWriter) func(huma.Context, func(huma.Context)) {
+	if writeError == nil {
+		writeError = defaultErrorWriter
+	}
+	return func(ctx huma.Context, next func(huma.Context)) {
+		operation := ctx.Operation()
+		if operation == nil {
+			writeError(ctx, Failure{Status: http.StatusInternalServerError, Code: FailureAuthUnavailable, Detail: "authentication operation metadata is unavailable"})
+			return
+		}
+		capability, ok := operation.Metadata[RequiredCapabilityExtension].(string)
+		if !ok {
+			capability, ok = operation.Extensions[RequiredCapabilityExtension].(string)
+		}
+		if !ok || strings.TrimSpace(capability) == "" {
+			writeError(ctx, Failure{Status: http.StatusInternalServerError, Code: FailureMissingCapability, Detail: "required capability is not declared"})
+			return
+		}
+
+		if verifier == nil || resolver == nil {
+			writeError(ctx, Failure{Status: http.StatusInternalServerError, Code: FailureAuthUnavailable, Detail: "authentication is not configured"})
+			return
+		}
+		bearer, err := bearerFromHeader(ctx.Header("Authorization"))
+		if err != nil {
+			writeError(ctx, Failure{Status: http.StatusUnauthorized, Code: FailureAuthenticationRequired, Detail: "a bearer token is required"})
+			return
+		}
+		verified, err := verifier.Verify(ctx.Context(), bearer)
+		if err != nil {
+			writeError(ctx, Failure{Status: http.StatusUnauthorized, Code: FailureInvalidToken, Detail: "the bearer token is invalid"})
+			return
+		}
+		withIdentity := huma.WithValue(ctx, identityContextKey, verified)
+		account, err := resolver.ResolveAccount(withIdentity.Context(), verified.Subject)
+		if err != nil {
+			if !errors.Is(err, ErrNoOrganization) && !errors.Is(err, ErrMultipleOrganizations) {
+				writeError(withIdentity, Failure{Status: http.StatusInternalServerError, Code: FailureAuthUnavailable, Detail: "unable to resolve the authenticated account"})
+				return
+			}
+			allowUnresolved, _ := operation.Metadata[AllowUnresolvedPrincipalExtension].(bool)
+			if !allowUnresolved {
+				allowUnresolved, _ = operation.Extensions[AllowUnresolvedPrincipalExtension].(bool)
+			}
+			if !(allowUnresolved && errors.Is(err, ErrNoOrganization)) {
+				failure := Failure{Status: http.StatusForbidden, Code: FailureNoOrganization, Detail: "the verified account has no organization membership"}
+				if errors.Is(err, ErrMultipleOrganizations) {
+					failure.Status = http.StatusConflict
+					failure.Code = FailureMultipleOrganizations
+					failure.Detail = "the account has more than one organization membership"
+				}
+				writeError(withIdentity, failure)
+				return
+			}
+			next(withIdentity)
+			return
+		}
+
+		principal := AccountPrincipal{
+			UserID:         account.User.ID,
+			Subject:        account.User.ProviderSubject,
+			Email:          account.User.Email,
+			OrganizationID: account.Membership.OrganizationID,
+			Organization:   account.Membership.OrganizationName,
+			Role:           OrganizationRole(account.Membership.Role),
+		}
+		if !principal.HasCapability(Capability(capability)) {
+			writeError(huma.WithValue(withIdentity, principalContextKey, Principal(principal)), Failure{
+				Status: http.StatusForbidden,
+				Code:   FailureCapabilityRequired,
+				Detail: "the principal lacks the required capability",
+			})
+			return
+		}
+		next(huma.WithValue(withIdentity, principalContextKey, Principal(principal)))
+	}
+}
+
+func bearerFromHeader(value string) (string, error) {
+	parts := strings.Fields(value)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "bearer") || strings.TrimSpace(parts[1]) == "" {
+		return "", errors.New("authorization header is not a bearer token")
+	}
+	return parts[1], nil
+}
+
+// IdentityFromContext retrieves the verified identity assertion for handlers
+// such as invitation claim, which may run before local membership exists.
+func IdentityFromContext(ctx context.Context) (VerifiedIdentity, bool) {
+	identity, ok := ctx.Value(identityContextKey).(VerifiedIdentity)
+	return identity, ok
+}
+
+// PrincipalFromContext retrieves the resolved local principal.
+func PrincipalFromContext(ctx context.Context) (Principal, bool) {
+	principal, ok := ctx.Value(principalContextKey).(Principal)
+	return principal, ok
+}
+
+func defaultErrorWriter(ctx huma.Context, failure Failure) {
+	ctx.SetHeader("Content-Type", "application/problem+json")
+	ctx.SetStatus(failure.Status)
+	_ = json.NewEncoder(ctx.BodyWriter()).Encode(map[string]any{
+		"type": string(failure.Code), "title": http.StatusText(failure.Status), "status": failure.Status, "detail": failure.Detail,
+	})
+}

--- a/backend/internal/auth/token.go
+++ b/backend/internal/auth/token.go
@@ -1,0 +1,123 @@
+package auth
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// TokenInput contains the claims minted by cmd/devtoken. It is intentionally
+// explicit so local tokens exercise the same subject and verified-email path
+// as provider tokens.
+type TokenInput struct {
+	Subject       string
+	Email         string
+	EmailVerified bool
+	Issuer        string
+	Audience      string
+	KeyID         string
+	Now           time.Time
+	ExpiresAt     time.Time
+	NotBefore     time.Time
+	Lifetime      time.Duration
+}
+
+// MintLocalToken signs an ES256 or RS256 local-development token.
+func MintLocalToken(input TokenInput, privateKey any) (string, error) {
+	if strings.TrimSpace(input.Subject) == "" || strings.TrimSpace(input.Issuer) == "" || strings.TrimSpace(input.Audience) == "" {
+		return "", errors.New("mint token: subject, issuer, and audience are required")
+	}
+	if strings.TrimSpace(input.Email) == "" {
+		return "", errors.New("mint token: email is required")
+	}
+	method, err := signingMethod(privateKey)
+	if err != nil {
+		return "", err
+	}
+	now := input.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if input.Lifetime == 0 {
+		input.Lifetime = 5 * time.Minute
+	}
+	expiresAt := input.ExpiresAt
+	if expiresAt.IsZero() {
+		expiresAt = now.Add(input.Lifetime)
+	}
+	notBefore := input.NotBefore
+	if notBefore.IsZero() {
+		notBefore = now
+	}
+	claims := jwt.MapClaims{
+		"sub":            input.Subject,
+		"email":          strings.ToLower(strings.TrimSpace(input.Email)),
+		"email_verified": input.EmailVerified,
+		"iss":            strings.TrimRight(strings.TrimSpace(input.Issuer), "/"),
+		"aud":            input.Audience,
+		"exp":            expiresAt.Unix(),
+		"nbf":            notBefore.Unix(),
+		"iat":            now.Unix(),
+	}
+	token := jwt.NewWithClaims(method, claims)
+	if strings.TrimSpace(input.KeyID) != "" {
+		token.Header["kid"] = strings.TrimSpace(input.KeyID)
+	}
+	signed, err := token.SignedString(privateKey)
+	if err != nil {
+		return "", fmt.Errorf("mint token: sign: %w", err)
+	}
+	return signed, nil
+}
+
+func signingMethod(key any) (jwt.SigningMethod, error) {
+	switch value := key.(type) {
+	case *ecdsa.PrivateKey:
+		if value == nil || value.Curve != elliptic.P256() {
+			return nil, errors.New("mint token: ES256 requires an ECDSA P-256 private key")
+		}
+		return jwt.SigningMethodES256, nil
+	case *rsa.PrivateKey:
+		if value == nil || value.N == nil || value.N.BitLen() < 2048 {
+			return nil, errors.New("mint token: RS256 requires an RSA private key of at least 2048 bits")
+		}
+		return jwt.SigningMethodRS256, nil
+	default:
+		return nil, fmt.Errorf("mint token: key type %T is not ES256 or RS256", key)
+	}
+}
+
+// ParsePrivateKeyPEM parses PKCS#8, SEC1, and PKCS#1 PEM private keys.
+func ParsePrivateKeyPEM(value string) (any, error) {
+	block, _ := pem.Decode([]byte(strings.ReplaceAll(value, `\n`, "\n")))
+	if block == nil {
+		return nil, errors.New("parse private key: PEM block is missing")
+	}
+	if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+		if _, err := signingMethod(key); err != nil {
+			return nil, err
+		}
+		return key, nil
+	}
+	if key, err := x509.ParseECPrivateKey(block.Bytes); err == nil {
+		if _, err := signingMethod(key); err != nil {
+			return nil, err
+		}
+		return key, nil
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		if _, err := signingMethod(key); err != nil {
+			return nil, err
+		}
+		return key, nil
+	}
+	return nil, errors.New("parse private key: unsupported key encoding")
+}

--- a/backend/internal/auth/verifier.go
+++ b/backend/internal/auth/verifier.go
@@ -1,0 +1,478 @@
+// Package auth contains authentication, principal and capability primitives
+// shared by the HTTP API and local development tools.
+package auth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+const (
+	// ClockSkew is the permitted clock difference between the API and the
+	// identity provider when checking temporal JWT claims.
+	ClockSkew = 30 * time.Second
+	algES256  = "ES256"
+	algRS256  = "RS256"
+)
+
+var (
+	ErrInvalidToken       = errors.New("invalid access token")
+	ErrUnsupportedAlg     = errors.New("unsupported JWT signing algorithm")
+	ErrLocalProduction    = errors.New("local token verification is not allowed in production")
+	ErrMissingVerifierKey = errors.New("token verifier key is not configured")
+)
+
+// Verifier verifies a bearer token and returns only claims that have passed
+// signature and registered-claim validation.
+type Verifier interface {
+	Verify(context.Context, string) (VerifiedIdentity, error)
+}
+
+// VerifiedIdentity is the identity-provider assertion carried by a verified
+// access token. Authorization data is deliberately not read from the token.
+type VerifiedIdentity struct {
+	Subject       string
+	Email         string
+	EmailVerified bool
+	Issuer        string
+	Claims        map[string]any
+}
+
+type verifierOptions struct {
+	Issuer   string
+	Audience string
+	Now      func() time.Time
+	Skew     time.Duration
+}
+
+func (o verifierOptions) normalized() (verifierOptions, error) {
+	o.Issuer = strings.TrimRight(strings.TrimSpace(o.Issuer), "/")
+	o.Audience = strings.TrimSpace(o.Audience)
+	if o.Issuer == "" {
+		return o, errors.New("token verifier issuer is required")
+	}
+	if o.Audience == "" {
+		return o, errors.New("token verifier audience is required")
+	}
+	if o.Now == nil {
+		o.Now = time.Now
+	}
+	if o.Skew == 0 {
+		o.Skew = ClockSkew
+	}
+	if o.Skew < 0 {
+		return o, errors.New("token verifier clock skew must not be negative")
+	}
+	return o, nil
+}
+
+// LocalVerifier validates tokens against one statically configured public key.
+// It is intended for development and tests; production construction is
+// rejected by NewLocalVerifierForEnvironment.
+type LocalVerifier struct {
+	options verifierOptions
+	key     any
+}
+
+// LocalVerifierOptions configures a local verifier.
+type LocalVerifierOptions struct {
+	Issuer    string
+	Audience  string
+	PublicKey any
+	Now       func() time.Time
+	Skew      time.Duration
+}
+
+// NewLocalVerifier constructs a verifier from an asymmetric public key.
+func NewLocalVerifier(options LocalVerifierOptions) (*LocalVerifier, error) {
+	base, err := (verifierOptions{
+		Issuer:   options.Issuer,
+		Audience: options.Audience,
+		Now:      options.Now,
+		Skew:     options.Skew,
+	}).normalized()
+	if err != nil {
+		return nil, err
+	}
+	if err := validateVerificationKey(options.PublicKey); err != nil {
+		return nil, err
+	}
+	return &LocalVerifier{options: base, key: options.PublicKey}, nil
+}
+
+// NewLocalVerifierForEnvironment applies the production safety rule before
+// constructing a local verifier.
+func NewLocalVerifierForEnvironment(environment string, options LocalVerifierOptions) (*LocalVerifier, error) {
+	if strings.EqualFold(strings.TrimSpace(environment), "production") {
+		return nil, ErrLocalProduction
+	}
+	return NewLocalVerifier(options)
+}
+
+// NewLocalVerifierFromPEM parses a PKIX, PKCS#1, or SEC1 public key.
+func NewLocalVerifierFromPEM(environment string, options LocalPEMOptions) (*LocalVerifier, error) {
+	key, err := ParsePublicKeyPEM(options.PublicKeyPEM)
+	if err != nil {
+		return nil, err
+	}
+	return NewLocalVerifierForEnvironment(environment, LocalVerifierOptions{
+		Issuer:    options.Issuer,
+		Audience:  options.Audience,
+		PublicKey: key,
+		Now:       options.Now,
+		Skew:      options.Skew,
+	})
+}
+
+// LocalPEMOptions is the PEM-backed form used by API configuration.
+type LocalPEMOptions struct {
+	Issuer       string
+	Audience     string
+	PublicKeyPEM string
+	Now          func() time.Time
+	Skew         time.Duration
+}
+
+// Verify verifies a locally signed bearer token.
+func (v *LocalVerifier) Verify(_ context.Context, bearer string) (VerifiedIdentity, error) {
+	if v == nil {
+		return VerifiedIdentity{}, ErrMissingVerifierKey
+	}
+	return verifyJWT(bearer, v.options, func(_ *jwt.Token) (any, error) {
+		return v.key, nil
+	})
+}
+
+// SupabaseVerifier validates JWTs against a cached Supabase JWKS document.
+// Unknown key refreshes are rate-limited so attacker-controlled kids cannot
+// turn verification into an outbound request primitive.
+type SupabaseVerifier struct {
+	options       verifierOptions
+	issuer        string
+	client        *http.Client
+	refreshEvery  time.Duration
+	mu            sync.Mutex
+	keys          map[string]any
+	lastRefreshAt time.Time
+}
+
+// SupabaseVerifierOptions configures a Supabase JWKS verifier.
+type SupabaseVerifierOptions struct {
+	Issuer       string
+	Audience     string
+	Client       *http.Client
+	Now          func() time.Time
+	Skew         time.Duration
+	RefreshEvery time.Duration
+}
+
+// NewSupabaseVerifier creates a cached JWKS verifier. The first verification
+// performs the initial fetch lazily, keeping construction side-effect free.
+func NewSupabaseVerifier(options SupabaseVerifierOptions) (*SupabaseVerifier, error) {
+	base, err := (verifierOptions{
+		Issuer:   options.Issuer,
+		Audience: options.Audience,
+		Now:      options.Now,
+		Skew:     options.Skew,
+	}).normalized()
+	if err != nil {
+		return nil, err
+	}
+	refreshEvery := options.RefreshEvery
+	if refreshEvery == 0 {
+		refreshEvery = time.Minute
+	}
+	if refreshEvery < 0 {
+		return nil, errors.New("JWKS refresh interval must not be negative")
+	}
+	client := options.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &SupabaseVerifier{
+		options:      base,
+		issuer:       base.Issuer,
+		client:       client,
+		refreshEvery: refreshEvery,
+		keys:         make(map[string]any),
+	}, nil
+}
+
+// Verify verifies a Supabase bearer token using its kid-selected JWKS key.
+func (v *SupabaseVerifier) Verify(ctx context.Context, bearer string) (VerifiedIdentity, error) {
+	if v == nil {
+		return VerifiedIdentity{}, ErrMissingVerifierKey
+	}
+	return verifyJWT(bearer, v.options, func(token *jwt.Token) (any, error) {
+		kid, _ := token.Header["kid"].(string)
+		if strings.TrimSpace(kid) == "" {
+			return nil, errors.New("JWT kid is required")
+		}
+		return v.key(ctx, kid)
+	})
+}
+
+func (v *SupabaseVerifier) key(ctx context.Context, kid string) (any, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if key, ok := v.keys[kid]; ok {
+		return key, nil
+	}
+	now := v.options.Now().UTC()
+	if !v.lastRefreshAt.IsZero() && now.Sub(v.lastRefreshAt) < v.refreshEvery {
+		return nil, fmt.Errorf("JWKS key %q is unavailable and refresh is rate-limited", kid)
+	}
+	if err := v.refreshLocked(ctx); err != nil {
+		return nil, err
+	}
+	key, ok := v.keys[kid]
+	if !ok {
+		return nil, fmt.Errorf("JWKS key %q is not published", kid)
+	}
+	return key, nil
+}
+
+type jwksDocument struct {
+	Keys []json.RawMessage `json:"keys"`
+}
+
+func (v *SupabaseVerifier) refreshLocked(ctx context.Context) error {
+	// Record attempts, not only successful refreshes. A failing JWKS endpoint
+	// must not become an attacker-controlled outbound request loop.
+	v.lastRefreshAt = v.options.Now().UTC()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, v.issuer+"/.well-known/jwks.json", nil)
+	if err != nil {
+		return fmt.Errorf("create JWKS request: %w", err)
+	}
+	response, err := v.client.Do(request)
+	if err != nil {
+		return fmt.Errorf("fetch JWKS: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("fetch JWKS: unexpected status %d", response.StatusCode)
+	}
+	var document jwksDocument
+	decoder := json.NewDecoder(io.LimitReader(response.Body, 1<<20))
+	if err := decoder.Decode(&document); err != nil {
+		return fmt.Errorf("decode JWKS: %w", err)
+	}
+	keys := make(map[string]any, len(document.Keys))
+	for _, raw := range document.Keys {
+		key, keyID, err := parseJWK(raw)
+		if err != nil {
+			return err
+		}
+		keys[keyID] = key
+	}
+	if len(keys) == 0 {
+		return errors.New("decode JWKS: no usable keys")
+	}
+	v.keys = keys
+	return nil
+}
+
+func parseJWK(raw json.RawMessage) (any, string, error) {
+	var jwk struct {
+		Kty string `json:"kty"`
+		Kid string `json:"kid"`
+		Alg string `json:"alg"`
+		Crv string `json:"crv"`
+		X   string `json:"x"`
+		Y   string `json:"y"`
+		N   string `json:"n"`
+		E   string `json:"e"`
+	}
+	if err := json.Unmarshal(raw, &jwk); err != nil {
+		return nil, "", fmt.Errorf("decode JWK: %w", err)
+	}
+	if jwk.Kid == "" {
+		return nil, "", errors.New("decode JWK: kid is required")
+	}
+	if jwk.Alg != "" && jwk.Alg != algES256 && jwk.Alg != algRS256 {
+		return nil, "", fmt.Errorf("decode JWK %q: unsupported alg %q", jwk.Kid, jwk.Alg)
+	}
+	switch jwk.Kty {
+	case "RSA":
+		modulus, err := base64.RawURLEncoding.DecodeString(jwk.N)
+		if err != nil {
+			return nil, "", fmt.Errorf("decode JWK %q modulus: %w", jwk.Kid, err)
+		}
+		exponentBytes, err := base64.RawURLEncoding.DecodeString(jwk.E)
+		if err != nil || len(exponentBytes) == 0 {
+			return nil, "", fmt.Errorf("decode JWK %q exponent", jwk.Kid)
+		}
+		exponent := 0
+		for _, value := range exponentBytes {
+			exponent = exponent<<8 | int(value)
+		}
+		if exponent < 2 {
+			return nil, "", fmt.Errorf("decode JWK %q exponent is invalid", jwk.Kid)
+		}
+		key := &rsa.PublicKey{N: new(big.Int).SetBytes(modulus), E: exponent}
+		if err := validateVerificationKey(key); err != nil {
+			return nil, "", fmt.Errorf("decode JWK %q: %w", jwk.Kid, err)
+		}
+		return key, jwk.Kid, nil
+	case "EC":
+		if jwk.Crv != "P-256" {
+			return nil, "", fmt.Errorf("decode JWK %q curve %q is unsupported", jwk.Kid, jwk.Crv)
+		}
+		xBytes, err := base64.RawURLEncoding.DecodeString(jwk.X)
+		if err != nil {
+			return nil, "", fmt.Errorf("decode JWK %q x: %w", jwk.Kid, err)
+		}
+		yBytes, err := base64.RawURLEncoding.DecodeString(jwk.Y)
+		if err != nil {
+			return nil, "", fmt.Errorf("decode JWK %q y: %w", jwk.Kid, err)
+		}
+		x := new(big.Int).SetBytes(xBytes)
+		y := new(big.Int).SetBytes(yBytes)
+		if !elliptic.P256().IsOnCurve(x, y) {
+			return nil, "", fmt.Errorf("decode JWK %q point is not on P-256", jwk.Kid)
+		}
+		return &ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}, jwk.Kid, nil
+	default:
+		return nil, "", fmt.Errorf("decode JWK %q type %q is unsupported", jwk.Kid, jwk.Kty)
+	}
+}
+
+func validateVerificationKey(key any) error {
+	switch value := key.(type) {
+	case *ecdsa.PublicKey:
+		if value == nil || value.Curve != elliptic.P256() {
+			return errors.New("local verifier requires an ECDSA P-256 public key")
+		}
+	case *rsa.PublicKey:
+		if value == nil || value.N == nil || value.N.BitLen() < 2048 {
+			return errors.New("local verifier requires an RSA public key of at least 2048 bits")
+		}
+	default:
+		return fmt.Errorf("local verifier key type %T is not ES256 or RS256", key)
+	}
+	return nil
+}
+
+func verifyJWT(raw string, options verifierOptions, keyFunc jwt.Keyfunc) (VerifiedIdentity, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return VerifiedIdentity{}, ErrInvalidToken
+	}
+	claims := jwt.MapClaims{}
+	parser := &jwt.Parser{ValidMethods: []string{algES256, algRS256}, UseJSONNumber: true, SkipClaimsValidation: true}
+	unverified, _, parseErr := parser.ParseUnverified(raw, jwt.MapClaims{})
+	if parseErr != nil || unverified == nil {
+		return VerifiedIdentity{}, fmt.Errorf("%w: malformed JWT", ErrInvalidToken)
+	}
+	if unverified.Method.Alg() != algES256 && unverified.Method.Alg() != algRS256 {
+		return VerifiedIdentity{}, ErrUnsupportedAlg
+	}
+	token, err := parser.ParseWithClaims(raw, claims, keyFunc)
+	if err != nil || token == nil || !token.Valid {
+		if errors.Is(err, ErrUnsupportedAlg) {
+			return VerifiedIdentity{}, err
+		}
+		return VerifiedIdentity{}, fmt.Errorf("%w: %v", ErrInvalidToken, err)
+	}
+	if err := validateClaims(claims, options); err != nil {
+		return VerifiedIdentity{}, fmt.Errorf("%w: %v", ErrInvalidToken, err)
+	}
+	subject, _ := claims["sub"].(string)
+	issuer, _ := claims["iss"].(string)
+	email, _ := claims["email"].(string)
+	emailVerified, _ := claims["email_verified"].(bool)
+	if !emailVerified {
+		if confirmedAt, ok := claims["email_confirmed_at"].(string); ok && strings.TrimSpace(confirmedAt) != "" {
+			emailVerified = true
+		}
+	}
+	return VerifiedIdentity{
+		Subject:       strings.TrimSpace(subject),
+		Email:         strings.ToLower(strings.TrimSpace(email)),
+		EmailVerified: emailVerified,
+		Issuer:        issuer,
+		Claims:        claims,
+	}, nil
+}
+
+func validateClaims(claims jwt.MapClaims, options verifierOptions) error {
+	issuer, ok := claims["iss"].(string)
+	if !ok || strings.TrimRight(issuer, "/") != options.Issuer {
+		return errors.New("issuer claim is invalid")
+	}
+	if !claims.VerifyAudience(options.Audience, true) {
+		return errors.New("audience claim is invalid")
+	}
+	subject, ok := claims["sub"].(string)
+	if !ok || strings.TrimSpace(subject) == "" {
+		return errors.New("subject claim is required")
+	}
+	expiresAt, ok, err := numericClaim(claims, "exp")
+	if err != nil || !ok {
+		return errors.New("exp claim is required and must be numeric")
+	}
+	now := options.Now().UTC()
+	if now.After(time.Unix(int64(expiresAt), 0).Add(options.Skew)) {
+		return errors.New("token is expired")
+	}
+	if notBefore, ok, err := numericClaim(claims, "nbf"); err != nil {
+		return errors.New("nbf claim must be numeric")
+	} else if ok && now.Before(time.Unix(int64(notBefore), 0).Add(-options.Skew)) {
+		return errors.New("token is not valid yet")
+	}
+	return nil
+}
+
+func numericClaim(claims jwt.MapClaims, name string) (float64, bool, error) {
+	value, ok := claims[name]
+	if !ok {
+		return 0, false, nil
+	}
+	switch value := value.(type) {
+	case json.Number:
+		result, err := value.Float64()
+		return result, true, err
+	case float64:
+		return value, true, nil
+	default:
+		return 0, true, errors.New("not numeric")
+	}
+}
+
+// ParsePublicKeyPEM parses common public-key encodings accepted by the local
+// verifier.
+func ParsePublicKeyPEM(value string) (any, error) {
+	block, _ := pem.Decode([]byte(strings.ReplaceAll(value, `\n`, "\n")))
+	if block == nil {
+		return nil, errors.New("parse public key: PEM block is missing")
+	}
+	if key, err := x509.ParsePKIXPublicKey(block.Bytes); err == nil {
+		if err := validateVerificationKey(key); err != nil {
+			return nil, err
+		}
+		return key, nil
+	}
+	if key, err := x509.ParsePKCS1PublicKey(block.Bytes); err == nil {
+		if err := validateVerificationKey(key); err != nil {
+			return nil, err
+		}
+		return key, nil
+	}
+	return nil, errors.New("parse public key: unsupported key encoding")
+}

--- a/backend/internal/auth/verifier_test.go
+++ b/backend/internal/auth/verifier_test.go
@@ -1,0 +1,138 @@
+package auth
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalVerifierValidatesAsymmetricClaimsAndClockSkew(t *testing.T) {
+	now := time.Date(2026, 8, 24, 16, 0, 0, 0, time.UTC)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	verifier, err := NewLocalVerifier(LocalVerifierOptions{
+		Issuer: "https://issuer.test", Audience: "authenticated", PublicKey: &key.PublicKey, Now: func() time.Time { return now },
+	})
+	require.NoError(t, err)
+
+	token, err := MintLocalToken(TokenInput{
+		Subject: "subject-1", Email: "owner@example.test", EmailVerified: true,
+		Issuer: "https://issuer.test", Audience: "authenticated", Now: now,
+		ExpiresAt: now.Add(ClockSkew), NotBefore: now.Add(-ClockSkew),
+	}, key)
+	require.NoError(t, err)
+	identity, err := verifier.Verify(t.Context(), token)
+	require.NoError(t, err)
+	require.Equal(t, "subject-1", identity.Subject)
+	require.True(t, identity.EmailVerified)
+
+	for _, test := range []struct {
+		name      string
+		expiresAt time.Time
+		notBefore time.Time
+		wantErr   bool
+	}{
+		{name: "expired beyond skew", expiresAt: now.Add(-ClockSkew - time.Second), notBefore: now.Add(-time.Minute), wantErr: true},
+		{name: "not before beyond skew", expiresAt: now.Add(time.Minute), notBefore: now.Add(ClockSkew + time.Second), wantErr: true},
+		{name: "expired within skew", expiresAt: now.Add(-ClockSkew + time.Second), notBefore: now.Add(-time.Minute)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			raw, err := MintLocalToken(TokenInput{
+				Subject: "subject-1", Email: "owner@example.test", EmailVerified: true,
+				Issuer: "https://issuer.test", Audience: "authenticated", Now: now,
+				ExpiresAt: test.expiresAt, NotBefore: test.notBefore,
+			}, key)
+			require.NoError(t, err)
+			_, err = verifier.Verify(t.Context(), raw)
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestLocalVerifierRejectsUnsupportedAlgorithmAndProduction(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	_, err = NewLocalVerifierForEnvironment("production", LocalVerifierOptions{
+		Issuer: "https://issuer.test", Audience: "authenticated", PublicKey: &key.PublicKey,
+	})
+	require.ErrorIs(t, err, ErrLocalProduction)
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": "subject-1", "email": "owner@example.test", "iss": "https://issuer.test",
+		"aud": "authenticated", "exp": time.Now().Add(time.Minute).Unix(),
+	})
+	raw, err := token.SignedString([]byte("not-an-asymmetric-key"))
+	require.NoError(t, err)
+	verifier, err := NewLocalVerifier(LocalVerifierOptions{
+		Issuer: "https://issuer.test", Audience: "authenticated", PublicKey: &key.PublicKey,
+	})
+	require.NoError(t, err)
+	_, err = verifier.Verify(t.Context(), raw)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrUnsupportedAlg))
+}
+
+func TestSupabaseVerifierCachesJWKSAndRateLimitsUnknownKids(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/.well-known/jwks.json", r.URL.Path)
+		requests++
+		_ = json.NewEncoder(w).Encode(map[string]any{"keys": []any{map[string]any{
+			"kty": "EC", "kid": "known", "alg": "ES256", "crv": "P-256",
+			"x": base64URL(key.PublicKey.X.Bytes()), "y": base64URL(key.PublicKey.Y.Bytes()),
+		}}})
+	}))
+	defer server.Close()
+	now := time.Date(2026, 8, 24, 16, 0, 0, 0, time.UTC)
+	verifier, err := NewSupabaseVerifier(SupabaseVerifierOptions{
+		Issuer: server.URL, Audience: "authenticated", Now: func() time.Time { return now }, RefreshEvery: time.Minute,
+	})
+	require.NoError(t, err)
+	known, err := MintLocalToken(TokenInput{
+		Subject: "subject-1", Email: "owner@example.test", EmailVerified: true,
+		Issuer: server.URL, Audience: "authenticated", KeyID: "known", Now: now, Lifetime: time.Minute,
+	}, key)
+	require.NoError(t, err)
+	_, err = verifier.Verify(t.Context(), known)
+	require.NoError(t, err)
+	require.Equal(t, 1, requests)
+	unknown, err := MintLocalToken(TokenInput{
+		Subject: "subject-1", Email: "owner@example.test", EmailVerified: true,
+		Issuer: server.URL, Audience: "authenticated", KeyID: "unknown", Now: now, Lifetime: time.Minute,
+	}, key)
+	require.NoError(t, err)
+	_, err = verifier.Verify(t.Context(), unknown)
+	require.Error(t, err)
+	require.Equal(t, 1, requests, "unknown kid triggered an unbounded JWKS refresh")
+}
+
+func TestCapabilityMatrixContainsEverySpecCell(t *testing.T) {
+	want := map[OrganizationRole]map[Capability]bool{
+		RoleOwner:         {CapabilityManageAdministrators: true, CapabilityDeletePersonalData: true, CapabilityManageSchoolYear: true, CapabilityManageRoster: true, CapabilityManageCatalog: true, CapabilityManageAssignments: true, CapabilityManagePublishing: true, CapabilityReadAuditLog: true},
+		RoleAdministrator: {CapabilityManageAdministrators: false, CapabilityDeletePersonalData: false, CapabilityManageSchoolYear: true, CapabilityManageRoster: true, CapabilityManageCatalog: true, CapabilityManageAssignments: true, CapabilityManagePublishing: true, CapabilityReadAuditLog: true},
+		RoleCoordinator:   {CapabilityManageAdministrators: false, CapabilityDeletePersonalData: false, CapabilityManageSchoolYear: false, CapabilityManageRoster: true, CapabilityManageCatalog: true, CapabilityManageAssignments: true, CapabilityManagePublishing: false, CapabilityReadAuditLog: false},
+	}
+	for _, cell := range MatrixCells() {
+		require.Equal(t, want[cell.Role][cell.Capability], cell.Allowed, "%s/%s", cell.Role, cell.Capability)
+	}
+}
+
+func base64URL(value []byte) string {
+	return base64.RawURLEncoding.EncodeToString(value)
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -12,26 +12,35 @@ import (
 )
 
 const (
-	defaultAppEnv     = "development"
-	defaultAppVersion = "0.1.0"
-	defaultPort       = "8080"
-	defaultAPIBaseURL = "http://localhost:8080"
+	defaultAppEnv       = "development"
+	defaultAppVersion   = "0.1.0"
+	defaultPort         = "8080"
+	defaultAPIBaseURL   = "http://localhost:8080"
+	defaultAuthIssuer   = "http://localhost:8080"
+	defaultAuthAudience = "authenticated"
+	defaultAuthProvider = "local"
 )
 
 // Config contains the settings used by the API and its dependencies.
 // Values are intentionally kept as strings because they originate in the
 // environment and are passed to the HTTP and database clients unchanged.
 type Config struct {
-	AppEnv            string
-	AppVersion        string
-	Port              string
-	APIBaseURL        string
-	TrustedProxyCIDRs []string
-	DatabaseURL       string
-	TestDatabaseURL   string
-	SupabaseURL       string
-	SupabaseAnonKey   string
-	SupabaseJWTSecret string
+	AppEnv              string
+	AppVersion          string
+	Port                string
+	APIBaseURL          string
+	TrustedProxyCIDRs   []string
+	DatabaseURL         string
+	TestDatabaseURL     string
+	SupabaseURL         string
+	SupabaseAnonKey     string
+	SupabaseJWTSecret   string
+	AuthProvider        string
+	AuthIssuer          string
+	AuthAudience        string
+	AuthLocalPublicKey  string
+	AuthLocalPrivateKey string
+	AuthLocalKeyID      string
 }
 
 // Load reads .env when it exists, then builds and validates the application
@@ -66,17 +75,28 @@ func loadDotEnv(path string) error {
 func fromEnvironment() (*Config, error) {
 	port := getEnv("PORT", defaultPort)
 
+	supabaseURL := strings.TrimSpace(os.Getenv("SUPABASE_URL"))
+	authIssuer := getEnv("AUTH_ISSUER", defaultAuthIssuer)
+	if supabaseURL != "" && strings.TrimSpace(os.Getenv("AUTH_ISSUER")) == "" {
+		authIssuer = supabaseURL
+	}
 	cfg := &Config{
-		AppEnv:            getEnv("APP_ENV", defaultAppEnv),
-		AppVersion:        getEnv("APP_VERSION", defaultAppVersion),
-		Port:              port,
-		APIBaseURL:        getEnv("API_BASE_URL", defaultAPIBaseURL),
-		TrustedProxyCIDRs: getListEnv("TRUSTED_PROXY_CIDRS"),
-		DatabaseURL:       strings.TrimSpace(os.Getenv("DATABASE_URL")),
-		TestDatabaseURL:   strings.TrimSpace(os.Getenv("TEST_DATABASE_URL")),
-		SupabaseURL:       strings.TrimSpace(os.Getenv("SUPABASE_URL")),
-		SupabaseAnonKey:   strings.TrimSpace(os.Getenv("SUPABASE_ANON_KEY")),
-		SupabaseJWTSecret: strings.TrimSpace(os.Getenv("SUPABASE_JWT_SECRET")),
+		AppEnv:              getEnv("APP_ENV", defaultAppEnv),
+		AppVersion:          getEnv("APP_VERSION", defaultAppVersion),
+		Port:                port,
+		APIBaseURL:          getEnv("API_BASE_URL", defaultAPIBaseURL),
+		TrustedProxyCIDRs:   getListEnv("TRUSTED_PROXY_CIDRS"),
+		DatabaseURL:         strings.TrimSpace(os.Getenv("DATABASE_URL")),
+		TestDatabaseURL:     strings.TrimSpace(os.Getenv("TEST_DATABASE_URL")),
+		SupabaseURL:         supabaseURL,
+		SupabaseAnonKey:     strings.TrimSpace(os.Getenv("SUPABASE_ANON_KEY")),
+		SupabaseJWTSecret:   strings.TrimSpace(os.Getenv("SUPABASE_JWT_SECRET")),
+		AuthProvider:        getEnv("AUTH_PROVIDER", defaultAuthProvider),
+		AuthIssuer:          authIssuer,
+		AuthAudience:        getEnv("AUTH_AUDIENCE", defaultAuthAudience),
+		AuthLocalPublicKey:  strings.TrimSpace(os.Getenv("AUTH_LOCAL_PUBLIC_KEY")),
+		AuthLocalPrivateKey: strings.TrimSpace(os.Getenv("AUTH_LOCAL_PRIVATE_KEY")),
+		AuthLocalKeyID:      strings.TrimSpace(os.Getenv("AUTH_LOCAL_KEY_ID")),
 	}
 
 	if err := cfg.Validate(); err != nil {
@@ -117,6 +137,16 @@ func (c Config) Validate() error {
 	}
 	if strings.TrimSpace(c.Port) == "" {
 		return fmt.Errorf("configuration error: PORT must not be empty")
+	}
+	provider := strings.ToLower(strings.TrimSpace(c.AuthProvider))
+	if provider != "" && provider != "local" && provider != "supabase" {
+		return fmt.Errorf("configuration error: AUTH_PROVIDER must be local or supabase")
+	}
+	if strings.TrimSpace(c.AuthIssuer) != "" && strings.TrimSpace(c.AuthAudience) == "" {
+		return fmt.Errorf("configuration error: AUTH_AUDIENCE must not be empty")
+	}
+	if strings.TrimSpace(c.AuthIssuer) == "" && strings.TrimSpace(c.AuthAudience) != "" {
+		return fmt.Errorf("configuration error: AUTH_ISSUER must not be empty")
 	}
 	for _, cidr := range c.TrustedProxyCIDRs {
 		if _, err := netip.ParsePrefix(cidr); err != nil {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestLoadFromDotEnv(t *testing.T) {
-	for _, key := range []string{"APP_ENV", "APP_VERSION", "PORT", "API_BASE_URL", "TRUSTED_PROXY_CIDRS", "DATABASE_URL", "TEST_DATABASE_URL"} {
+	for _, key := range []string{"APP_ENV", "APP_VERSION", "PORT", "API_BASE_URL", "TRUSTED_PROXY_CIDRS", "DATABASE_URL", "TEST_DATABASE_URL", "AUTH_PROVIDER", "AUTH_ISSUER", "AUTH_AUDIENCE", "AUTH_LOCAL_PUBLIC_KEY", "AUTH_LOCAL_PRIVATE_KEY", "AUTH_LOCAL_KEY_ID"} {
 		unsetEnv(t, key)
 	}
 

--- a/backend/internal/data/identity/identity.go
+++ b/backend/internal/data/identity/identity.go
@@ -5,6 +5,8 @@ package identity
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -61,6 +63,42 @@ type OrganizationMember struct {
 	CreatedAt         time.Time
 	UpdatedAt         time.Time
 }
+
+// User is the local account record mapped from a verified provider subject.
+type User struct {
+	ID              ids.XID
+	ProviderSubject string
+	Email           string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+// Membership is the organization and role selected for an account request.
+type Membership struct {
+	ID               ids.XID
+	OrganizationID   ids.XID
+	OrganizationName string
+	Role             string
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+}
+
+// Account is the result of resolving a provider subject to exactly one local
+// organization membership.
+type Account struct {
+	User       User
+	Membership Membership
+}
+
+var (
+	ErrNoOrganization        = errors.New("account has no organization membership")
+	ErrMultipleOrganizations = errors.New("account has multiple organization memberships")
+	ErrInvitationInvalid     = errors.New("admin invitation is invalid")
+	ErrInvitationEmail       = errors.New("admin invitation email does not match")
+	ErrInvitationUnverified  = errors.New("invitation claim requires a verified email")
+)
+
+const adminInvitationPurpose = "admin_invitation"
 
 // Tx is the only object handed to identity callbacks. Generated sqlc queries
 // remain private to this package, keeping all database access behind data.
@@ -127,6 +165,51 @@ func (tx *Tx) CreateOrganization(ctx context.Context, name, homeroomLabel string
 	}, nil
 }
 
+// ResolveAccount maps a provider subject to one and only one membership.
+// Returning an explicit error for zero or multiple memberships prevents a
+// request from silently selecting a tenant.
+func (s *DB) ResolveAccount(ctx context.Context, providerSubject string) (Account, error) {
+	if s == nil || s.pool == nil {
+		return Account{}, errors.New("resolve account: data accessor is nil")
+	}
+	providerSubject = strings.TrimSpace(providerSubject)
+	if providerSubject == "" {
+		return Account{}, errors.New("resolve account: provider subject is empty")
+	}
+	var rows []db.GetAccountMembershipsByProviderSubjectRow
+	if err := s.InReadTx(ctx, func(ctx context.Context, tx *Tx) error {
+		var err error
+		rows, err = tx.queries.GetAccountMembershipsByProviderSubject(ctx, providerSubject)
+		return err
+	}); err != nil {
+		return Account{}, fmt.Errorf("resolve account: %w", err)
+	}
+	if len(rows) == 0 {
+		return Account{}, ErrNoOrganization
+	}
+	if len(rows) != 1 {
+		return Account{}, ErrMultipleOrganizations
+	}
+	row := rows[0]
+	return Account{
+		User: User{
+			ID:              row.UserID,
+			ProviderSubject: row.ProviderSubject,
+			Email:           row.Email,
+			CreatedAt:       row.UserCreatedAt.Time,
+			UpdatedAt:       row.UserUpdatedAt.Time,
+		},
+		Membership: Membership{
+			ID:               row.MembershipID,
+			OrganizationID:   row.OrganizationID,
+			OrganizationName: row.OrganizationName,
+			Role:             string(row.Role),
+			CreatedAt:        row.MembershipCreatedAt.Time,
+			UpdatedAt:        row.MembershipUpdatedAt.Time,
+		},
+	}, nil
+}
+
 // CreateAccessToken stores a hashed access token with no object or tenant
 // scope. Purpose-specific ownership is represented by later typed relations.
 func (tx *Tx) CreateAccessToken(ctx context.Context, tokenHash []byte, purpose string, expiresAt time.Time, generation int) (AccessToken, error) {
@@ -149,6 +232,116 @@ func (tx *Tx) CreateAccessToken(ctx context.Context, tokenHash []byte, purpose s
 		return AccessToken{}, fmt.Errorf("create access token: %w", err)
 	}
 	return accessToken(row)
+}
+
+// ClaimInput is the verified identity data required to bind an invitation.
+// The bearer value is accepted only long enough to hash and consume it.
+type ClaimInput struct {
+	Bearer          string
+	ProviderSubject string
+	Email           string
+	EmailVerified   bool
+	Now             time.Time
+}
+
+// ClaimAdminInvitation atomically verifies, consumes, and binds an admin
+// invitation to the verified provider subject. The email check is deliberately
+// performed against the verified token claim, not a request body.
+func (s *DB) ClaimAdminInvitation(ctx context.Context, input ClaimInput) (Account, error) {
+	if s == nil || s.pool == nil {
+		return Account{}, errors.New("claim admin invitation: data accessor is nil")
+	}
+	if !input.EmailVerified {
+		return Account{}, ErrInvitationUnverified
+	}
+	input.ProviderSubject = strings.TrimSpace(input.ProviderSubject)
+	input.Email = strings.ToLower(strings.TrimSpace(input.Email))
+	if input.ProviderSubject == "" || input.Email == "" {
+		return Account{}, errors.New("claim admin invitation: verified subject and email are required")
+	}
+	hash, err := hashBearer(input.Bearer)
+	if err != nil {
+		return Account{}, err
+	}
+	now := input.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	var account Account
+	err = s.InTx(ctx, func(ctx context.Context, tx *Tx) error {
+		token, err := tx.GetAccessTokenByHash(ctx, hash)
+		if err != nil {
+			return fmt.Errorf("%w: token lookup failed", ErrInvitationInvalid)
+		}
+		if token.Purpose != adminInvitationPurpose || token.RevokedAt != nil || token.ConsumedAt != nil || !now.Before(token.ExpiresAt) {
+			return ErrInvitationInvalid
+		}
+		member, err := tx.GetOrganizationMemberByInvitationToken(ctx, token.ID)
+		if err != nil || member.UserID != nil || member.InvitedEmail == nil {
+			return ErrInvitationInvalid
+		}
+		if !strings.EqualFold(strings.TrimSpace(*member.InvitedEmail), input.Email) {
+			return ErrInvitationEmail
+		}
+		user, err := tx.queries.GetUserByProviderSubject(ctx, input.ProviderSubject)
+		if errors.Is(err, pgx.ErrNoRows) {
+			row, createErr := tx.queries.CreateUser(ctx, db.CreateUserParams{
+				ProviderSubject: input.ProviderSubject,
+				Email:           input.Email,
+			})
+			if createErr != nil {
+				return fmt.Errorf("claim admin invitation: create user: %w", createErr)
+			}
+			user = row
+		} else if err != nil {
+			return fmt.Errorf("claim admin invitation: find user: %w", err)
+		}
+		consumed, err := tx.ConsumeAccessToken(ctx, token.ID)
+		if err != nil {
+			return err
+		}
+		if !consumed {
+			return ErrInvitationInvalid
+		}
+		claimed, err := tx.queries.ClaimOrganizationMember(ctx, db.ClaimOrganizationMemberParams{ID: member.ID, UserID: &user.ID})
+		if err != nil {
+			return fmt.Errorf("claim admin invitation: bind membership: %w", err)
+		}
+		if claimed != 1 {
+			return ErrInvitationInvalid
+		}
+		rows, err := tx.queries.GetAccountMembershipsByProviderSubject(ctx, input.ProviderSubject)
+		if err != nil || len(rows) != 1 {
+			if len(rows) > 1 {
+				return ErrMultipleOrganizations
+			}
+			return fmt.Errorf("claim admin invitation: resolve claimed membership: %w", err)
+		}
+		row := rows[0]
+		account = Account{
+			User:       User{ID: row.UserID, ProviderSubject: row.ProviderSubject, Email: row.Email},
+			Membership: Membership{ID: row.MembershipID, OrganizationID: row.OrganizationID, OrganizationName: row.OrganizationName, Role: string(row.Role)},
+		}
+		return nil
+	})
+	if err != nil {
+		return Account{}, fmt.Errorf("claim admin invitation: %w", err)
+	}
+	return account, nil
+}
+
+func hashBearer(value string) ([]byte, error) {
+	// Keep the token primitive in the identity service; this small indirection
+	// avoids a package cycle while preserving the same strict 256-bit format.
+	if strings.TrimSpace(value) == "" {
+		return nil, ErrInvitationInvalid
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil || len(raw) != 32 {
+		return nil, ErrInvitationInvalid
+	}
+	digest := sha256.Sum256(raw)
+	return append([]byte(nil), digest[:]...), nil
 }
 
 // CreateOrganizationMember inserts either an active member or an invitation.

--- a/backend/internal/db/gen/identity.sql.go
+++ b/backend/internal/db/gen/identity.sql.go
@@ -12,6 +12,29 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const claimOrganizationMember = `-- name: ClaimOrganizationMember :execrows
+update organization_members
+set user_id = $2,
+    invited_email = null,
+    invitation_token_id = null
+where id = $1
+  and user_id is null
+  and invited_email is not null
+`
+
+type ClaimOrganizationMemberParams struct {
+	ID     ids.XID  `json:"id"`
+	UserID *ids.XID `json:"user_id"`
+}
+
+func (q *Queries) ClaimOrganizationMember(ctx context.Context, arg ClaimOrganizationMemberParams) (int64, error) {
+	result, err := q.db.Exec(ctx, claimOrganizationMember, arg.ID, arg.UserID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const consumeAccessToken = `-- name: ConsumeAccessToken :execrows
 update access_tokens
 set consumed_at = coalesce(consumed_at, now())
@@ -130,6 +153,30 @@ func (q *Queries) CreateOrganizationMember(ctx context.Context, arg CreateOrgani
 	return i, err
 }
 
+const createUser = `-- name: CreateUser :one
+insert into users (provider_subject, email)
+values ($1, $2)
+returning id, provider_subject, email, created_at, updated_at
+`
+
+type CreateUserParams struct {
+	ProviderSubject string `json:"provider_subject"`
+	Email           string `json:"email"`
+}
+
+func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, error) {
+	row := q.db.QueryRow(ctx, createUser, arg.ProviderSubject, arg.Email)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.ProviderSubject,
+		&i.Email,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getAccessTokenByHash = `-- name: GetAccessTokenByHash :one
 select id, token_hash, purpose, expires_at, revoked_at, consumed_at, generation, created_at, updated_at
 from access_tokens
@@ -176,6 +223,72 @@ func (q *Queries) GetAccessTokenByID(ctx context.Context, id ids.XID) (AccessTok
 	return i, err
 }
 
+const getAccountMembershipsByProviderSubject = `-- name: GetAccountMembershipsByProviderSubject :many
+select
+    u.id as user_id,
+    u.provider_subject,
+    u.email,
+    u.created_at as user_created_at,
+    u.updated_at as user_updated_at,
+    om.id as membership_id,
+    om.organization_id,
+    o.name as organization_name,
+    om.role,
+    om.created_at as membership_created_at,
+    om.updated_at as membership_updated_at
+from users u
+join organization_members om on om.user_id = u.id
+join organizations o on o.id = om.organization_id
+where u.provider_subject = $1
+order by om.organization_id
+`
+
+type GetAccountMembershipsByProviderSubjectRow struct {
+	UserID              ids.XID            `json:"user_id"`
+	ProviderSubject     string             `json:"provider_subject"`
+	Email               string             `json:"email"`
+	UserCreatedAt       pgtype.Timestamptz `json:"user_created_at"`
+	UserUpdatedAt       pgtype.Timestamptz `json:"user_updated_at"`
+	MembershipID        ids.XID            `json:"membership_id"`
+	OrganizationID      ids.XID            `json:"organization_id"`
+	OrganizationName    string             `json:"organization_name"`
+	Role                OrganizationRole   `json:"role"`
+	MembershipCreatedAt pgtype.Timestamptz `json:"membership_created_at"`
+	MembershipUpdatedAt pgtype.Timestamptz `json:"membership_updated_at"`
+}
+
+func (q *Queries) GetAccountMembershipsByProviderSubject(ctx context.Context, providerSubject string) ([]GetAccountMembershipsByProviderSubjectRow, error) {
+	rows, err := q.db.Query(ctx, getAccountMembershipsByProviderSubject, providerSubject)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetAccountMembershipsByProviderSubjectRow{}
+	for rows.Next() {
+		var i GetAccountMembershipsByProviderSubjectRow
+		if err := rows.Scan(
+			&i.UserID,
+			&i.ProviderSubject,
+			&i.Email,
+			&i.UserCreatedAt,
+			&i.UserUpdatedAt,
+			&i.MembershipID,
+			&i.OrganizationID,
+			&i.OrganizationName,
+			&i.Role,
+			&i.MembershipCreatedAt,
+			&i.MembershipUpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getOrganizationMemberByInvitationToken = `-- name: GetOrganizationMemberByInvitationToken :one
 select id, organization_id, user_id, role, invited_email, invitation_token_id, created_at, updated_at
 from organization_members
@@ -192,6 +305,25 @@ func (q *Queries) GetOrganizationMemberByInvitationToken(ctx context.Context, in
 		&i.Role,
 		&i.InvitedEmail,
 		&i.InvitationTokenID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getUserByProviderSubject = `-- name: GetUserByProviderSubject :one
+select id, provider_subject, email, created_at, updated_at
+from users
+where provider_subject = $1
+`
+
+func (q *Queries) GetUserByProviderSubject(ctx context.Context, providerSubject string) (User, error) {
+	row := q.db.QueryRow(ctx, getUserByProviderSubject, providerSubject)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.ProviderSubject,
+		&i.Email,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/backend/internal/identity/bootstrap.go
+++ b/backend/internal/identity/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/chrismott/miniclass/internal/auth"
 	data "github.com/chrismott/miniclass/internal/data"
 	identitydata "github.com/chrismott/miniclass/internal/data/identity"
 	"github.com/chrismott/miniclass/internal/ids"
@@ -29,6 +30,59 @@ func NewStore(database *data.DB) *Store {
 		return nil
 	}
 	return &Store{database: identitydata.New(database.Pool())}
+}
+
+// ResolveAccount maps a verified provider subject to one local membership.
+func (s *Store) ResolveAccount(ctx context.Context, providerSubject string) (auth.Account, error) {
+	if s == nil || s.database == nil {
+		return auth.Account{}, errors.New("resolve account: data accessor is nil")
+	}
+	account, err := s.database.ResolveAccount(ctx, providerSubject)
+	if errors.Is(err, identitydata.ErrNoOrganization) {
+		return auth.Account{}, auth.ErrNoOrganization
+	}
+	if errors.Is(err, identitydata.ErrMultipleOrganizations) {
+		return auth.Account{}, auth.ErrMultipleOrganizations
+	}
+	if err != nil {
+		return auth.Account{}, err
+	}
+	return auth.Account{
+		User: auth.AccountUser{ID: account.User.ID, ProviderSubject: account.User.ProviderSubject, Email: account.User.Email},
+		Membership: auth.AccountMembership{
+			ID: account.Membership.ID, OrganizationID: account.Membership.OrganizationID,
+			OrganizationName: account.Membership.OrganizationName, Role: account.Membership.Role,
+		},
+	}, nil
+}
+
+// ClaimAdminInvitation binds a verified provider identity to an invitation.
+func (s *Store) ClaimAdminInvitation(ctx context.Context, input auth.InvitationClaimInput) (auth.Account, error) {
+	if s == nil || s.database == nil {
+		return auth.Account{}, errors.New("claim admin invitation: data accessor is nil")
+	}
+	account, err := s.database.ClaimAdminInvitation(ctx, identitydata.ClaimInput{
+		Bearer: input.Bearer, ProviderSubject: input.ProviderSubject, Email: input.Email, EmailVerified: input.EmailVerified,
+	})
+	if errors.Is(err, identitydata.ErrInvitationUnverified) {
+		return auth.Account{}, auth.ErrInvitationUnverified
+	}
+	if errors.Is(err, identitydata.ErrInvitationEmail) {
+		return auth.Account{}, auth.ErrInvitationEmail
+	}
+	if errors.Is(err, identitydata.ErrInvitationInvalid) {
+		return auth.Account{}, auth.ErrInvitationInvalid
+	}
+	if err != nil {
+		return auth.Account{}, err
+	}
+	return auth.Account{
+		User: auth.AccountUser{ID: account.User.ID, ProviderSubject: account.User.ProviderSubject, Email: account.User.Email},
+		Membership: auth.AccountMembership{
+			ID: account.Membership.ID, OrganizationID: account.Membership.OrganizationID,
+			OrganizationName: account.Membership.OrganizationName, Role: account.Membership.Role,
+		},
+	}, nil
 }
 
 // GetAccessTokenByBearer resolves a bearer value to its persisted token

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -23,6 +23,29 @@
         ],
         "type": "object"
       },
+      "ClaimInvitationInputBody": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/ClaimInvitationInputBody.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "token": {
+            "description": "The one-time admin invitation bearer value.",
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "token"
+        ],
+        "type": "object"
+      },
       "ErrorDetail": {
         "additionalProperties": false,
         "properties": {
@@ -135,15 +158,102 @@
         ],
         "type": "object"
       },
+      "MeOrganization": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "description": "Opaque organization identifier.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Organization display name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "MePrincipal": {
+        "additionalProperties": false,
+        "properties": {
+          "email": {
+            "description": "Verified provider email.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Opaque application user identifier.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "email"
+        ],
+        "type": "object"
+      },
+      "MeResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/MeResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "organization": {
+            "$ref": "#/components/schemas/MeOrganization",
+            "description": "The one organization resolved for the principal."
+          },
+          "principal": {
+            "$ref": "#/components/schemas/MePrincipal",
+            "description": "The authenticated application principal."
+          },
+          "role": {
+            "description": "The resolved organization role.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "principal",
+          "organization",
+          "role"
+        ],
+        "type": "object"
+      },
       "ProblemType": {
         "description": "Stable RFC 9457 problem type slug.",
         "enum": [
+          "authentication-required",
+          "authentication-unavailable",
+          "capability-not-declared",
+          "capability-required",
           "database-unavailable",
           "internal-error",
+          "invalid-token",
+          "invitation-email-mismatch",
+          "invitation-email-unverified",
+          "invitation-invalid",
           "method-not-allowed",
+          "multiple-organizations",
+          "no-organization",
+          "resource-not-found",
           "route-not-found"
         ],
         "type": "string"
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "bearerFormat": "JWT",
+        "description": "Verified Supabase or local ES256/RS256 bearer token.",
+        "scheme": "bearer",
+        "type": "http"
       }
     }
   },
@@ -178,7 +288,13 @@
             "description": "Error"
           }
         },
-        "summary": "Get API information"
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get API information",
+        "x-required-capability": "authenticated"
       }
     },
     "/api/": {
@@ -206,7 +322,88 @@
             "description": "Error"
           }
         },
-        "summary": "Get API information"
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get API information",
+        "x-required-capability": "authenticated"
+      }
+    },
+    "/api/auth/claim": {
+      "post": {
+        "operationId": "post-auth-claim-invitation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClaimInvitationInputBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Claim an administrator invitation",
+        "x-allow-unresolved-principal": true,
+        "x-required-capability": "authenticated"
       }
     },
     "/api/health": {
@@ -244,14 +441,65 @@
             "description": "Service Unavailable"
           }
         },
-        "summary": "Check API and database health"
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Check API and database health",
+        "x-required-capability": "authenticated"
+      }
+    },
+    "/api/me": {
+      "get": {
+        "operationId": "get-me",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get the authenticated principal",
+        "x-required-capability": "authenticated"
       }
     }
   },
   "x-miniclass-problem-types": [
+    "authentication-required",
+    "authentication-unavailable",
+    "capability-not-declared",
+    "capability-required",
     "database-unavailable",
     "internal-error",
+    "invalid-token",
+    "invitation-email-mismatch",
+    "invitation-email-unverified",
+    "invitation-invalid",
     "method-not-allowed",
+    "multiple-organizations",
+    "no-organization",
+    "resource-not-found",
     "route-not-found"
   ]
 }

--- a/backend/sql/queries/identity.sql
+++ b/backend/sql/queries/identity.sql
@@ -19,6 +19,35 @@ insert into organization_members (
 values ($1, $2, $3, $4, $5)
 returning id, organization_id, user_id, role, invited_email, invitation_token_id, created_at, updated_at;
 
+-- name: CreateUser :one
+insert into users (provider_subject, email)
+values ($1, $2)
+returning id, provider_subject, email, created_at, updated_at;
+
+-- name: GetUserByProviderSubject :one
+select id, provider_subject, email, created_at, updated_at
+from users
+where provider_subject = $1;
+
+-- name: GetAccountMembershipsByProviderSubject :many
+select
+    u.id as user_id,
+    u.provider_subject,
+    u.email,
+    u.created_at as user_created_at,
+    u.updated_at as user_updated_at,
+    om.id as membership_id,
+    om.organization_id,
+    o.name as organization_name,
+    om.role,
+    om.created_at as membership_created_at,
+    om.updated_at as membership_updated_at
+from users u
+join organization_members om on om.user_id = u.id
+join organizations o on o.id = om.organization_id
+where u.provider_subject = $1
+order by om.organization_id;
+
 -- name: GetAccessTokenByHash :one
 select id, token_hash, purpose, expires_at, revoked_at, consumed_at, generation, created_at, updated_at
 from access_tokens
@@ -51,3 +80,12 @@ where invitation_token_id = $1;
 select id, organization_id, user_id, role, invited_email, invitation_token_id, created_at, updated_at
 from organization_members
 where invitation_token_id = $1;
+
+-- name: ClaimOrganizationMember :execrows
+update organization_members
+set user_id = $2,
+    invited_email = null,
+    invitation_token_id = null
+where id = $1
+  and user_id is null
+  and invited_email is not null;

--- a/backend/tests/integration/auth_test.go
+++ b/backend/tests/integration/auth_test.go
@@ -1,0 +1,113 @@
+package integration
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/chrismott/miniclass/internal/api"
+	"github.com/chrismott/miniclass/internal/auth"
+	"github.com/chrismott/miniclass/internal/identity"
+	dbtesting "github.com/chrismott/miniclass/internal/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthenticatedMeWithLocallySignedJWT(t *testing.T) {
+	harness := dbtesting.Open(t)
+	ctx := harness.Context
+	userSubject := "local-auth-subject"
+	userEmail := "local-organizer@example.test"
+	var organizationID, userID string
+	require.NoError(t, harness.Migrator.QueryRow(ctx, `
+		insert into organizations (name)
+		values ('Synthetic Auth Academy')
+		returning id`).Scan(&organizationID))
+	require.NoError(t, harness.Migrator.QueryRow(ctx, `
+		insert into users (provider_subject, email)
+		values ($1, $2)
+		returning id`, userSubject, userEmail).Scan(&userID))
+	_, err := harness.Migrator.Exec(ctx, `
+		insert into organization_members (organization_id, user_id, role)
+		values ($1, $2, 'owner')`, organizationID, userID)
+	require.NoError(t, err)
+
+	verifier, token := localTestVerifier(t, userSubject, userEmail)
+	server := api.NewServer(
+		api.WithDatabase(harness.Database),
+		api.WithIdentity(identity.NewStore(harness.Database)),
+		api.WithVerifier(verifier),
+	)
+	request := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	request.Header.Set("Authorization", "Bearer "+token)
+	recording := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recording, request)
+
+	require.Equal(t, http.StatusOK, recording.Code)
+	var response map[string]any
+	require.NoError(t, json.NewDecoder(recording.Body).Decode(&response))
+	require.Equal(t, "owner", response["role"])
+	organization := response["organization"].(map[string]any)
+	require.Equal(t, organizationID, organization["id"])
+}
+
+func TestAdminInvitationClaimUsesVerifiedEmailAndConsumesBearer(t *testing.T) {
+	harness := dbtesting.Open(t)
+	store := identity.NewStore(harness.Database)
+	invitation, err := identity.Bootstrap(harness.Context, store, identity.BootstrapInput{
+		OrganizationName: "Synthetic Claim Academy",
+		HomeroomLabel:    "homeroom",
+		OwnerEmail:       "claim-owner@example.test",
+		ClaimBaseURL:     "https://planner.example/claim",
+		InvitationTTL:    time.Hour,
+	})
+	require.NoError(t, err)
+	verifier, token := localTestVerifier(t, "claim-subject", "claim-owner@example.test")
+	server := api.NewServer(
+		api.WithIdentity(store),
+		api.WithVerifier(verifier),
+		api.WithDatabase(harness.Database),
+	)
+
+	request := httptest.NewRequest(http.MethodPost, "/api/auth/claim", jsonReader(map[string]string{"token": invitation.TokenValue}))
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Content-Type", "application/json")
+	recording := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recording, request)
+	require.Equal(t, http.StatusOK, recording.Code)
+
+	second := httptest.NewRequest(http.MethodPost, "/api/auth/claim", jsonReader(map[string]string{"token": invitation.TokenValue}))
+	second.Header.Set("Authorization", "Bearer "+token)
+	second.Header.Set("Content-Type", "application/json")
+	secondRecording := httptest.NewRecorder()
+	server.Handler().ServeHTTP(secondRecording, second)
+	require.Equal(t, http.StatusForbidden, secondRecording.Code)
+}
+
+func localTestVerifier(t *testing.T, subject, email string) (auth.Verifier, string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	issuer := "https://local-issuer.example"
+	verifier, err := auth.NewLocalVerifier(auth.LocalVerifierOptions{Issuer: issuer, Audience: "authenticated", PublicKey: &key.PublicKey})
+	require.NoError(t, err)
+	token, err := auth.MintLocalToken(auth.TokenInput{
+		Subject: subject, Email: email, EmailVerified: true,
+		Issuer: issuer, Audience: "authenticated", Lifetime: time.Minute,
+	}, key)
+	require.NoError(t, err)
+	return verifier, token
+}
+
+func jsonReader(value any) *bytes.Reader {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return bytes.NewReader(encoded)
+}

--- a/backend/tests/integration/health_test.go
+++ b/backend/tests/integration/health_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/chrismott/miniclass/internal/api"
 	"github.com/chrismott/miniclass/internal/api/handlers"
 	"github.com/chrismott/miniclass/internal/api/problems"
+	"github.com/chrismott/miniclass/internal/auth"
 	"github.com/chrismott/miniclass/internal/data"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -100,11 +101,16 @@ func TestHealthIntegration(t *testing.T) {
 		api.WithAddress("test"),
 		api.WithDatabase(database),
 		api.WithVersion("integration-test"),
+		api.WithVerifier(integrationVerifier{}),
+		api.WithAccountResolver(integrationResolver{}),
 	)
 	httpServer := httptest.NewServer(server.Handler())
 	t.Cleanup(httpServer.Close)
 
-	response, err := http.Get(httpServer.URL + "/api/health")
+	request, err := http.NewRequest(http.MethodGet, httpServer.URL+"/api/health", nil)
+	require.NoError(t, err)
+	request.Header.Set("Authorization", "Bearer integration")
+	response, err := http.DefaultClient.Do(request)
 	require.NoError(t, err)
 	if err != nil {
 		return
@@ -127,11 +133,14 @@ func (unavailableDatabase) PingDB(context.Context) error {
 }
 
 func TestHealthFailureUsesProblemDetails(t *testing.T) {
-	server := api.NewServer(api.WithDatabase(unavailableDatabase{}))
+	server := api.NewServer(api.WithDatabase(unavailableDatabase{}), api.WithVerifier(integrationVerifier{}), api.WithAccountResolver(integrationResolver{}))
 	httpServer := httptest.NewServer(server.Handler())
 	t.Cleanup(httpServer.Close)
 
-	response, err := http.Get(httpServer.URL + "/api/health")
+	request, err := http.NewRequest(http.MethodGet, httpServer.URL+"/api/health", nil)
+	require.NoError(t, err)
+	request.Header.Set("Authorization", "Bearer integration")
+	response, err := http.DefaultClient.Do(request)
 	require.NoError(t, err)
 	if err != nil {
 		return
@@ -150,6 +159,21 @@ func TestHealthFailureUsesProblemDetails(t *testing.T) {
 	require.Equal(t, string(problems.DatabaseUnavailable), problem.Type)
 	require.Equal(t, http.StatusServiceUnavailable, problem.Status)
 	require.Equal(t, "database unavailable", problem.Detail)
+}
+
+type integrationVerifier struct{}
+
+func (integrationVerifier) Verify(context.Context, string) (auth.VerifiedIdentity, error) {
+	return auth.VerifiedIdentity{Subject: "integration-subject", Email: "integration@example.test", EmailVerified: true}, nil
+}
+
+type integrationResolver struct{}
+
+func (integrationResolver) ResolveAccount(context.Context, string) (auth.Account, error) {
+	return auth.Account{
+		User:       auth.AccountUser{ProviderSubject: "integration-subject", Email: "integration@example.test"},
+		Membership: auth.AccountMembership{OrganizationName: "Synthetic Integration", Role: "owner"},
+	}, nil
 }
 
 func withSearchPath(databaseURL, schemaName string) (string, error) {


### PR DESCRIPTION
## Summary

- Add ES256/RS256 bearer verification for local static keys and Supabase cached JWKS, including issuer/audience/time validation and unknown-kid refresh rate limiting.
- Add the SPEC §6.6 capability matrix, principal model, Huma capability metadata, and authentication middleware with distinct organization and capability failures.
- Add GET /api/me, verified-email invitation claiming, generated identity queries, and the local `cmd/devtoken` helper.

## Scope and design

Implements SPEC §§6.6, 9.3, and 9.4, with ADR 0008 and ADR 0009. Identity data access remains behind the existing `internal/identity` adapter boundary.

Fixes #52

## Validation

- `cd backend && make test`
- `cd backend && make lint`
- `cd backend && make format`
- `cd backend && make generated-code-drift`
- `cd frontend && bun install --frozen-lockfile && bun run test -- --run && bun run build && bun run lint`
- `git diff --check`
- PostgreSQL 18 disposable migration up/down/up equivalent passed; the exact wrapper cannot run locally because host `psql` is unavailable.

The database-backed integration tests skip locally because `TEST_DATABASE_URL` and `TEST_APP_DATABASE_URL` are not configured; CI supplies both.