### PR TITLE
feat: add audit log read endpoint

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -1,5 +1,15 @@
 # Detent handoff notes
 
+## Issue #59 audit log read endpoint
+
+- PR #76 is open, non-draft, references `Fixes #59`, cites SPEC §20.1/§6.6 and ADR 0008/0010.
+- Added `GET /api/audit-log`, `internal/data` keyset query on `(occurred_at, id)`, object-type filter,
+  opaque cursor, closed action enum in OpenAPI, and Coordinator authorization coverage.
+- Local backend tests/lint/format, frontend tests/build/lint, OpenAPI drift, and `git diff --check` pass;
+  CI current-head all nine required checks pass. Migration round-trip passed in CI; local wrapper lacked
+  `POSTGRES_ADMIN_DATABASE_URL`.
+- Workpad comment `5398726896` is complete; no reviews or actionable comments remain. No skill draft.
+
 ## Issue #46 trusted proxy Real-IP extraction
 
 - Replaced deprecated unconditional `chi/middleware.RealIP` with `internal/api/realip.go`.

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -61,6 +61,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	server := api.NewServerWithConfig(
 		*cfg,
 		api.WithDatabase(database),
+		api.WithAuditLog(database),
 		api.WithIdentity(identity.NewStore(database)),
 		api.WithSchoolYears(schoolyear.New(database)),
 		api.WithVerifier(verifier),

--- a/backend/internal/api/auth_test.go
+++ b/backend/internal/api/auth_test.go
@@ -7,12 +7,16 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/chrismott/miniclass/internal/api/problems"
 	"github.com/chrismott/miniclass/internal/auth"
+	"github.com/chrismott/miniclass/internal/data"
+	"github.com/chrismott/miniclass/internal/ids"
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,6 +46,72 @@ func TestAuthenticatedMeEndpointReturnsResolvedPrincipal(t *testing.T) {
 	require.Equal(t, "org-test", response.Organization.ID)
 	require.Equal(t, "Synthetic Academy", response.Organization.Name)
 	require.Equal(t, "owner", response.Role)
+}
+
+type auditLogReaderStub struct {
+	entries []data.AuditLogEntry
+	filter  data.AuditLogFilter
+}
+
+func (s *auditLogReaderStub) ListAuditLog(_ context.Context, _ string, filter data.AuditLogFilter) ([]data.AuditLogEntry, error) {
+	s.filter = filter
+	return s.entries, nil
+}
+
+func TestAuditLogEndpointReturnsKeysetPageAndFilter(t *testing.T) {
+	verifier, resolver, token := testAuth(t)
+	reader := &auditLogReaderStub{entries: []data.AuditLogEntry{{
+		ID: "audit-2", OccurredAt: pgtype.Timestamptz{Time: time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC), Valid: true},
+		ActorType: "user", ActorUserID: func() *ids.XID { id := ids.XID("user-1"); return &id }(), ActorLabel: "organizer@example.test",
+		Action: "edit", ObjectType: "student", ObjectID: func() *ids.XID { id := ids.XID("student-1"); return &id }(), ChangeSummary: []byte(`{"name":{"from":"A","to":"B"}}`), Reason: pgtype.Text{String: "correction", Valid: true},
+	}}}
+	router := NewRouter(RouterOptions{Verifier: verifier, Identity: resolver, AuditLog: reader})
+	request := httptest.NewRequest(http.MethodGet, "/api/audit-log?object_type=student&limit=1", nil)
+	request.Header.Set("Authorization", "Bearer "+token)
+	recording := httptest.NewRecorder()
+	router.ServeHTTP(recording, request)
+
+	require.Equal(t, http.StatusOK, recording.Code)
+	var response struct {
+		Entries []struct {
+			Action string `json:"action"`
+			Actor  struct {
+				Type string `json:"type"`
+			} `json:"actor"`
+			ObjectID string `json:"object_id"`
+			Reason   string `json:"reason"`
+		} `json:"entries"`
+		NextCursor string `json:"next_cursor"`
+	}
+	require.NoError(t, json.NewDecoder(recording.Body).Decode(&response))
+	require.Len(t, response.Entries, 1)
+	require.Equal(t, "edit", response.Entries[0].Action)
+	require.Equal(t, "user", response.Entries[0].Actor.Type)
+	require.Equal(t, "student-1", response.Entries[0].ObjectID)
+	require.Equal(t, "correction", response.Entries[0].Reason)
+	require.NotEmpty(t, response.NextCursor)
+	require.Equal(t, int32(1), reader.filter.PageSize)
+	require.Equal(t, "student", *reader.filter.ObjectType)
+}
+
+func TestCoordinatorCannotReadAuditLog(t *testing.T) {
+	verifier, _, token := testAuth(t)
+	resolver := testAccountResolver{account: auth.Account{
+		User:       auth.AccountUser{ID: "coordinator-1", ProviderSubject: "subject-test", Email: "coordinator@example.test"},
+		Membership: auth.AccountMembership{OrganizationID: "org-test", OrganizationName: "Synthetic Academy", Role: string(auth.RoleCoordinator)},
+	}}
+	reader := &auditLogReaderStub{}
+	router := NewRouter(RouterOptions{Verifier: verifier, Identity: resolver, AuditLog: reader})
+	request := httptest.NewRequest(http.MethodGet, "/api/audit-log", nil)
+	request.Header.Set("Authorization", "Bearer "+token)
+	recording := httptest.NewRecorder()
+	router.ServeHTTP(recording, request)
+
+	require.Equal(t, http.StatusForbidden, recording.Code)
+	var response huma.ErrorModel
+	require.NoError(t, json.NewDecoder(recording.Body).Decode(&response))
+	require.Equal(t, string(problems.CapabilityRequired), response.Type)
+	require.Nil(t, reader.entries)
 }
 
 func TestAuthenticationAndMembershipFailuresUseDistinctProblems(t *testing.T) {

--- a/backend/internal/api/handlers/audit.go
+++ b/backend/internal/api/handlers/audit.go
@@ -1,0 +1,150 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/chrismott/miniclass/internal/api/problems"
+	"github.com/chrismott/miniclass/internal/auth"
+	"github.com/chrismott/miniclass/internal/data"
+	"github.com/chrismott/miniclass/internal/ids"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const (
+	defaultAuditPageSize int32 = 50
+	maxAuditPageSize     int32 = 100
+)
+
+// AuditLogReader is the tenant-scoped data operation needed by the endpoint.
+type AuditLogReader interface {
+	ListAuditLog(context.Context, string, data.AuditLogFilter) ([]data.AuditLogEntry, error)
+}
+
+type AuditLogInput struct {
+	ObjectType string `query:"object_type" doc:"Filter by affected object type."`
+	Cursor     string `query:"cursor" doc:"Opaque cursor returned by the previous page."`
+	Limit      int32  `query:"limit" minimum:"1" maximum:"100" default:"50" doc:"Number of entries to return."`
+}
+
+type AuditLogActor struct {
+	Type  string `json:"type" doc:"Actor principal type."`
+	ID    string `json:"id,omitempty" doc:"Actor user identifier, when present."`
+	Label string `json:"label" doc:"Actor label captured at the time of the action."`
+}
+
+type AuditLogEntry struct {
+	ID            string          `json:"id" doc:"Opaque audit entry identifier."`
+	OccurredAt    string          `json:"occurred_at" doc:"Time the action occurred."`
+	Actor         AuditLogActor   `json:"actor"`
+	Action        string          `json:"action" enum:"create,edit,soft_delete,hard_delete,import_commit,school_year_create,program_create,membership_change,session_non_participation,session_state_transition,offering_edit_after_publish,tag_definition_change,tag_assignment_change,pairing_change,exclusion_change,vocabulary_change,solve_run,manual_operation,override,publish,republish,link_generate,link_regenerate,link_revoke,permission_change,administrator_add,administrator_remove"`
+	ObjectType    string          `json:"object_type"`
+	ObjectID      string          `json:"object_id,omitempty"`
+	ChangeSummary json.RawMessage `json:"change_summary"`
+	Reason        string          `json:"reason,omitempty"`
+}
+
+type AuditLogOutput struct {
+	Body struct {
+		Entries    []AuditLogEntry `json:"entries"`
+		NextCursor string          `json:"next_cursor,omitempty" doc:"Cursor for the next page, when more entries exist."`
+	}
+}
+
+type AuditLogHandler struct{ reader AuditLogReader }
+
+func NewAuditLogHandler(reader AuditLogReader) *AuditLogHandler {
+	return &AuditLogHandler{reader: reader}
+}
+
+func (h *AuditLogHandler) Handle(ctx context.Context, input *AuditLogInput) (*AuditLogOutput, error) {
+	if h == nil || h.reader == nil {
+		return nil, problems.New(http.StatusInternalServerError, problems.DatabaseUnavailable, "audit log is not configured")
+	}
+	principal, ok := authPrincipal(ctx)
+	if !ok {
+		return nil, problems.New(http.StatusInternalServerError, problems.AuthenticationUnavailable, "resolved principal is missing")
+	}
+	pageSize := defaultAuditPageSize
+	if input != nil && input.Limit != 0 {
+		pageSize = input.Limit
+	}
+	if pageSize < 1 || pageSize > maxAuditPageSize {
+		return nil, problems.New(http.StatusBadRequest, problems.InvalidAuditCursor, "limit must be between 1 and 100")
+	}
+	filter := data.AuditLogFilter{PageSize: pageSize}
+	if input != nil && strings.TrimSpace(input.ObjectType) != "" {
+		objectType := strings.TrimSpace(input.ObjectType)
+		filter.ObjectType = &objectType
+	}
+	if input != nil && strings.TrimSpace(input.Cursor) != "" {
+		occurredAt, id, err := decodeAuditCursor(input.Cursor)
+		if err != nil {
+			return nil, problems.New(http.StatusBadRequest, problems.InvalidAuditCursor, "cursor is invalid")
+		}
+		filter.CursorOccurredAt, filter.CursorID = &occurredAt, &id
+	}
+	rows, err := h.reader.ListAuditLog(ctx, string(principal.OrganizationID), filter)
+	if err != nil {
+		return nil, problems.New(http.StatusInternalServerError, problems.InternalError, "unable to read audit log")
+	}
+	output := &AuditLogOutput{}
+	output.Body.Entries = make([]AuditLogEntry, len(rows))
+	for i, row := range rows {
+		output.Body.Entries[i] = auditResponse(row)
+	}
+	if len(rows) == int(pageSize) {
+		output.Body.NextCursor = encodeAuditCursor(rows[len(rows)-1])
+	}
+	return output, nil
+}
+
+func authPrincipal(ctx context.Context) (auth.AccountPrincipal, bool) {
+	principal, ok := auth.PrincipalFromContext(ctx)
+	if !ok {
+		return auth.AccountPrincipal{}, false
+	}
+	account, ok := principal.(auth.AccountPrincipal)
+	return account, ok
+}
+
+func auditResponse(row data.AuditLogEntry) AuditLogEntry {
+	response := AuditLogEntry{ID: string(row.ID), OccurredAt: row.OccurredAt.Time.UTC().Format(time.RFC3339Nano), Actor: AuditLogActor{Type: row.ActorType, Label: row.ActorLabel}, Action: row.Action, ObjectType: row.ObjectType, ChangeSummary: row.ChangeSummary}
+	if row.ActorUserID != nil {
+		response.Actor.ID = string(*row.ActorUserID)
+	}
+	if row.ObjectID != nil {
+		response.ObjectID = string(*row.ObjectID)
+	}
+	if row.Reason.Valid {
+		response.Reason = row.Reason.String
+	}
+	return response
+}
+
+type auditCursor struct {
+	OccurredAt time.Time `json:"occurred_at"`
+	ID         ids.XID   `json:"id"`
+}
+
+func encodeAuditCursor(row data.AuditLogEntry) string {
+	payload, _ := json.Marshal(auditCursor{OccurredAt: row.OccurredAt.Time.UTC(), ID: row.ID})
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func decodeAuditCursor(value string) (pgtype.Timestamptz, ids.XID, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		return pgtype.Timestamptz{}, "", err
+	}
+	var cursor auditCursor
+	if err := json.Unmarshal(raw, &cursor); err != nil || cursor.ID == "" || cursor.OccurredAt.IsZero() {
+		return pgtype.Timestamptz{}, "", errors.New("invalid cursor")
+	}
+	return pgtype.Timestamptz{Time: cursor.OccurredAt, Valid: true}, cursor.ID, nil
+}

--- a/backend/internal/api/problems/problems.go
+++ b/backend/internal/api/problems/problems.go
@@ -37,6 +37,7 @@ const (
 	SchoolYearClosed            Slug = "school-year-closed"
 	SchoolYearTransitionInvalid Slug = "school-year-transition-invalid"
 	SchoolYearReasonRequired    Slug = "school-year-reason-required"
+	InvalidAuditCursor          Slug = "invalid-audit-cursor"
 )
 
 // Definition describes one registered problem type.
@@ -68,6 +69,7 @@ var registry = map[Slug]Definition{
 	SchoolYearClosed:            {Slug: SchoolYearClosed, Title: "School year is closed"},
 	SchoolYearTransitionInvalid: {Slug: SchoolYearTransitionInvalid, Title: "Invalid school-year transition"},
 	SchoolYearReasonRequired:    {Slug: SchoolYearReasonRequired, Title: "School-year transition reason required"},
+	InvalidAuditCursor:          {Slug: InvalidAuditCursor, Title: "Invalid audit cursor"},
 }
 
 // Definitions returns the registry in stable slug order for contract

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -29,6 +29,7 @@ type RouterOptions struct {
 	Administrators         handlers.AdministratorManager
 	InvitationClaimBaseURL string
 	SchoolYears            handlers.SchoolYearService
+	AuditLog               handlers.AuditLogReader
 	Verifier               auth.Verifier
 }
 
@@ -127,6 +128,15 @@ func registerOperations(api huma.API, options RouterOptions) {
 		Path:        apiBasePath + "/me",
 		Summary:     "Get the authenticated principal",
 	}, auth.CapabilityAuthenticated, false, (handlers.MeHandler{}).Handle)
+
+	auditLog := handlers.NewAuditLogHandler(options.AuditLog)
+	registerOperation(api, huma.Operation{
+		OperationID: "get-audit-log",
+		Method:      http.MethodGet,
+		Path:        apiBasePath + "/audit-log",
+		Summary:     "Read the audit log",
+		Errors:      []int{http.StatusBadRequest, http.StatusInternalServerError},
+	}, auth.CapabilityReadAuditLog, false, auditLog.Handle)
 
 	claim := handlers.NewClaimInvitationHandler(options.Claimer)
 	registerOperation(api, huma.Operation{

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -29,6 +29,7 @@ type ServerOptions struct {
 	Administrators         handlers.AdministratorManager
 	InvitationClaimBaseURL string
 	SchoolYears            handlers.SchoolYearService
+	AuditLog               handlers.AuditLogReader
 	Verifier               auth.Verifier
 	Logger                 *slog.Logger
 	TrustedProxyCIDRs      []string
@@ -78,6 +79,7 @@ func NewServer(options ...ServerOption) *Server {
 		Administrators:         settings.Administrators,
 		InvitationClaimBaseURL: settings.InvitationClaimBaseURL,
 		SchoolYears:            settings.SchoolYears,
+		AuditLog:               settings.AuditLog,
 		Verifier:               settings.Verifier,
 		Logger:                 settings.Logger,
 		TrustedProxyCIDRs:      settings.TrustedProxyCIDRs,
@@ -126,6 +128,11 @@ func WithAllowedOrigins(origins ...string) ServerOption {
 // WithDatabase sets the dependency checked by the health endpoint.
 func WithDatabase(database handlers.DatabasePinger) ServerOption {
 	return func(options *ServerOptions) { options.Database = database }
+}
+
+// WithAuditLog supplies the tenant-scoped audit log reader.
+func WithAuditLog(reader handlers.AuditLogReader) ServerOption {
+	return func(options *ServerOptions) { options.AuditLog = reader }
 }
 
 // WithIdentity supplies the local identity resolver used by authentication.

--- a/backend/internal/data/audit.go
+++ b/backend/internal/data/audit.go
@@ -1,0 +1,75 @@
+package data
+
+import (
+	"context"
+
+	db "github.com/chrismott/miniclass/internal/db/gen"
+	"github.com/chrismott/miniclass/internal/ids"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// AuditLogFilter describes the only filters supported by the Phase 1 audit
+// endpoint. The cursor is the last row from the previous page.
+type AuditLogFilter struct {
+	ObjectType       *string
+	CursorOccurredAt *pgtype.Timestamptz
+	CursorID         *ids.XID
+	PageSize         int32
+}
+
+// AuditLogEntry is the data-layer representation exposed to API adapters.
+// Keeping generated SQL types here prevents API packages from bypassing the
+// tenant data boundary.
+type AuditLogEntry struct {
+	ID            ids.XID
+	OccurredAt    pgtype.Timestamptz
+	ActorType     string
+	ActorUserID   *ids.XID
+	ActorLabel    string
+	Action        string
+	ObjectType    string
+	ObjectID      *ids.XID
+	ChangeSummary []byte
+	Reason        pgtype.Text
+	SchoolYearID  *ids.XID
+	RequestID     pgtype.Text
+}
+
+// ListAuditLog reads one tenant-scoped page using keyset pagination.
+func (d *DB) ListAuditLog(ctx context.Context, organizationID string, filter AuditLogFilter) ([]AuditLogEntry, error) {
+	var entries []AuditLogEntry
+	err := d.InTenantRead(ctx, organizationID, func(ctx context.Context, tx *Tx) error {
+		var objectType pgtype.Text
+		if filter.ObjectType != nil {
+			objectType = pgtype.Text{String: *filter.ObjectType, Valid: true}
+		}
+		var occurredAt pgtype.Timestamptz
+		if filter.CursorOccurredAt != nil {
+			occurredAt = *filter.CursorOccurredAt
+		}
+		var cursorID ids.XID
+		if filter.CursorID != nil {
+			cursorID = *filter.CursorID
+		}
+		rows, err := tx.Queries().ListAuditLog(ctx, db.ListAuditLogParams{
+			ObjectType:       objectType,
+			CursorOccurredAt: occurredAt,
+			CursorID:         cursorID,
+			PageSize:         filter.PageSize,
+		})
+		if err != nil {
+			return err
+		}
+		entries = make([]AuditLogEntry, len(rows))
+		for i, row := range rows {
+			entries[i] = AuditLogEntry{
+				ID: row.ID, OccurredAt: row.OccurredAt, ActorType: string(row.ActorType),
+				ActorUserID: row.ActorUserID, ActorLabel: row.ActorLabel, Action: row.Action,
+				ObjectType: row.ObjectType, ObjectID: row.ObjectID, ChangeSummary: row.ChangeSummary,
+				Reason: row.Reason, SchoolYearID: row.SchoolYearID, RequestID: row.RequestID,
+			}
+		}
+		return nil
+	})
+	return entries, err
+}

--- a/backend/internal/db/gen/audit.sql.go
+++ b/backend/internal/db/gen/audit.sql.go
@@ -117,3 +117,62 @@ func (q *Queries) GetAuditLogByID(ctx context.Context, id ids.XID) (AuditLog, er
 	)
 	return i, err
 }
+
+const listAuditLog = `-- name: ListAuditLog :many
+select id, organization_id, occurred_at, actor_type, actor_user_id, actor_label,
+    action, object_type, object_id, change_summary, reason, school_year_id, request_id
+from audit_log
+where ($1::text is null or object_type = $1::text)
+  and (
+      $2::timestamptz is null
+      or (occurred_at, id) < ($2::timestamptz, $3::public.xid20)
+  )
+order by occurred_at desc, id desc
+limit $4::integer
+`
+
+type ListAuditLogParams struct {
+	ObjectType       pgtype.Text        `json:"object_type"`
+	CursorOccurredAt pgtype.Timestamptz `json:"cursor_occurred_at"`
+	CursorID         ids.XID            `json:"cursor_id"`
+	PageSize         int32              `json:"page_size"`
+}
+
+func (q *Queries) ListAuditLog(ctx context.Context, arg ListAuditLogParams) ([]AuditLog, error) {
+	rows, err := q.db.Query(ctx, listAuditLog,
+		arg.ObjectType,
+		arg.CursorOccurredAt,
+		arg.CursorID,
+		arg.PageSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AuditLog{}
+	for rows.Next() {
+		var i AuditLog
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.OccurredAt,
+			&i.ActorType,
+			&i.ActorUserID,
+			&i.ActorLabel,
+			&i.Action,
+			&i.ObjectType,
+			&i.ObjectID,
+			&i.ChangeSummary,
+			&i.Reason,
+			&i.SchoolYearID,
+			&i.RequestID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -87,6 +87,126 @@
         ],
         "type": "object"
       },
+      "AuditLogActor": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "description": "Actor user identifier, when present.",
+            "type": "string"
+          },
+          "label": {
+            "description": "Actor label captured at the time of the action.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Actor principal type.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "label"
+        ],
+        "type": "object"
+      },
+      "AuditLogEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "enum": [
+              "create",
+              "edit",
+              "soft_delete",
+              "hard_delete",
+              "import_commit",
+              "school_year_create",
+              "program_create",
+              "membership_change",
+              "session_non_participation",
+              "session_state_transition",
+              "offering_edit_after_publish",
+              "tag_definition_change",
+              "tag_assignment_change",
+              "pairing_change",
+              "exclusion_change",
+              "vocabulary_change",
+              "solve_run",
+              "manual_operation",
+              "override",
+              "publish",
+              "republish",
+              "link_generate",
+              "link_regenerate",
+              "link_revoke",
+              "permission_change",
+              "administrator_add",
+              "administrator_remove"
+            ],
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActor"
+          },
+          "change_summary": {},
+          "id": {
+            "description": "Opaque audit entry identifier.",
+            "type": "string"
+          },
+          "object_id": {
+            "type": "string"
+          },
+          "object_type": {
+            "type": "string"
+          },
+          "occurred_at": {
+            "description": "Time the action occurred.",
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "occurred_at",
+          "actor",
+          "action",
+          "object_type",
+          "change_summary"
+        ],
+        "type": "object"
+      },
+      "AuditLogOutputBody": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/AuditLogOutputBody.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "entries": {
+            "items": {
+              "$ref": "#/components/schemas/AuditLogEntry"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "next_cursor": {
+            "description": "Cursor for the next page, when more entries exist.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "entries"
+        ],
+        "type": "object"
+      },
       "ChangeAdministratorRoleInputBody": {
         "additionalProperties": false,
         "properties": {
@@ -424,6 +544,7 @@
           "capability-required",
           "database-unavailable",
           "internal-error",
+          "invalid-audit-cursor",
           "invalid-token",
           "invitation-email-mismatch",
           "invitation-email-unverified",
@@ -1038,6 +1159,96 @@
         "x-required-capability": "manage_administrators"
       }
     },
+    "/api/audit-log": {
+      "get": {
+        "operationId": "get-audit-log",
+        "parameters": [
+          {
+            "description": "Filter by affected object type.",
+            "explode": false,
+            "in": "query",
+            "name": "object_type",
+            "schema": {
+              "description": "Filter by affected object type.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Opaque cursor returned by the previous page.",
+            "explode": false,
+            "in": "query",
+            "name": "cursor",
+            "schema": {
+              "description": "Opaque cursor returned by the previous page.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of entries to return.",
+            "explode": false,
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 50,
+              "description": "Number of entries to return.",
+              "format": "int32",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogOutputBody"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Read the audit log",
+        "x-required-capability": "read_audit_log"
+      }
+    },
     "/api/auth/claim": {
       "post": {
         "operationId": "post-auth-claim-invitation",
@@ -1543,6 +1754,7 @@
     "capability-required",
     "database-unavailable",
     "internal-error",
+    "invalid-audit-cursor",
     "invalid-token",
     "invitation-email-mismatch",
     "invitation-email-unverified",

--- a/backend/sql/queries/audit.sql
+++ b/backend/sql/queries/audit.sql
@@ -25,3 +25,15 @@ select id, organization_id, occurred_at, actor_type, actor_user_id, actor_label,
     action, object_type, object_id, change_summary, reason, school_year_id, request_id
 from audit_log
 where id = $1;
+
+-- name: ListAuditLog :many
+select id, organization_id, occurred_at, actor_type, actor_user_id, actor_label,
+    action, object_type, object_id, change_summary, reason, school_year_id, request_id
+from audit_log
+where (sqlc.narg('object_type')::text is null or object_type = sqlc.narg('object_type')::text)
+  and (
+      sqlc.narg('cursor_occurred_at')::timestamptz is null
+      or (occurred_at, id) < (sqlc.narg('cursor_occurred_at')::timestamptz, sqlc.arg('cursor_id')::public.xid20)
+  )
+order by occurred_at desc, id desc
+limit sqlc.arg('page_size')::integer;


### PR DESCRIPTION
## Summary

Implements P1-10 audit log reads from SPEC §20.1 and the Owner/Administrator capability rule in SPEC §6.6.

- Adds `GET /api/audit-log` with tenant-scoped data access and keyset pagination on `(occurred_at, id)`.
- Supports only the Phase 1 `object_type` filter and an opaque URL-safe cursor.
- Returns actor, timestamp, closed-set action, affected object, change summary, and reason.
- Declares `read_audit_log` in Huma metadata, so Coordinator requests are denied by the shared capability middleware.
- Regenerates `internal/db/gen` and `openapi.json`.

ADR references: `docs/adr/0008-authorization-capabilities-and-audit.md`, `docs/adr/0010-schema-generated-code-and-migration-conventions.md`.

## Validation

- `cd backend && make test` (pass; database-backed integration tests skipped because test database URLs are not configured)
- `cd backend && make lint` (pass)
- `cd backend && make format` (pass)
- `cd backend && make generated-code-drift` (pass)
- `cd frontend && bun install --frozen-lockfile && bun run test -- --run` (8 passed)
- `cd frontend && bun install --frozen-lockfile && bun run build` (pass)
- `cd frontend && bun install --frozen-lockfile && bun run lint` (pass)
- `git diff --check` (pass)
- Migration round-trip wrapper attempted; it requires `POSTGRES_ADMIN_DATABASE_URL`, which is unavailable in this worker.

Fixes #59
