### PR TITLE
feat: add frontend authentication shell

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -283,3 +283,26 @@
   comments. All nine current-head checks pass; slowest were Generated code drift (1m28s), Backend lint
   (1m09s), and Backend tests (1m02s). The exact wrapper's host `psql` limitation is the only local
   environment note; no blocker or human action remains.
+
+## Issue #60 frontend auth shell, session, and school-year routing
+
+- `frontend/src/lib/auth.ts` creates the `supabase-js` browser client with persisted, auto-refreshing
+  sessions from `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`; `AuthProvider` subscribes to session
+  changes and exposes email/password sign-in, sign-up for invitation claim, password reset, and sign-out.
+- `frontend/src/lib/api.ts` adds dynamic `Authorization: Bearer` injection for `/api/me` and
+  `/api/auth/claim`, plus the P1-4 `/api/school-years` and `/api/school-years/:id` resource calls.
+- `frontend/src/App.tsx` protects `/years` and `/y/:schoolYearId/...`; the year remains route-only and
+  a 404 from Go renders `School year not found`. `AppShell` has the user menu/sign-out; there is no
+  dashboard or statistics page. `frontend/index.html` has a strict static CSP meta policy.
+- Focused coverage is in `frontend/src/App.test.tsx` and `frontend/src/lib/api.test.ts`; frozen Bun
+  install, 12 frontend tests, build, lint, and `git diff --check` pass. React Router emits only its
+  existing v7 future-flag warnings in tests.
+- PR #77 is open, non-draft, mergeable, references `Fixes #60`, cites SPEC §§9.3/9.4/6.6 and ADR 0009,
+  and has no review or inline comments. After rebasing onto merged P1-4, all nine current-head checks
+  pass on commit `1a6d049`: Backend tests, Backend lint, Backend format, Generated code drift,
+  Migration round-trip, Frontend tests, Frontend build, Frontend lint, and Repository formatting.
+- Telemetry: quiet-window wait 0s; local frontend gate under 8s; PR CI completed in about 1m20s after
+  the rebase, with slow checks Generated code drift (1m19s), Backend lint (1m16s), and Migration
+  round-trip (1m05s). No post-merge main CI run is active.
+- Final handoff: update the single Workpad comment to `complete`; Detent owns the completion-lane
+  transition. Skill draft: no — the implementation used standard frontend auth and routing patterns.

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -6,6 +6,7 @@
       "name": "miniclass-frontend",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.3",
+        "@supabase/supabase-js": "2.112.4",
         "@tanstack/react-query": "^5.28.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -175,11 +176,11 @@
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.3", "http://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q=="],
 
-    "@redocly/ajv": ["@redocly/ajv@8.11.2", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2", "uri-js-replace": "^1.0.1" } }, "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg=="],
+    "@redocly/ajv": ["@redocly/ajv@8.11.2", "http://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz", { "dependencies": { "fast-deep-equal": "^3.1.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2", "uri-js-replace": "^1.0.1" } }, "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg=="],
 
-    "@redocly/config": ["@redocly/config@0.22.0", "", {}, "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ=="],
+    "@redocly/config": ["@redocly/config@0.22.0", "http://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz", {}, "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ=="],
 
-    "@redocly/openapi-core": ["@redocly/openapi-core@1.34.19", "", { "dependencies": { "@redocly/ajv": "8.11.2", "@redocly/config": "0.22.0", "colorette": "1.4.0", "https-proxy-agent": "7.0.6", "js-levenshtein": "1.1.6", "js-yaml": "4.3.1", "minimatch": "5.1.9", "pluralize": "8.0.0", "yaml-ast-parser": "0.0.43" } }, "sha512-o/0VgsBXgwcY1lyeqcVtSGdTQAPnVggo0fbFVPlxl5XVDKUcVH0OLRqt3CbkwByT5FU305E0iE0O7MzThjDblw=="],
+    "@redocly/openapi-core": ["@redocly/openapi-core@1.34.19", "http://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.19.tgz", { "dependencies": { "@redocly/ajv": "8.11.2", "@redocly/config": "0.22.0", "colorette": "1.4.0", "https-proxy-agent": "7.0.6", "js-levenshtein": "1.1.6", "js-yaml": "4.3.1", "minimatch": "5.1.9", "pluralize": "8.0.0", "yaml-ast-parser": "0.0.43" } }, "sha512-o/0VgsBXgwcY1lyeqcVtSGdTQAPnVggo0fbFVPlxl5XVDKUcVH0OLRqt3CbkwByT5FU305E0iE0O7MzThjDblw=="],
 
     "@remix-run/router": ["@remix-run/router@1.23.4", "http://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz", {}, "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q=="],
 
@@ -236,6 +237,20 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.5", "http://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.5.tgz", { "os": "win32", "cpu": "x64" }, "sha512-/gDJaRs4gl0NPIwqCz+6PkpmhhjRAD2j6P4rSNHBzUkO3naEx2mIU0pRle1vUNRQ7mE/+8OOeXLTv/J56FKiQg=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.12", "http://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz", {}, "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g=="],
+
+    "@supabase/auth-js": ["@supabase/auth-js@2.112.4", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-z8DesgwLzKM5PiT0yNmJU8VJyh1zAhYi+20Z7drdJQLXg/wWW4yGt/un+He5ERYUo94Vz66t5aeyr1DIDemI5A=="],
+
+    "@supabase/functions-js": ["@supabase/functions-js@2.112.4", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-DQ0aVH8wSQAccVqNoEkec62qCu2QRNyoGN53RqsVZ1k6F1zq4/v8scrlR6LNT2RJmT97apiTmORijPVhErCS2g=="],
+
+    "@supabase/phoenix": ["@supabase/phoenix@0.4.5", "", {}, "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="],
+
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.112.4", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-uaubtPSeg2TR4wrtfQoQWgkTAe+a0qWX2KhmwvTfNl5mGN9+U7owiJt6abk3o/V6O899PSRD1yzxs5RlF4xTug=="],
+
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.112.4", "", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-vZ+j079SKrM0Xiq7MJCvQKLDpaH2kfKfLY68xuQE1sqsCsMmx1CyrDBJHsxZ3cX01VOs5SI9igmoZAF3BmdZxw=="],
+
+    "@supabase/storage-js": ["@supabase/storage-js@2.112.4", "", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-lQ0JemuTlMIXVKgSci1qez8yPnM5hyDngeAfEBjZS2Om4D+Cus0EE5BE6glFobrxdyii1OF4UzWfF0zcQgDq5A=="],
+
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.112.4", "", { "dependencies": { "@supabase/auth-js": "2.112.4", "@supabase/functions-js": "2.112.4", "@supabase/postgrest-js": "2.112.4", "@supabase/realtime-js": "2.112.4", "@supabase/storage-js": "2.112.4" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-UiCX1udlFY1fQQrO7Z3GU7obQsju0w5Vk9mOOwalfo/+Gy+tahWVenSSuu5E/GTy/q//HxvGv2IrCdW66/61kw=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.3", "http://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
 
@@ -335,7 +350,7 @@
 
     "ajv": ["ajv@6.15.0", "http://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
-    "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
+    "ansi-colors": ["ansi-colors@4.1.3", "http://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "http://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -381,7 +396,7 @@
 
     "chalk": ["chalk@4.1.2", "http://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-    "change-case": ["change-case@5.4.4", "", {}, "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="],
+    "change-case": ["change-case@5.4.4", "http://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz", {}, "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="],
 
     "check-error": ["check-error@1.0.3", "http://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz", { "dependencies": { "get-func-name": "^2.0.2" } }, "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg=="],
 
@@ -393,7 +408,7 @@
 
     "color-name": ["color-name@1.1.4", "http://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "colorette": ["colorette@1.4.0", "", {}, "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="],
+    "colorette": ["colorette@1.4.0", "http://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz", {}, "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="],
 
     "combined-stream": ["combined-stream@1.0.8", "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
@@ -563,6 +578,8 @@
 
     "human-signals": ["human-signals@5.0.0", "http://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz", {}, "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="],
 
+    "iceberg-js": ["iceberg-js@0.8.1", "", {}, "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="],
+
     "iconv-lite": ["iconv-lite@0.6.3", "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "ignore": ["ignore@5.3.2", "http://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
@@ -573,7 +590,7 @@
 
     "indent-string": ["indent-string@4.0.0", "http://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
-    "index-to-position": ["index-to-position@1.2.0", "", {}, "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw=="],
+    "index-to-position": ["index-to-position@1.2.0", "http://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz", {}, "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw=="],
 
     "inflight": ["inflight@1.0.6", "http://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
@@ -629,7 +646,7 @@
 
     "jiti": ["jiti@2.7.0", "http://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
-    "js-levenshtein": ["js-levenshtein@1.1.6", "", {}, "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="],
+    "js-levenshtein": ["js-levenshtein@1.1.6", "http://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz", {}, "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="],
 
     "js-tokens": ["js-tokens@9.0.1", "http://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
@@ -735,11 +752,11 @@
 
     "onetime": ["onetime@6.0.0", "http://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
 
-    "openapi-fetch": ["openapi-fetch@0.14.1", "", { "dependencies": { "openapi-typescript-helpers": "^0.0.15" } }, "sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A=="],
+    "openapi-fetch": ["openapi-fetch@0.14.1", "http://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.14.1.tgz", { "dependencies": { "openapi-typescript-helpers": "^0.0.15" } }, "sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A=="],
 
-    "openapi-typescript": ["openapi-typescript@7.13.0", "", { "dependencies": { "@redocly/openapi-core": "^1.34.6", "ansi-colors": "^4.1.3", "change-case": "^5.4.4", "parse-json": "^8.3.0", "supports-color": "^10.2.2", "yargs-parser": "^21.1.1" }, "peerDependencies": { "typescript": "^5.x" }, "bin": { "openapi-typescript": "bin/cli.js" } }, "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ=="],
+    "openapi-typescript": ["openapi-typescript@7.13.0", "http://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz", { "dependencies": { "@redocly/openapi-core": "^1.34.6", "ansi-colors": "^4.1.3", "change-case": "^5.4.4", "parse-json": "^8.3.0", "supports-color": "^10.2.2", "yargs-parser": "^21.1.1" }, "peerDependencies": { "typescript": "^5.x" }, "bin": { "openapi-typescript": "bin/cli.js" } }, "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ=="],
 
-    "openapi-typescript-helpers": ["openapi-typescript-helpers@0.0.15", "", {}, "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw=="],
+    "openapi-typescript-helpers": ["openapi-typescript-helpers@0.0.15", "http://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz", {}, "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw=="],
 
     "optionator": ["optionator@0.9.4", "http://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -749,7 +766,7 @@
 
     "parent-module": ["parent-module@1.0.1", "http://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
-    "parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
+    "parse-json": ["parse-json@8.3.0", "http://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
 
     "parse5": ["parse5@7.3.0", "http://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -771,7 +788,7 @@
 
     "pkg-types": ["pkg-types@1.3.1", "http://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
-    "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
+    "pluralize": ["pluralize@8.0.0", "http://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "http://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -805,7 +822,7 @@
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "http://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
-    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+    "require-from-string": ["require-from-string@2.0.2", "http://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "requires-port": ["requires-port@1.0.0", "http://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz", {}, "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="],
 
@@ -871,7 +888,7 @@
 
     "strip-literal": ["strip-literal@2.1.1", "http://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q=="],
 
-    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+    "supports-color": ["supports-color@10.2.2", "http://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
     "symbol-tree": ["symbol-tree@3.2.4", "http://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
@@ -897,6 +914,8 @@
 
     "ts-api-utils": ["ts-api-utils@1.4.3", "http://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz", { "peerDependencies": { "typescript": ">=4.2.0" } }, "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw=="],
 
+    "tslib": ["tslib@2.8.1", "http://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "type-check": ["type-check@0.4.0", "http://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "type-detect": ["type-detect@4.1.0", "http://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz", {}, "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw=="],
@@ -913,7 +932,7 @@
 
     "uri-js": ["uri-js@4.4.1", "http://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
-    "uri-js-replace": ["uri-js-replace@1.0.1", "", {}, "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g=="],
+    "uri-js-replace": ["uri-js-replace@1.0.1", "http://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz", {}, "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g=="],
 
     "url-parse": ["url-parse@1.5.10", "http://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz", { "dependencies": { "querystringify": "^2.1.1", "requires-port": "^1.0.0" } }, "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ=="],
 
@@ -955,9 +974,9 @@
 
     "yallist": ["yallist@3.1.1", "http://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "yaml-ast-parser": ["yaml-ast-parser@0.0.43", "", {}, "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="],
+    "yaml-ast-parser": ["yaml-ast-parser@0.0.43", "http://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz", {}, "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="],
 
-    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+    "yargs-parser": ["yargs-parser@21.1.1", "http://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "yocto-queue": ["yocto-queue@1.2.2", "http://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
@@ -969,9 +988,9 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "http://registry.npmjs.org/semver/-/semver-6.3.1.tgz", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@redocly/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+    "@redocly/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "http://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "@redocly/openapi-core/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+    "@redocly/openapi-core/minimatch": ["minimatch@5.1.9", "http://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.3", "http://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz", { "dependencies": { "@emnapi/wasi-threads": "1.2.3", "tslib": "^2.4.0" }, "bundled": true }, "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg=="],
 
@@ -1009,7 +1028,7 @@
 
     "p-locate/p-limit": ["p-limit@3.1.0", "http://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
-    "parse-json/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+    "parse-json/type-fest": ["type-fest@4.41.0", "http://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "pkg-types/pathe": ["pathe@2.0.3", "http://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#f7f8fc" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self' https://*.supabase.co https://*.supabase.in; font-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data:; object-src 'none'; script-src 'self'; style-src 'self'" />
     <title>MiniClass</title>
   </head>
   <body>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
+    "@supabase/supabase-js": "2.112.4",
     "@tanstack/react-query": "^5.28.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,21 +1,92 @@
-import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import App from './App'
+import { AppWithAuth } from './App'
+import type { AuthClient, Session } from './lib/auth'
 
-vi.mock('./features/health/HealthCheck', () => ({
-  HealthCheck: () => <div data-testid="health-check">Backend health check</div>,
-}))
+function renderApp(path: string, authClient: AuthClient | null) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[path]}>
+        <AppWithAuth authClient={authClient} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+function authenticatedClient(): AuthClient {
+  const session = {
+    access_token: 'test-access-token',
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    expires_in: 3600,
+    refresh_token: 'test-refresh-token',
+    token_type: 'bearer',
+    user: { id: 'user-test', email: 'admin@example.com' },
+  } as Session
+
+  return {
+    auth: {
+      getSession: vi.fn(async () => ({ data: { session }, error: null })),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+      resetPasswordForEmail: vi.fn(async () => ({ data: {}, error: null })),
+      signInWithPassword: vi.fn(async () => ({ data: { session, user: session.user }, error: null })),
+      signUp: vi.fn(async () => ({ data: { session, user: session.user }, error: null })),
+      signOut: vi.fn(async () => ({ error: null })),
+    },
+  } as unknown as AuthClient
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 describe('App routing', () => {
-  it('redirects the root route to the health page', () => {
-    render(
-      <MemoryRouter initialEntries={['/']}>
-        <App />
-      </MemoryRouter>,
-    )
+  it('redirects an unauthenticated user from a protected route to sign-in', async () => {
+    renderApp('/years', null)
 
-    expect(screen.getByTestId('health-check')).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Sign in' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Email')).toBeInTheDocument()
+  })
+
+  it('lands an authenticated user on the school-year list without a dashboard', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/me')) {
+        return new Response(JSON.stringify({
+          principal: { id: 'user-test', email: 'admin@example.com' },
+          organization: { id: 'org-test', name: 'Test organisation' },
+          role: 'Owner',
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      return new Response('[]', { status: 200, headers: { 'Content-Type': 'application/json' } })
+    }))
+
+    renderApp('/', authenticatedClient())
+
+    expect(await screen.findByRole('heading', { name: 'School years' })).toBeInTheDocument()
+    expect(await screen.findByText('No school years yet')).toBeInTheDocument()
+    expect(screen.queryByText(/statistics|dashboard/i)).not.toBeInTheDocument()
+  })
+
+  it('renders a clean not-found page for a foreign school-year URL', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/school-years/foreign-year')) {
+        return new Response(JSON.stringify({ type: 'resource-not-found', detail: 'school year not found' }), { status: 404, headers: { 'Content-Type': 'application/problem+json' } })
+      }
+      return new Response(JSON.stringify({
+        principal: { id: 'user-test', email: 'admin@example.com' },
+        organization: { id: 'org-test', name: 'Test organisation' },
+        role: 'Owner',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    }))
+
+    renderApp('/y/foreign-year/classes', authenticatedClient())
+
+    expect(await screen.findByRole('heading', { name: 'School year not found' })).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByRole('link', { name: 'Back to school years' })).toHaveAttribute('href', '/years'))
   })
 })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,67 @@
-import { Navigate, Route, Routes } from 'react-router-dom'
+import { Navigate, Outlet, Route, Routes, useLocation } from 'react-router-dom'
 
+import { AppShell } from '@/components/AppShell'
+import type { AuthClient } from '@/lib/auth'
+import { AuthProvider } from '@/lib/hooks/AuthProvider'
+import { useAuth } from '@/lib/hooks/useAuth'
 import { HealthCheck } from '@/features/health/HealthCheck'
+import { ClaimInvitationPage } from '@/features/auth/ClaimInvitationPage'
+import { ResetPasswordPage } from '@/features/auth/ResetPasswordPage'
+import { SignInPage } from '@/features/auth/SignInPage'
+import { SchoolYearGuard, SchoolYearListPage, SchoolYearNotFound, SchoolYearWorkspace } from '@/features/school-years/SchoolYearPages'
 
 function App() {
   return (
+    <AuthProvider>
+      <AppRoutes />
+    </AuthProvider>
+  )
+}
+
+export function AppWithAuth({ authClient }: { authClient: AuthClient | null }) {
+  return (
+    <AuthProvider client={authClient}>
+      <AppRoutes />
+    </AuthProvider>
+  )
+}
+
+function AppRoutes() {
+  return (
     <Routes>
-      <Route path="/" element={<Navigate replace to="/health" />} />
+      <Route path="/" element={<Navigate replace to="/years" />} />
       <Route path="/health" element={<HealthCheck />} />
-      <Route path="*" element={<Navigate replace to="/health" />} />
+      <Route path="/sign-in" element={<SignInPage />} />
+      <Route path="/reset-password" element={<ResetPasswordPage />} />
+      <Route path="/claim/:token" element={<ClaimInvitationPage />} />
+      <Route element={<ProtectedRoute />}>
+        <Route element={<AppShell />}>
+          <Route path="/years" element={<SchoolYearListPage />} />
+          <Route path="/y/:schoolYearId" element={<SchoolYearGuard />}>
+            <Route index element={<SchoolYearWorkspace />} />
+            <Route path="*" element={<SchoolYearWorkspace />} />
+          </Route>
+        </Route>
+      </Route>
+      <Route path="*" element={<SchoolYearNotFound />} />
     </Routes>
   )
+}
+
+function ProtectedRoute() {
+  const { isLoading, session } = useAuth()
+  const location = useLocation()
+
+  if (isLoading) {
+    return <p className="flex min-h-screen items-center justify-center text-sm text-muted-foreground" role="status">Checking your session…</p>
+  }
+
+  if (!session) {
+    const redirect = `${location.pathname}${location.search}`
+    return <Navigate replace to={`/sign-in?redirect=${encodeURIComponent(redirect)}`} />
+  }
+
+  return <Outlet />
 }
 
 export default App

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react'
+import { Link, Outlet, useNavigate } from 'react-router-dom'
+
+import { Button } from '@/components/ui/button'
+import { useAccount } from '@/lib/hooks/useAccount'
+import { useAuth } from '@/lib/hooks/useAuth'
+
+export function AppShell() {
+  const { session, signOut } = useAuth()
+  const { data: account } = useAccount()
+  const navigate = useNavigate()
+  const [isSigningOut, setIsSigningOut] = useState(false)
+
+  async function handleSignOut() {
+    setIsSigningOut(true)
+    try {
+      await signOut()
+      navigate('/sign-in', { replace: true })
+    } finally {
+      setIsSigningOut(false)
+    }
+  }
+
+  const email = account?.principal.email ?? session?.user.email ?? 'Administrator'
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="border-b bg-card">
+        <div className="mx-auto flex min-h-16 w-full max-w-6xl items-center justify-between gap-4 px-6">
+          <Link className="font-semibold tracking-tight text-foreground" to="/years">MiniClass</Link>
+          <div className="flex items-center gap-4">
+            <Link className="text-sm font-medium text-muted-foreground hover:text-foreground" to="/years">School years</Link>
+            <details className="relative">
+              <summary className="cursor-pointer list-none rounded-md border px-3 py-2 text-sm font-medium hover:bg-accent">{email}</summary>
+              <div className="absolute right-0 z-10 mt-2 w-64 rounded-lg border bg-card p-3 shadow-lg">
+                <p className="truncate text-sm font-medium">{email}</p>
+                {account && <p className="mt-1 text-xs text-muted-foreground">{account.organization.name} · {account.role}</p>}
+                <Button className="mt-3 w-full" variant="outline" size="sm" type="button" onClick={() => void handleSignOut()} disabled={isSigningOut}>
+                  {isSigningOut ? 'Signing out…' : 'Sign out'}
+                </Button>
+              </div>
+            </details>
+          </div>
+        </div>
+      </header>
+      <Outlet />
+    </div>
+  )
+}
+

--- a/frontend/src/features/auth/AuthLayout.tsx
+++ b/frontend/src/features/auth/AuthLayout.tsx
@@ -1,0 +1,23 @@
+import type { PropsWithChildren } from 'react'
+
+export function AuthLayout({ children }: PropsWithChildren) {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-6 py-12">
+      <div className="w-full max-w-md">
+        <div className="mb-8 text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary">MiniClass</p>
+          <p className="mt-3 text-sm text-muted-foreground">A calmer way to plan school enrichment.</p>
+        </div>
+        <section className="rounded-xl border bg-card p-6 shadow-sm sm:p-8">{children}</section>
+      </div>
+    </main>
+  )
+}
+
+export function AuthErrorMessage({ message }: { message: string }) {
+  return (
+    <p className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive" role="alert">
+      {message}
+    </p>
+  )
+}

--- a/frontend/src/features/auth/ClaimInvitationPage.tsx
+++ b/frontend/src/features/auth/ClaimInvitationPage.tsx
@@ -1,0 +1,97 @@
+import { useState, type FormEvent } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { apiClient, ApiError } from '@/lib/api'
+import { useAuth } from '@/lib/hooks/useAuth'
+
+import { AuthErrorMessage, AuthLayout } from './AuthLayout'
+import { errorMessage } from './auth-utils'
+
+export function ClaimInvitationPage() {
+  const { token } = useParams<{ token: string }>()
+  const { authConfigured, isLoading, session, signIn, signUp } = useAuth()
+  const navigate = useNavigate()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [mode, setMode] = useState<'sign-in' | 'create'>('sign-in')
+  const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  async function claim() {
+    if (!token) {
+      throw new Error('This invitation link is incomplete.')
+    }
+    await apiClient.claimInvitation(token)
+    navigate('/years', { replace: true })
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setError(null)
+    setMessage(null)
+    setIsSubmitting(true)
+    try {
+      if (session) {
+        await claim()
+        return
+      }
+
+      const result = mode === 'sign-in' ? await signIn(email.trim(), password) : await signUp(email.trim(), password)
+      if (result.session) {
+        await claim()
+      } else if (mode === 'create') {
+        setMessage('Check your email to verify the account, then return here and sign in to finish claiming the invitation.')
+      } else {
+        setMessage('Sign-in succeeded, but the session is not ready yet. Please try claiming again.')
+      }
+    } catch (reason) {
+      if (reason instanceof ApiError && reason.status === 403) {
+        setError('This invitation could not be claimed with the verified email on the signed-in account.')
+      } else {
+        setError(errorMessage(reason))
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (isLoading) {
+    return <AuthLayout><p className="text-sm text-muted-foreground" role="status">Checking your session…</p></AuthLayout>
+  }
+
+  return (
+    <AuthLayout>
+      <h1 className="text-2xl font-semibold tracking-tight">Claim your administrator invitation</h1>
+      <p className="mt-2 text-sm text-muted-foreground">The invitation is valid for one administrator account. The signed-in email must match the invitation.</p>
+      <div className="mt-6 space-y-3">
+        {!authConfigured && <AuthErrorMessage message="Authentication is not configured for this site." />}
+        {error && <AuthErrorMessage message={error} />}
+        {message && <p className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800" role="status">{message}</p>}
+      </div>
+
+      <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+        {!session && (
+          <>
+            <div className="flex gap-2 rounded-md bg-secondary p-1 text-sm" role="tablist" aria-label="Invitation account action">
+              <button className={`flex-1 rounded px-3 py-2 ${mode === 'sign-in' ? 'bg-background font-medium shadow-sm' : 'text-muted-foreground'}`} type="button" role="tab" aria-selected={mode === 'sign-in'} onClick={() => setMode('sign-in')}>Sign in</button>
+              <button className={`flex-1 rounded px-3 py-2 ${mode === 'create' ? 'bg-background font-medium shadow-sm' : 'text-muted-foreground'}`} type="button" role="tab" aria-selected={mode === 'create'} onClick={() => setMode('create')}>Create account</button>
+            </div>
+            <label className="block space-y-2 text-sm font-medium" htmlFor="claim-email">
+              Email
+              <Input id="claim-email" name="email" type="email" autoComplete="email" required value={email} onChange={(event) => setEmail(event.target.value)} />
+            </label>
+            <label className="block space-y-2 text-sm font-medium" htmlFor="claim-password">
+              Password
+              <Input id="claim-password" name="password" type="password" autoComplete={mode === 'sign-in' ? 'current-password' : 'new-password'} required minLength={8} value={password} onChange={(event) => setPassword(event.target.value)} />
+            </label>
+          </>
+        )}
+        <Button className="w-full" type="submit" disabled={isSubmitting || !authConfigured}>{isSubmitting ? 'Claiming…' : session ? 'Claim invitation' : mode === 'sign-in' ? 'Sign in and claim' : 'Create account and claim'}</Button>
+      </form>
+      <p className="mt-6 text-sm text-muted-foreground"><Link className="font-medium text-primary hover:underline" to="/sign-in">Back to sign in</Link></p>
+    </AuthLayout>
+  )
+}

--- a/frontend/src/features/auth/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/ResetPasswordPage.tsx
@@ -1,0 +1,51 @@
+import { useState, type FormEvent } from 'react'
+import { Link } from 'react-router-dom'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useAuth } from '@/lib/hooks/useAuth'
+
+import { AuthErrorMessage, AuthLayout } from './AuthLayout'
+import { errorMessage } from './auth-utils'
+
+export function ResetPasswordPage() {
+  const { authConfigured, resetPassword } = useAuth()
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [sent, setSent] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      await resetPassword(email.trim())
+      setSent(true)
+    } catch (reason) {
+      setError(errorMessage(reason))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <AuthLayout>
+      <h1 className="text-2xl font-semibold tracking-tight">Reset your password</h1>
+      <p className="mt-2 text-sm text-muted-foreground">We’ll email a reset link to your administrator account.</p>
+      <div className="mt-6 space-y-3">
+        {!authConfigured && <AuthErrorMessage message="Authentication is not configured for this site." />}
+        {error && <AuthErrorMessage message={error} />}
+        {sent && <p className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800" role="status">If that address is an administrator account, a reset link is on its way.</p>}
+      </div>
+      <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+        <label className="block space-y-2 text-sm font-medium" htmlFor="reset-email">
+          Email
+          <Input id="reset-email" name="email" type="email" autoComplete="email" required value={email} onChange={(event) => setEmail(event.target.value)} />
+        </label>
+        <Button className="w-full" type="submit" disabled={isSubmitting || !authConfigured}>{isSubmitting ? 'Sending…' : 'Send reset link'}</Button>
+      </form>
+      <p className="mt-6 text-sm text-muted-foreground"><Link className="font-medium text-primary hover:underline" to="/sign-in">Back to sign in</Link></p>
+    </AuthLayout>
+  )
+}

--- a/frontend/src/features/auth/SignInPage.tsx
+++ b/frontend/src/features/auth/SignInPage.tsx
@@ -1,0 +1,72 @@
+import { useState, type FormEvent } from 'react'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useAuth } from '@/lib/hooks/useAuth'
+
+import { AuthErrorMessage, AuthLayout } from './AuthLayout'
+import { errorMessage } from './auth-utils'
+
+function safeRedirect(value: string | null): string {
+  return value && value.startsWith('/') && !value.startsWith('//') ? value : '/years'
+}
+
+export function SignInPage() {
+  const { authConfigured, authError, isLoading, signIn } = useAuth()
+  const location = useLocation()
+  const navigate = useNavigate()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      await signIn(email.trim(), password)
+      const redirect = new URLSearchParams(location.search).get('redirect')
+      navigate(safeRedirect(redirect), { replace: true })
+    } catch (reason) {
+      setError(errorMessage(reason))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <AuthLayout>
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
+        <p className="mt-2 text-sm text-muted-foreground">Use your administrator email and password.</p>
+      </div>
+
+      <div className="mt-6 space-y-3">
+        {!authConfigured && <AuthErrorMessage message="Authentication is not configured for this site." />}
+        {authError && <AuthErrorMessage message={authError.message} />}
+        {error && <AuthErrorMessage message={error} />}
+      </div>
+
+      <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+        <label className="block space-y-2 text-sm font-medium" htmlFor="sign-in-email">
+          Email
+          <Input id="sign-in-email" name="email" type="email" autoComplete="email" required value={email} onChange={(event) => setEmail(event.target.value)} />
+        </label>
+        <label className="block space-y-2 text-sm font-medium" htmlFor="sign-in-password">
+          Password
+          <Input id="sign-in-password" name="password" type="password" autoComplete="current-password" required value={password} onChange={(event) => setPassword(event.target.value)} />
+        </label>
+        <Button className="w-full" type="submit" disabled={isLoading || isSubmitting || !authConfigured}>
+          {isSubmitting ? 'Signing in…' : 'Sign in'}
+        </Button>
+      </form>
+
+      <div className="mt-6 flex justify-between text-sm">
+        <Link className="font-medium text-primary hover:underline" to="/reset-password">Forgot password?</Link>
+        <Link className="text-muted-foreground hover:text-foreground" to="/health">System health</Link>
+      </div>
+    </AuthLayout>
+  )
+}

--- a/frontend/src/features/auth/auth-utils.ts
+++ b/frontend/src/features/auth/auth-utils.ts
@@ -1,0 +1,7 @@
+export function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+  return 'Something went wrong. Please try again.'
+}
+

--- a/frontend/src/features/school-years/SchoolYearPages.tsx
+++ b/frontend/src/features/school-years/SchoolYearPages.tsx
@@ -1,0 +1,107 @@
+import type { ReactNode } from 'react'
+import { Link, Outlet, useOutletContext, useParams } from 'react-router-dom'
+
+import { Button } from '@/components/ui/button'
+import { ApiError, type SchoolYear } from '@/lib/api'
+import { useSchoolYear, useSchoolYears } from '@/lib/hooks/useSchoolYears'
+
+function PageFrame({ children }: { children: ReactNode }) {
+  return <main className="mx-auto w-full max-w-6xl px-6 py-10">{children}</main>
+}
+
+export function SchoolYearListPage() {
+  const { data: years, error, isError, isLoading } = useSchoolYears()
+
+  return (
+    <PageFrame>
+      <div>
+        <p className="text-sm font-medium text-primary">Workspace</p>
+        <h1 className="mt-2 text-3xl font-semibold tracking-tight">School years</h1>
+        <p className="mt-2 max-w-2xl text-sm text-muted-foreground">Choose a school year to work in. The selected year is always part of the URL, so shared and bookmarked links stay explicit.</p>
+      </div>
+
+      {isLoading && <p className="mt-8 text-sm text-muted-foreground" role="status">Loading school years…</p>}
+      {isError && <SchoolYearError error={error} />}
+      {!isLoading && !isError && years?.length === 0 && (
+        <section className="mt-8 rounded-lg border bg-card p-6">
+          <h2 className="font-semibold">No school years yet</h2>
+          <p className="mt-2 text-sm text-muted-foreground">An Owner or Administrator can create the first school year when that workspace is ready.</p>
+        </section>
+      )}
+      {!isLoading && !isError && years && years.length > 0 && (
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {years.map((year) => (
+            <Link className="rounded-lg border bg-card p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-md" key={year.id} to={`/y/${year.id}`}>
+              <div className="flex items-start justify-between gap-3">
+                <h2 className="font-semibold">{year.label}</h2>
+                <span className="rounded-full bg-secondary px-2 py-1 text-xs font-medium capitalize text-secondary-foreground">{year.state}</span>
+              </div>
+              <p className="mt-4 text-sm text-muted-foreground">Open school-year workspace</p>
+            </Link>
+          ))}
+        </div>
+      )}
+    </PageFrame>
+  )
+}
+
+export function SchoolYearGuard() {
+  const { schoolYearId } = useParams<{ schoolYearId: string }>()
+  const result = useSchoolYear(schoolYearId)
+
+  if (result.isLoading) {
+    return <PageFrame><p className="text-sm text-muted-foreground" role="status">Loading school year…</p></PageFrame>
+  }
+
+  if (result.error instanceof ApiError && result.error.status === 404) {
+    return <SchoolYearNotFound />
+  }
+
+  if (result.isError || !result.data) {
+    return <PageFrame><SchoolYearError error={result.error} /></PageFrame>
+  }
+
+  return <Outlet context={result.data} />
+}
+
+export function SchoolYearWorkspace() {
+  const year = useOutletContext<SchoolYear>()
+
+  return (
+    <PageFrame>
+      <p className="text-sm font-medium text-primary">School-year workspace</p>
+      <div className="mt-2 flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">{year.label}</h1>
+          <p className="mt-2 text-sm text-muted-foreground">This workspace is scoped by the school-year URL.</p>
+        </div>
+        <span className="rounded-full bg-secondary px-3 py-1 text-sm font-medium capitalize text-secondary-foreground">{year.state}</span>
+      </div>
+      <section className="mt-8 rounded-lg border bg-card p-6">
+        <h2 className="font-semibold">Workspace ready</h2>
+        <p className="mt-2 text-sm text-muted-foreground">School-year tools will appear here as they become available.</p>
+      </section>
+    </PageFrame>
+  )
+}
+
+export function SchoolYearNotFound() {
+  return (
+    <PageFrame>
+      <p className="text-sm font-medium text-primary">Not found</p>
+      <h1 className="mt-2 text-3xl font-semibold tracking-tight">School year not found</h1>
+      <p className="mt-3 max-w-xl text-sm text-muted-foreground">That school year does not exist in your organisation, or you do not have access to it.</p>
+      <Button className="mt-6" asChild><Link to="/years">Back to school years</Link></Button>
+    </PageFrame>
+  )
+}
+
+function SchoolYearError({ error }: { error: unknown }) {
+  const message = error instanceof ApiError && error.status === 403
+    ? 'Your administrator account does not have access to school years.'
+    : error instanceof Error
+      ? error.message
+      : 'Unable to load school years.'
+
+  return <p className="mt-8 rounded-md border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive" role="alert">{message}</p>
+}

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ApiClient } from './api'
+
+describe('ApiClient authentication', () => {
+  it('adds the current Supabase access token to Go requests', async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers ?? (typeof input === 'object' && 'headers' in input ? (input as Request).headers : undefined))
+      expect(headers.get('Authorization')).toBe('Bearer test-access-token')
+      return new Response(JSON.stringify({
+        principal: { id: 'user-test', email: 'admin@example.com' },
+        organization: { id: 'org-test', name: 'Test organisation' },
+        role: 'Owner',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    })
+    const client = new ApiClient({
+      baseUrl: 'https://api.test',
+      fetch: fetcher,
+      getAccessToken: async () => 'test-access-token',
+    })
+
+    await expect(client.getMe()).resolves.toMatchObject({ role: 'Owner' })
+    expect(fetcher).toHaveBeenCalledOnce()
+  })
+
+  it('posts an invitation token through the Go claim endpoint', async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = typeof input === 'object' && 'headers' in input ? input as Request : new Request(input, init)
+      const headers = new Headers(init?.headers ?? request.headers)
+      expect(headers.get('Authorization')).toBe('Bearer test-access-token')
+      await expect(request.json()).resolves.toEqual({ token: 'invitation-token' })
+      return new Response(JSON.stringify({
+        principal: { id: 'user-test', email: 'admin@example.com' },
+        organization: { id: 'org-test', name: 'Test organisation' },
+        role: 'Owner',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    })
+    const client = new ApiClient({
+      baseUrl: 'https://api.test',
+      fetch: fetcher,
+      getAccessToken: async () => 'test-access-token',
+    })
+
+    await expect(client.claimInvitation('invitation-token')).resolves.toMatchObject({ role: 'Owner' })
+  })
+})

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,37 +1,57 @@
 import createClient from 'openapi-fetch'
 
 import type { paths } from './api.generated'
+import { supabase } from './auth'
 
 export type HealthResponse = paths['/api/health']['get']['responses'][200]['content']['application/json']
+export type MeResponse = paths['/api/me']['get']['responses'][200]['content']['application/json']
+
+export type SchoolYear = {
+  id: string
+  organization_id: string
+  label: string
+  state: 'setup' | 'active' | 'closed'
+  created_at: string
+  updated_at: string
+}
 
 export type ApiErrorKind = 'http' | 'network'
 
 export class ApiError extends Error {
   readonly kind: ApiErrorKind
   readonly status?: number
+  readonly code?: string
 
-  constructor(kind: ApiErrorKind, message: string, status?: number) {
+  constructor(kind: ApiErrorKind, message: string, status?: number, code?: string) {
     super(message)
     this.name = 'ApiError'
     this.kind = kind
     this.status = status
+    this.code = code
   }
 }
 
 export type ApiClientOptions = {
   baseUrl?: string
   fetch?: typeof globalThis.fetch
+  getAccessToken?: () => Promise<string | null>
 }
 
 const configuredBaseUrl = import.meta.env.VITE_API_URL ?? ''
 
 export class ApiClient {
   private readonly client: ReturnType<typeof createClient<paths>>
+  private readonly baseUrl: string
+  private readonly fetcher: typeof globalThis.fetch
+  private readonly getAccessToken: () => Promise<string | null>
 
   constructor(options: ApiClientOptions = {}) {
+    this.baseUrl = options.baseUrl ?? configuredBaseUrl
+    this.fetcher = options.fetch ?? ((input, init) => globalThis.fetch(input, init))
+    this.getAccessToken = options.getAccessToken ?? getSupabaseAccessToken
     this.client = createClient<paths>({
-      baseUrl: options.baseUrl ?? configuredBaseUrl,
-      fetch: options.fetch,
+      baseUrl: this.baseUrl,
+      fetch: this.authenticatedFetch,
     })
   }
 
@@ -50,6 +70,124 @@ export class ApiClient {
     const message = result.error?.detail ?? result.error?.title ?? `The API request failed with status ${result.response.status}`
     throw new ApiError('http', message, result.response.status)
   }
+
+  async getMe(): Promise<MeResponse> {
+    const result = await this.request(() => this.client.GET('/api/me'))
+    if (result.data !== undefined) {
+      return result.data
+    }
+
+    throw this.apiError(result.response, result.error)
+  }
+
+  async claimInvitation(token: string): Promise<MeResponse> {
+    const result = await this.request(() => this.client.POST('/api/auth/claim', { body: { token } }))
+    if (result.data !== undefined) {
+      return result.data
+    }
+
+    throw this.apiError(result.response, result.error)
+  }
+
+  async getSchoolYears(): Promise<SchoolYear[]> {
+    const response = await this.rawRequest('/api/school-years')
+    const payload: unknown = await this.readJson(response)
+    if (!Array.isArray(payload)) {
+      throw new ApiError('http', 'The school-year response was invalid.', response.status)
+    }
+
+    return payload.map(parseSchoolYear)
+  }
+
+  async getSchoolYear(id: string): Promise<SchoolYear> {
+    const response = await this.rawRequest(`/api/school-years/${encodeURIComponent(id)}`)
+    const payload: unknown = await this.readJson(response)
+    if (!isSchoolYear(payload)) {
+      throw new ApiError('http', 'The school-year response was invalid.', response.status)
+    }
+
+    return payload
+  }
+
+  private async request<T>(request: () => Promise<T>): Promise<T> {
+    try {
+      return await request()
+    } catch {
+      throw new ApiError('network', 'Unable to reach the API')
+    }
+  }
+
+  private authenticatedFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const inputHeaders = typeof input === 'object' && input !== null && 'headers' in input
+      ? (input as Request).headers
+      : undefined
+    const headers = new Headers(init?.headers ?? inputHeaders)
+    const token = await this.getAccessToken()
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`)
+    }
+
+    return this.fetcher(input, { ...init, headers })
+  }
+
+  private async rawRequest(path: string): Promise<Response> {
+    let response: Response
+    try {
+      response = await this.authenticatedFetch(`${this.baseUrl}${path}`)
+    } catch {
+      throw new ApiError('network', 'Unable to reach the API')
+    }
+
+    if (!response.ok) {
+      throw this.apiError(response)
+    }
+    return response
+  }
+
+  private async readJson(response: Response): Promise<unknown> {
+    try {
+      return await response.json()
+    } catch {
+      throw new ApiError('http', 'The API returned an invalid response.', response.status)
+    }
+  }
+
+  private apiError(response: Response, error?: { detail?: string; title?: string; type?: string } | null): ApiError {
+    const message = error?.detail ?? error?.title ?? `The API request failed with status ${response.status}`
+    return new ApiError('http', message, response.status, error?.type)
+  }
 }
 
 export const apiClient = new ApiClient()
+
+async function getSupabaseAccessToken(): Promise<string | null> {
+  if (!supabase) {
+    return null
+  }
+
+  const { data } = await supabase.auth.getSession()
+  return data.session?.access_token ?? null
+}
+
+function parseSchoolYear(value: unknown): SchoolYear {
+  if (!isSchoolYear(value)) {
+    throw new ApiError('http', 'The school-year response was invalid.')
+  }
+  return value
+}
+
+function isSchoolYear(value: unknown): value is SchoolYear {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const candidate = value as Record<string, unknown>
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.organization_id === 'string' &&
+    typeof candidate.label === 'string' &&
+    (candidate.state === 'setup' || candidate.state === 'active' || candidate.state === 'closed') &&
+    typeof candidate.created_at === 'string' &&
+    typeof candidate.updated_at === 'string'
+  )
+}

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,19 @@
+import { createClient, type AuthChangeEvent, type AuthError, type Session, type SupabaseClient } from '@supabase/supabase-js'
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+
+export const supabase: SupabaseClient | null =
+  supabaseUrl && supabaseAnonKey
+    ? createClient(supabaseUrl, supabaseAnonKey, {
+        auth: {
+          autoRefreshToken: true,
+          detectSessionInUrl: true,
+          persistSession: true,
+        },
+      })
+    : null
+
+export type AuthClient = Pick<SupabaseClient, 'auth'>
+export type { AuthChangeEvent, AuthError, Session }
+

--- a/frontend/src/lib/hooks/AuthProvider.tsx
+++ b/frontend/src/lib/hooks/AuthProvider.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { AuthError, Session } from '@supabase/supabase-js'
+
+import { supabase } from '@/lib/auth'
+
+import { AuthContext, type AuthContextValue, type AuthProviderProps } from './auth-context'
+
+export function AuthProvider({ children, client = supabase }: AuthProviderProps) {
+  const [session, setSession] = useState<Session | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [authError, setAuthError] = useState<AuthError | null>(null)
+
+  useEffect(() => {
+    let mounted = true
+
+    if (!client) {
+      setIsLoading(false)
+      return () => {
+        mounted = false
+      }
+    }
+
+    const { data } = client.auth.onAuthStateChange((_event, nextSession) => {
+      if (mounted) {
+        setSession(nextSession)
+        setAuthError(null)
+        setIsLoading(false)
+      }
+    })
+
+    void client.auth.getSession().then(({ data: sessionData, error }) => {
+      if (!mounted) {
+        return
+      }
+      setSession(sessionData.session)
+      setAuthError(error)
+      setIsLoading(false)
+    })
+
+    return () => {
+      mounted = false
+      data.subscription.unsubscribe()
+    }
+  }, [client])
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      authConfigured: client !== null,
+      authError,
+      isLoading,
+      session,
+      signIn: async (email, password) => {
+        if (!client) {
+          throw new Error('Authentication is not configured.')
+        }
+        const { data, error } = await client.auth.signInWithPassword({ email, password })
+        if (error) {
+          throw error
+        }
+        return { session: data.session }
+      },
+      signUp: async (email, password) => {
+        if (!client) {
+          throw new Error('Authentication is not configured.')
+        }
+        const { data, error } = await client.auth.signUp({ email, password })
+        if (error) {
+          throw error
+        }
+        return { session: data.session }
+      },
+      resetPassword: async (email) => {
+        if (!client) {
+          throw new Error('Authentication is not configured.')
+        }
+        const { error } = await client.auth.resetPasswordForEmail(email, {
+          redirectTo: `${window.location.origin}/reset-password`,
+        })
+        if (error) {
+          throw error
+        }
+      },
+      signOut: async () => {
+        if (!client) {
+          throw new Error('Authentication is not configured.')
+        }
+        const { error } = await client.auth.signOut()
+        if (error) {
+          throw error
+        }
+      },
+    }),
+    [authError, client, isLoading, session],
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}

--- a/frontend/src/lib/hooks/auth-context.ts
+++ b/frontend/src/lib/hooks/auth-context.ts
@@ -1,0 +1,25 @@
+import { createContext, type ReactNode } from 'react'
+
+import type { AuthClient, AuthError, Session } from '@/lib/auth'
+
+export type AuthActionResult = {
+  session: Session | null
+}
+
+export type AuthContextValue = {
+  authConfigured: boolean
+  authError: AuthError | null
+  isLoading: boolean
+  session: Session | null
+  signIn: (email: string, password: string) => Promise<AuthActionResult>
+  signUp: (email: string, password: string) => Promise<AuthActionResult>
+  resetPassword: (email: string) => Promise<void>
+  signOut: () => Promise<void>
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null)
+
+export type AuthProviderProps = {
+  client?: AuthClient | null
+  children: ReactNode
+}

--- a/frontend/src/lib/hooks/useAccount.ts
+++ b/frontend/src/lib/hooks/useAccount.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { apiClient } from '@/lib/api'
+
+import { useAuth } from './useAuth'
+
+export function useAccount() {
+  const { session } = useAuth()
+
+  return useQuery({
+    queryKey: ['account', session?.user.id],
+    queryFn: () => apiClient.getMe(),
+    enabled: Boolean(session),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  })
+}
+

--- a/frontend/src/lib/hooks/useAuth.ts
+++ b/frontend/src/lib/hooks/useAuth.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react'
+
+import { AuthContext } from './auth-context'
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used inside AuthProvider')
+  }
+  return context
+}
+

--- a/frontend/src/lib/hooks/useSchoolYears.ts
+++ b/frontend/src/lib/hooks/useSchoolYears.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { apiClient } from '@/lib/api'
+
+export function useSchoolYears() {
+  return useQuery({
+    queryKey: ['school-years'],
+    queryFn: () => apiClient.getSchoolYears(),
+    staleTime: 30 * 1000,
+    retry: false,
+  })
+}
+
+export function useSchoolYear(id: string | undefined) {
+  return useQuery({
+    queryKey: ['school-year', id],
+    queryFn: () => apiClient.getSchoolYear(id!),
+    enabled: Boolean(id),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  })
+}
+

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -2,6 +2,8 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_URL?: string
+  readonly VITE_SUPABASE_URL?: string
+  readonly VITE_SUPABASE_ANON_KEY?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

- add the Supabase browser session provider with persisted refresh, email/password sign-in, password reset, invitation claim, and bearer-authenticated Go requests
- add protected routes, the app shell/user menu/sign-out, and a school-year list plus `/y/:schoolYearId/...` route guard with a clean not-found state
- add strict static-site CSP and focused auth/routing/API coverage

## Spec and ADR

Implements SPEC §9.3 (administrator authentication and session mechanisms), SPEC §9.4 (server-side authorization/not-found behavior), and SPEC §6.6 (administrator roles/capabilities), following ADR 0009. The organisation remains server-derived and never enters a URL; the school year is explicit in the route.

## Validation

- `cd frontend && bun install --frozen-lockfile && bun run test -- --run`
- `cd frontend && bun install --frozen-lockfile && bun run build`
- `cd frontend && bun install --frozen-lockfile && bun run lint`
- `git diff --check`

Fixes #60