### PR TITLE
P1-12: add frontend school years and settings

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -343,25 +343,3 @@
   (1m09s), and Backend tests (1m02s). The exact wrapper's host `psql` limitation is the only local
   environment note; no blocker or human action remains.
 
-## Issue #60 frontend auth shell, session, and school-year routing
-
-- `frontend/src/lib/auth.ts` creates the `supabase-js` browser client with persisted, auto-refreshing
-  sessions from `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`; `AuthProvider` subscribes to session
-  changes and exposes email/password sign-in, sign-up for invitation claim, password reset, and sign-out.
-- `frontend/src/lib/api.ts` adds dynamic `Authorization: Bearer` injection for `/api/me` and
-  `/api/auth/claim`, plus the P1-4 `/api/school-years` and `/api/school-years/:id` resource calls.
-- `frontend/src/App.tsx` protects `/years` and `/y/:schoolYearId/...`; the year remains route-only and
-  a 404 from Go renders `School year not found`. `AppShell` has the user menu/sign-out; there is no
-  dashboard or statistics page. `frontend/index.html` has a strict static CSP meta policy.
-- Focused coverage is in `frontend/src/App.test.tsx` and `frontend/src/lib/api.test.ts`; frozen Bun
-  install, 12 frontend tests, build, lint, and `git diff --check` pass. React Router emits only its
-  existing v7 future-flag warnings in tests.
-- PR #77 is open, non-draft, mergeable, references `Fixes #60`, cites SPEC §§9.3/9.4/6.6 and ADR 0009,
-  and has no review or inline comments. After rebasing onto merged P1-4, all nine current-head checks
-  pass on commit `1a6d049`: Backend tests, Backend lint, Backend format, Generated code drift,
-  Migration round-trip, Frontend tests, Frontend build, Frontend lint, and Repository formatting.
-- Telemetry: quiet-window wait 0s; local frontend gate under 8s; PR CI completed in about 1m20s after
-  the rebase, with slow checks Generated code drift (1m19s), Backend lint (1m16s), and Migration
-  round-trip (1m05s). No post-merge main CI run is active.
-- Final handoff: update the single Workpad comment to `complete`; Detent owns the completion-lane
-  transition. Skill draft: no — the implementation used standard frontend auth and routing patterns.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -343,3 +343,22 @@
   (1m09s), and Backend tests (1m02s). The exact wrapper's host `psql` limitation is the only local
   environment note; no blocker or human action remains.
 
+## Issue #61 frontend school years and settings
+
+- Added `/years` as the landing page, `/y/:schoolYearId` lifecycle/detail view, and `/settings`.
+  School-year creation, label editing, setup/active/closed transitions, owner-only reasoned reopen,
+  closed-year read-only messaging, and RFC 9457 field errors are covered in the schoolyear feature.
+- Added settings UI for ordered grade levels, homerooms, homeroom label, and Owner-only administrator
+  management. Retired grade/homeroom entries remain in the response but `activeGradeLevels` and
+  `activeHomerooms` exclude them from pickers. API paths match the P1-5 and P1-9 contracts.
+- Added the shared raw JSON API request/error parser for settings resources; generated OpenAPI output
+  remains untouched because the dependent backend contracts are still on their review PRs.
+- Validation passed: frozen Bun install, 14 frontend tests, frontend build, frontend lint, backend
+  tests (integration skipped without test database URLs), backend lint, backend format, generated-code
+  generation with no backend artifact diff, and `git diff --check`. Migration round-trip wrapper was
+  attempted but cannot run locally because `POSTGRES_ADMIN_DATABASE_URL` is unset.
+- PR #80 is open, non-draft, mergeable, references `Fixes #61`, cites SPEC §§11.1/10.1/6.6, and has
+  no review or inline comments. All nine current-head checks passed on `d2e2532`; slow checks were
+  Backend tests, Backend lint, and Generated code drift. CI migration round-trip passed despite the
+  local wrapper lacking `POSTGRES_ADMIN_DATABASE_URL`. Skill draft: no — this was standard
+  frontend/API integration work.

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { AppWithAuth } from './App'
+import App, { AppWithAuth } from './App'
 import type { AuthClient, Session } from './lib/auth'
 
 function renderApp(path: string, authClient: AuthClient | null) {
@@ -43,7 +43,24 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
+vi.mock('./features/school-years/SchoolYearPages', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    SchoolYearPage: () => <div data-testid="school-year">School year</div>,
+  }
+})
+
+vi.mock('./features/settings/SettingsPage', () => ({
+  SettingsPage: () => <div data-testid="settings">Settings</div>,
+}))
+
 describe('App routing', () => {
+  it('redirects the root route to the school-year list', async () => {
+    renderApp('/', authenticatedClient())
+    expect(await screen.findByRole('heading', { name: 'School years' })).toBeInTheDocument()
+  })
+
   it('redirects an unauthenticated user from a protected route to sign-in', async () => {
     renderApp('/years', null)
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import App, { AppWithAuth } from './App'
+import { AppWithAuth } from './App'
 import type { AuthClient, Session } from './lib/auth'
 
 function renderApp(path: string, authClient: AuthClient | null) {
@@ -44,7 +44,7 @@ afterEach(() => {
 })
 
 vi.mock('./features/school-years/SchoolYearPages', async (importOriginal) => {
-  const actual = await importOriginal()
+  const actual = await importOriginal() as Record<string, unknown>
   return {
     ...actual,
     SchoolYearPage: () => <div data-testid="school-year">School year</div>,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,7 @@ import { ClaimInvitationPage } from '@/features/auth/ClaimInvitationPage'
 import { ResetPasswordPage } from '@/features/auth/ResetPasswordPage'
 import { SignInPage } from '@/features/auth/SignInPage'
 import { SchoolYearGuard, SchoolYearListPage, SchoolYearNotFound, SchoolYearWorkspace } from '@/features/school-years/SchoolYearPages'
-
+import { SettingsPage } from '@/features/settings/SettingsPage'
 function App() {
   return (
     <AuthProvider>
@@ -40,6 +40,7 @@ function AppRoutes() {
           <Route path="/y/:schoolYearId" element={<SchoolYearGuard />}>
             <Route index element={<SchoolYearWorkspace />} />
             <Route path="*" element={<SchoolYearWorkspace />} />
+            <Route path="settings" element={<SettingsPage />} />
           </Route>
         </Route>
       </Route>

--- a/frontend/src/features/schoolyear/SchoolYearPages.test.tsx
+++ b/frontend/src/features/schoolyear/SchoolYearPages.test.tsx
@@ -1,0 +1,62 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SchoolYear } from '@/lib/apiResources'
+
+import { SchoolYearPage } from './SchoolYearPages'
+import { useSchoolYear, useUpdateSchoolYear } from './useSchoolYears'
+
+vi.mock('./useSchoolYears', () => ({
+  useSchoolYear: vi.fn(),
+  useUpdateSchoolYear: vi.fn(),
+}))
+
+vi.mock('@/lib/apiResources', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/apiResources')>()
+  return { ...actual, resourceApi: { ...actual.resourceApi, getAccount: vi.fn() } }
+})
+
+import { resourceApi } from '@/lib/apiResources'
+
+const closedYear: SchoolYear = {
+  id: 'year-test',
+  organization_id: 'org-test',
+  label: '2025–26',
+  state: 'closed',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={queryClient}><MemoryRouter initialEntries={['/y/year-test']}><SchoolYearPage /></MemoryRouter></QueryClientProvider>)
+}
+
+beforeEach(() => {
+  vi.mocked(useSchoolYear).mockReturnValue({ data: closedYear, isLoading: false, isError: false, error: null } as ReturnType<typeof useSchoolYear>)
+  vi.mocked(useUpdateSchoolYear).mockReturnValue({ mutate: vi.fn(), isPending: false, isError: false, error: null } as unknown as ReturnType<typeof useUpdateSchoolYear>)
+  vi.mocked(resourceApi.getAccount).mockResolvedValue({ role: 'Owner' })
+})
+
+describe('SchoolYearPage', () => {
+  it('marks a closed year read-only and submits an owner reason when reopening', async () => {
+    const mutate = vi.fn()
+    vi.mocked(useUpdateSchoolYear).mockReturnValue({ mutate, isPending: false, isError: false, error: null } as unknown as ReturnType<typeof useUpdateSchoolYear>)
+    renderPage()
+
+    expect(screen.getByRole('heading', { name: 'Read-only history' })).toBeInTheDocument()
+    fireEvent.click(await screen.findByRole('button', { name: 'Reopen year' }))
+    fireEvent.change(screen.getByLabelText('Reason for reopening'), { target: { value: 'Corrected an import error' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm reopen' }))
+
+    expect(mutate).toHaveBeenCalledWith({ state: 'active', reason: 'Corrected an import error' })
+  })
+
+  it('does not show the owner-only reopen control to an administrator', async () => {
+    vi.mocked(resourceApi.getAccount).mockResolvedValue({ role: 'Administrator' })
+    renderPage()
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Reopen year' })).not.toBeInTheDocument())
+  })
+})

--- a/frontend/src/features/schoolyear/SchoolYearPages.tsx
+++ b/frontend/src/features/schoolyear/SchoolYearPages.tsx
@@ -1,0 +1,150 @@
+import { useState, type FormEvent, type ReactNode } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { ApiError } from '@/lib/api'
+import { resourceApi, type SchoolYear, type SchoolYearState } from '@/lib/apiResources'
+import { useCreateSchoolYear, useSchoolYear, useSchoolYears, useUpdateSchoolYear } from './useSchoolYears'
+
+function PageFrame({ children }: { children: ReactNode }) {
+  return <main className="mx-auto w-full max-w-6xl px-6 py-10">{children}</main>
+}
+
+function Problem({ error, fallback }: { error: unknown; fallback: string }) {
+  const message = error instanceof ApiError && error.code === 'school-year-closed'
+    ? 'This school year is closed and its records are read-only.'
+    : error instanceof Error ? error.message : fallback
+  return <p className="mt-4 rounded-md border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive" role="alert">{message}</p>
+}
+
+function fieldError(error: unknown, field: string): string | undefined {
+  if (!(error instanceof ApiError)) return undefined
+  const detail = error.fieldErrors.find(({ location }) => location?.endsWith(`.${field}`) || location?.endsWith(field))
+  return detail?.message
+}
+
+function StateBadge({ state }: { state: SchoolYearState }) {
+  return <span className="rounded-full bg-secondary px-2 py-1 text-xs font-medium capitalize text-secondary-foreground">{state}</span>
+}
+
+export function SchoolYearListPage() {
+  const { data: years, error, isError, isLoading } = useSchoolYears()
+  const create = useCreateSchoolYear()
+  const [label, setLabel] = useState('')
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    create.mutate(label)
+  }
+
+  return (
+    <PageFrame>
+      <p className="text-sm font-medium text-primary">Workspace</p>
+      <h1 className="mt-2 text-3xl font-semibold tracking-tight">School years</h1>
+      <p className="mt-2 max-w-2xl text-sm text-muted-foreground">Choose a year to work in. The selected year stays in the URL so shared links remain explicit.</p>
+
+      <section className="mt-8 rounded-lg border bg-card p-5 shadow-sm" aria-labelledby="create-school-year-heading">
+        <h2 id="create-school-year-heading" className="font-semibold">Create a school year</h2>
+        <form className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start" onSubmit={submit}>
+          <div className="flex-1">
+            <label className="text-sm font-medium" htmlFor="school-year-label">Display label</label>
+            <Input id="school-year-label" className="mt-1" value={label} onChange={(event) => setLabel(event.target.value)} />
+            {fieldError(create.error, 'label') && <p className="mt-1 text-sm text-destructive">{fieldError(create.error, 'label')}</p>}
+          </div>
+          <Button className="sm:mt-6" disabled={create.isPending} type="submit">{create.isPending ? 'Creating…' : 'Create year'}</Button>
+        </form>
+        {create.isError && !fieldError(create.error, 'label') && <Problem error={create.error} fallback="Unable to create the school year." />}
+      </section>
+
+      {isLoading && <p className="mt-8 text-sm text-muted-foreground" role="status">Loading school years…</p>}
+      {isError && <Problem error={error} fallback="Unable to load school years." />}
+      {!isLoading && !isError && years?.length === 0 && <p className="mt-8 rounded-lg border bg-card p-6 text-sm text-muted-foreground">No school years yet.</p>}
+      {!isLoading && !isError && years && years.length > 0 && (
+        <Table className="mt-8" aria-label="School years">
+          <TableHeader><TableRow><TableHead>Year</TableHead><TableHead>State</TableHead><TableHead>Updated</TableHead><TableHead><span className="sr-only">Open</span></TableHead></TableRow></TableHeader>
+          <TableBody>{years.map((year) => (
+            <TableRow key={year.id}>
+              <TableCell className="font-medium">{year.label}</TableCell>
+              <TableCell><StateBadge state={year.state} /></TableCell>
+              <TableCell className="text-muted-foreground">{formatDate(year.updated_at)}</TableCell>
+              <TableCell className="text-right"><Button asChild size="sm" variant="outline"><Link to={`/y/${year.id}`}>Open</Link></Button></TableCell>
+            </TableRow>
+          ))}</TableBody>
+        </Table>
+      )}
+    </PageFrame>
+  )
+}
+
+export function SchoolYearPage() {
+  const { schoolYearId } = useParams<{ schoolYearId: string }>()
+  const result = useSchoolYear(schoolYearId)
+  const account = useAccountRole()
+
+  if (result.isLoading) return <PageFrame><p className="text-sm text-muted-foreground" role="status">Loading school year…</p></PageFrame>
+  if (result.error instanceof ApiError && result.error.status === 404) return <SchoolYearNotFound />
+  if (result.isError || !result.data) return <PageFrame><Problem error={result.error} fallback="Unable to load school year." /></PageFrame>
+
+  return <SchoolYearEditor year={result.data} isOwner={account.role === 'owner'} />
+}
+
+function SchoolYearEditor({ year, isOwner }: { year: SchoolYear; isOwner: boolean }) {
+  const update = useUpdateSchoolYear(year.id)
+  const navigate = useNavigate()
+  const [label, setLabel] = useState(year.label)
+  const [reason, setReason] = useState('')
+  const [reopenMode, setReopenMode] = useState(false)
+  const readOnly = year.state === 'closed'
+
+  function transition(state: SchoolYearState) {
+    update.mutate({ state, ...(state === 'active' && year.state === 'closed' ? { reason } : {}) })
+  }
+
+  return (
+    <PageFrame>
+      <Link className="text-sm font-medium text-muted-foreground hover:text-foreground" to="/years">← Back to school years</Link>
+      <div className="mt-6 flex flex-wrap items-start justify-between gap-4">
+        <div><p className="text-sm font-medium text-primary">School-year workspace</p><h1 className="mt-2 text-3xl font-semibold tracking-tight">{year.label}</h1></div>
+        <StateBadge state={year.state} />
+      </div>
+
+      {readOnly && <section className="mt-8 rounded-lg border border-amber-200 bg-amber-50 p-5 text-sm text-amber-950"><h2 className="font-semibold">Read-only history</h2><p className="mt-1">This year is closed. Its records can be viewed but not edited.</p></section>}
+
+      <section className="mt-6 rounded-lg border bg-card p-5 shadow-sm" aria-labelledby="school-year-details-heading">
+        <h2 id="school-year-details-heading" className="font-semibold">Year details</h2>
+        <form className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end" onSubmit={(event) => { event.preventDefault(); update.mutate({ label }) }}>
+          <div className="flex-1"><label className="text-sm font-medium" htmlFor="school-year-edit-label">Display label</label><Input id="school-year-edit-label" className="mt-1" disabled={readOnly} value={label} onChange={(event) => setLabel(event.target.value)} />{fieldError(update.error, 'label') && <p className="mt-1 text-sm text-destructive">{fieldError(update.error, 'label')}</p>}</div>
+          <Button disabled={readOnly || update.isPending} type="submit">{update.isPending ? 'Saving…' : 'Save label'}</Button>
+        </form>
+        {!readOnly && <div className="mt-6 flex flex-wrap gap-3">
+          {year.state === 'setup' && <Button disabled={update.isPending} onClick={() => transition('active')}>Activate year</Button>}
+          {year.state === 'active' && <Button disabled={update.isPending} variant="outline" onClick={() => transition('closed')}>Close year</Button>}
+        </div>}
+        {readOnly && isOwner && !reopenMode && <Button className="mt-6" disabled={update.isPending} onClick={() => setReopenMode(true)}>Reopen year</Button>}
+        {reopenMode && <form className="mt-6 rounded-md border bg-muted/30 p-4" onSubmit={(event) => { event.preventDefault(); transition('active') }}><label className="text-sm font-medium" htmlFor="reopen-reason">Reason for reopening</label><Input id="reopen-reason" className="mt-1" value={reason} onChange={(event) => setReason(event.target.value)} /><p className="mt-1 text-xs text-muted-foreground">The reason is recorded in the audit log.</p><div className="mt-3 flex gap-2"><Button disabled={update.isPending} type="submit">{update.isPending ? 'Reopening…' : 'Confirm reopen'}</Button><Button type="button" variant="outline" onClick={() => setReopenMode(false)}>Cancel</Button></div></form>}
+        {update.isError && <Problem error={update.error} fallback="Unable to update the school year." />}
+      </section>
+      <p className="mt-4 text-sm text-muted-foreground">Created {formatDate(year.created_at)} · Updated {formatDate(year.updated_at)}</p>
+      <Button className="mt-6" variant="outline" onClick={() => navigate('/settings')}>Organisation settings</Button>
+    </PageFrame>
+  )
+}
+
+function useAccountRole() {
+  const result = useQuery({ queryKey: ['account'], queryFn: resourceApi.getAccount })
+  return { role: normalizeRole(result.data?.role) }
+}
+
+function normalizeRole(role?: string) { return role?.toLowerCase() ?? '' }
+
+function SchoolYearNotFound() {
+  return <PageFrame><p className="text-sm font-medium text-primary">Not found</p><h1 className="mt-2 text-3xl font-semibold tracking-tight">School year not found</h1><p className="mt-3 max-w-xl text-sm text-muted-foreground">That school year does not exist in your organisation, or you do not have access to it.</p><Button className="mt-6" asChild><Link to="/years">Back to school years</Link></Button></PageFrame>
+}
+
+function formatDate(value: string) {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(date)
+}

--- a/frontend/src/features/schoolyear/useSchoolYears.ts
+++ b/frontend/src/features/schoolyear/useSchoolYears.ts
@@ -1,0 +1,36 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { resourceApi, type SchoolYear } from '@/lib/apiResources'
+
+export const schoolYearsKey = ['school-years'] as const
+
+export function useSchoolYears() {
+  return useQuery({ queryKey: schoolYearsKey, queryFn: resourceApi.listSchoolYears })
+}
+
+export function useCreateSchoolYear() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (label: string) => resourceApi.createSchoolYear(label),
+    onSuccess: async () => queryClient.invalidateQueries({ queryKey: schoolYearsKey }),
+  })
+}
+
+export function useSchoolYear(id: string | undefined) {
+  return useQuery({
+    enabled: Boolean(id),
+    queryKey: [...schoolYearsKey, id],
+    queryFn: () => resourceApi.getSchoolYear(id as string),
+  })
+}
+
+export function useUpdateSchoolYear(id: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (update: Parameters<typeof resourceApi.updateSchoolYear>[1]) => resourceApi.updateSchoolYear(id, update),
+    onSuccess: async (year: SchoolYear) => {
+      queryClient.setQueryData([...schoolYearsKey, id], year)
+      await queryClient.invalidateQueries({ queryKey: schoolYearsKey })
+    },
+  })
+}

--- a/frontend/src/features/settings/SettingsPage.test.tsx
+++ b/frontend/src/features/settings/SettingsPage.test.tsx
@@ -1,0 +1,51 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { VocabularyResponse } from '@/lib/apiResources'
+
+import { SettingsPage } from './SettingsPage'
+import { useAdministrators, useVocabulary } from './useSettings'
+
+vi.mock('./useSettings', () => ({
+  useVocabulary: vi.fn(),
+  useAdministrators: vi.fn(),
+  useAdministratorMutation: () => ({ mutate: vi.fn(), isPending: false, isError: false, error: null }),
+  useVocabularyMutation: () => ({ mutate: vi.fn(), isPending: false, isError: false, error: null }),
+}))
+
+vi.mock('@/lib/apiResources', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/apiResources')>()
+  return { ...actual, resourceApi: { ...actual.resourceApi, getAccount: vi.fn() } }
+})
+
+import { resourceApi } from '@/lib/apiResources'
+
+const vocabulary: VocabularyResponse = { organization_id: 'org-test', homeroom_label: 'homeroom', grade_levels: [], homerooms: [] }
+
+function renderSettings() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={queryClient}><SettingsPage /></QueryClientProvider>)
+}
+
+describe('SettingsPage', () => {
+  it('shows administrator management only for an Owner', async () => {
+    vi.mocked(resourceApi.getAccount).mockResolvedValue({ role: 'Owner' })
+    vi.mocked(useVocabulary).mockReturnValue({ data: vocabulary, isLoading: false, isError: false, error: null } as ReturnType<typeof useVocabulary>)
+    vi.mocked(useAdministrators).mockReturnValue({ data: { members: [] }, isLoading: false, isError: false, error: null } as unknown as ReturnType<typeof useAdministrators>)
+
+    renderSettings()
+
+    expect(await screen.findByRole('heading', { name: 'Administrators' })).toBeInTheDocument()
+  })
+
+  it('hides administrator management for an Administrator', async () => {
+    vi.mocked(resourceApi.getAccount).mockResolvedValue({ role: 'Administrator' })
+    vi.mocked(useVocabulary).mockReturnValue({ data: vocabulary, isLoading: false, isError: false, error: null } as ReturnType<typeof useVocabulary>)
+    vi.mocked(useAdministrators).mockReturnValue({ data: { members: [] }, isLoading: false, isError: false, error: null } as unknown as ReturnType<typeof useAdministrators>)
+
+    renderSettings()
+
+    await waitFor(() => expect(screen.queryByRole('heading', { name: 'Administrators' })).not.toBeInTheDocument())
+  })
+})

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -1,0 +1,111 @@
+import { useState, type FormEvent, type ReactNode } from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { ApiError } from '@/lib/api'
+import { resourceApi, type Administrator, type GradeLevel, type Homeroom } from '@/lib/apiResources'
+import { useAdministratorMutation, useAdministrators, useVocabulary, useVocabularyMutation } from './useSettings'
+
+function FieldError({ error, field }: { error: unknown; field: string }) {
+  if (!(error instanceof ApiError)) return null
+  const match = error.fieldErrors.find(({ location }) => location?.endsWith(`.${field}`) || location?.endsWith(field))
+  return match?.message ? <p className="mt-1 text-sm text-destructive">{match.message}</p> : null
+}
+
+function Problem({ error, fallback }: { error: unknown; fallback: string }) {
+  return <p className="mt-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive" role="alert">{error instanceof Error ? error.message : fallback}</p>
+}
+
+function Section({ title, description, children }: { title: string; description: string; children: ReactNode }) {
+  return <section className="rounded-lg border bg-card p-5 shadow-sm"><h2 className="font-semibold">{title}</h2><p className="mt-1 text-sm text-muted-foreground">{description}</p><div className="mt-5">{children}</div></section>
+}
+
+export function SettingsPage() {
+  const account = useQuery({ queryKey: ['account'], queryFn: resourceApi.getAccount })
+  const vocabulary = useVocabulary()
+  const administrators = useAdministrators(account.data?.role?.toLowerCase() === 'owner')
+  const isOwner = account.data?.role?.toLowerCase() === 'owner'
+
+  return (
+    <main className="mx-auto w-full max-w-6xl px-6 py-10">
+      <p className="text-sm font-medium text-primary">Organisation</p>
+      <h1 className="mt-2 text-3xl font-semibold tracking-tight">Settings</h1>
+      <p className="mt-2 max-w-2xl text-sm text-muted-foreground">Manage the vocabulary used by roster records and the people who can administer this organisation.</p>
+      {vocabulary.isLoading && <p className="mt-8 text-sm text-muted-foreground" role="status">Loading settings…</p>}
+      {vocabulary.isError && <Problem error={vocabulary.error} fallback="Unable to load organisation settings." />}
+      {vocabulary.data && <div className="mt-8 grid gap-6 lg:grid-cols-2"><GradeLevelsSection levels={vocabulary.data.grade_levels} /><HomeroomsSection homerooms={vocabulary.data.homerooms} /><HomeroomLabelSection label={vocabulary.data.homeroom_label} /><AdministratorSection enabled={isOwner} administrators={administrators.data?.members ?? []} isLoading={administrators.isLoading} /></div>}
+    </main>
+  )
+}
+
+function GradeLevelsSection({ levels }: { levels: GradeLevel[] }) {
+  const create = useVocabularyMutation((value: { code: string; label: string }) => resourceApi.createGradeLevel(value))
+  const update = useVocabularyMutation((value: { id: string; code?: string; label?: string; retired?: boolean }) => resourceApi.updateGradeLevel(value.id, value))
+  const reorder = useVocabularyMutation((ids: string[]) => resourceApi.reorderGradeLevels(ids))
+  const [code, setCode] = useState('')
+  const [label, setLabel] = useState('')
+  const [editing, setEditing] = useState<string | null>(null)
+  const [editCode, setEditCode] = useState('')
+  const [editLabel, setEditLabel] = useState('')
+  const ordered = [...levels].sort((a, b) => a.ordinal - b.ordinal)
+
+  function add(event: FormEvent) { event.preventDefault(); create.mutate({ code, label }) }
+  function move(index: number, direction: -1 | 1) {
+    const next = [...ordered]; const target = index + direction
+    if (target < 0 || target >= next.length) return
+    const [item] = next.splice(index, 1); next.splice(target, 0, item); reorder.mutate(next.map((level) => level.id))
+  }
+
+  return <Section title="Grade levels" description="Ordered vocabulary for roster records. Retired levels remain visible on existing records.">
+    <form className="grid gap-3 sm:grid-cols-[1fr_2fr_auto]" onSubmit={add}><div><label className="text-sm font-medium" htmlFor="grade-code">Code</label><Input id="grade-code" className="mt-1" value={code} onChange={(event) => setCode(event.target.value)} /><FieldError error={create.error} field="code" /></div><div><label className="text-sm font-medium" htmlFor="grade-label">Label</label><Input id="grade-label" className="mt-1" value={label} onChange={(event) => setLabel(event.target.value)} /><FieldError error={create.error} field="label" /></div><Button className="sm:mt-6" disabled={create.isPending} type="submit">Add</Button></form>
+    {create.isError && <Problem error={create.error} fallback="Unable to add grade level." />}
+    <Table className="mt-6" aria-label="Grade levels"><TableHeader><TableRow><TableHead>Code</TableHead><TableHead>Label</TableHead><TableHead>State</TableHead><TableHead><span className="sr-only">Actions</span></TableHead></TableRow></TableHeader><TableBody>{ordered.map((level, index) => <TableRow key={level.id}>
+      {editing === level.id ? <TableCell colSpan={2}><div className="flex gap-2"><Input aria-label="Edit grade code" value={editCode} onChange={(event) => setEditCode(event.target.value)} /><Input aria-label="Edit grade label" value={editLabel} onChange={(event) => setEditLabel(event.target.value)} /></div><FieldError error={update.error} field="label" /></TableCell> : <><TableCell className="font-medium">{level.code}</TableCell><TableCell>{level.label}</TableCell></>}
+      <TableCell>{level.retired_at ? <span className="text-muted-foreground">Retired</span> : 'Active'}</TableCell><TableCell><div className="flex justify-end gap-1">{editing === level.id ? <><Button size="sm" onClick={() => { update.mutate({ id: level.id, code: editCode, label: editLabel }); setEditing(null) }}>Save</Button><Button size="sm" variant="outline" onClick={() => setEditing(null)}>Cancel</Button></> : <Button size="sm" variant="outline" onClick={() => { setEditing(level.id); setEditCode(level.code); setEditLabel(level.label) }}>Edit</Button>}<Button size="sm" variant="outline" disabled={index === 0 || reorder.isPending} onClick={() => move(index, -1)} aria-label={`Move ${level.label} up`}>↑</Button><Button size="sm" variant="outline" disabled={index === ordered.length - 1 || reorder.isPending} onClick={() => move(index, 1)} aria-label={`Move ${level.label} down`}>↓</Button><Button size="sm" variant="outline" onClick={() => update.mutate({ id: level.id, retired: !level.retired_at })}>{level.retired_at ? 'Restore' : 'Retire'}</Button></div></TableCell>
+    </TableRow>)}</TableBody></Table>
+    {update.isError && <Problem error={update.error} fallback="Unable to update grade level." />}
+  </Section>
+}
+
+function HomeroomsSection({ homerooms }: { homerooms: Homeroom[] }) {
+  const create = useVocabularyMutation((name: string) => resourceApi.createHomeroom(name))
+  const update = useVocabularyMutation((value: { id: string; name?: string; retired?: boolean }) => resourceApi.updateHomeroom(value.id, value))
+  const [name, setName] = useState('')
+  const [editing, setEditing] = useState<string | null>(null)
+  const [editName, setEditName] = useState('')
+  return <Section title="Homerooms" description="Organisation-scoped homerooms. Retire and replace a name when historical vocabulary should remain available.">
+    <form className="flex gap-3" onSubmit={(event) => { event.preventDefault(); create.mutate(name) }}><div className="flex-1"><label className="text-sm font-medium" htmlFor="homeroom-name">Name</label><Input id="homeroom-name" className="mt-1" value={name} onChange={(event) => setName(event.target.value)} /><FieldError error={create.error} field="name" /></div><Button className="mt-6" disabled={create.isPending} type="submit">Add</Button></form>
+    {create.isError && <Problem error={create.error} fallback="Unable to add homeroom." />}
+    <Table className="mt-6" aria-label="Homerooms"><TableHeader><TableRow><TableHead>Name</TableHead><TableHead>State</TableHead><TableHead><span className="sr-only">Actions</span></TableHead></TableRow></TableHeader><TableBody>{homerooms.map((room) => <TableRow key={room.id}><TableCell>{editing === room.id ? <Input aria-label="Edit homeroom name" value={editName} onChange={(event) => setEditName(event.target.value)} /> : room.name}</TableCell><TableCell>{room.retired_at ? <span className="text-muted-foreground">Retired</span> : 'Active'}</TableCell><TableCell><div className="flex justify-end gap-1">{editing === room.id ? <><Button size="sm" onClick={() => { update.mutate({ id: room.id, name: editName }); setEditing(null) }}>Save</Button><Button size="sm" variant="outline" onClick={() => setEditing(null)}>Cancel</Button></> : <Button size="sm" variant="outline" onClick={() => { setEditing(room.id); setEditName(room.name) }}>Edit</Button>}<Button size="sm" variant="outline" onClick={() => update.mutate({ id: room.id, retired: !room.retired_at })}>{room.retired_at ? 'Restore' : 'Retire'}</Button></div></TableCell></TableRow>)}</TableBody></Table>
+    {update.isError && <Problem error={update.error} fallback="Unable to update homeroom." />}
+  </Section>
+}
+
+function HomeroomLabelSection({ label }: { label: string }) {
+  const update = useVocabularyMutation((value: string) => resourceApi.updateHomeroomLabel(value))
+  const [value, setValue] = useState(label)
+  return <Section title="Homeroom label" description="Choose the term organisers see for this vocabulary: homeroom, class, form, or advisory.">
+    <form className="flex gap-3" onSubmit={(event) => { event.preventDefault(); update.mutate(value) }}><div className="flex-1"><label className="text-sm font-medium" htmlFor="homeroom-label">Label</label><Input id="homeroom-label" className="mt-1" value={value} onChange={(event) => setValue(event.target.value)} /><FieldError error={update.error} field="homeroom_label" /></div><Button className="mt-6" disabled={update.isPending} type="submit">Save</Button></form>
+    {update.isError && <Problem error={update.error} fallback="Unable to update homeroom label." />}
+  </Section>
+}
+
+function AdministratorSection({ enabled, administrators, isLoading }: { enabled: boolean; administrators: Administrator[]; isLoading: boolean }) {
+  const invite = useAdministratorMutation((value: { email: string; role: string }) => resourceApi.inviteAdministrator(value))
+  const action = useAdministratorMutation((value: { id: string; operation: 'resend' | 'revoke' | 'remove' | 'role'; role?: string }) => value.operation === 'resend' ? resourceApi.resendInvitation(value.id) : value.operation === 'revoke' ? resourceApi.revokeInvitation(value.id) : value.operation === 'remove' ? resourceApi.removeAdministrator(value.id) : resourceApi.changeAdministratorRole(value.id, value.role ?? 'administrator'))
+  const [email, setEmail] = useState('')
+  const [role, setRole] = useState('administrator')
+  if (!enabled) return null
+  return <Section title="Administrators" description="Only Owners can manage access to this organisation.">
+    <form className="grid gap-3 sm:grid-cols-[2fr_1fr_auto]" onSubmit={(event) => { event.preventDefault(); invite.mutate({ email, role }) }}><div><label className="text-sm font-medium" htmlFor="administrator-email">Email</label><Input id="administrator-email" className="mt-1" value={email} onChange={(event) => setEmail(event.target.value)} /><FieldError error={invite.error} field="email" /></div><div><label className="text-sm font-medium" htmlFor="administrator-role">Role</label><select id="administrator-role" className="mt-1 flex h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm" value={role} onChange={(event) => setRole(event.target.value)}><option value="administrator">Administrator</option><option value="coordinator">Coordinator</option></select></div><Button className="sm:mt-6" disabled={invite.isPending} type="submit">Invite</Button></form>
+    {invite.isError && <Problem error={invite.error} fallback="Unable to invite administrator." />}
+    {isLoading ? <p className="mt-5 text-sm text-muted-foreground" role="status">Loading administrators…</p> : <Table className="mt-6" aria-label="Administrators"><TableHeader><TableRow><TableHead>Email</TableHead><TableHead>Role</TableHead><TableHead>Status</TableHead><TableHead><span className="sr-only">Actions</span></TableHead></TableRow></TableHeader><TableBody>{administrators.map((member) => <AdministratorRow action={action} key={member.id} member={member} />)}</TableBody></Table>}
+    {action.isError && <Problem error={action.error} fallback="Unable to update administrator." />}
+  </Section>
+}
+
+function AdministratorRow({ member, action }: { member: Administrator; action: ReturnType<typeof useAdministratorMutation<{ id: string; operation: 'resend' | 'revoke' | 'remove' | 'role'; role?: string }>> }) {
+  return <TableRow><TableCell>{member.email}</TableCell><TableCell><select aria-label={`Role for ${member.email}`} className="rounded-md border bg-transparent px-2 py-1 text-sm" value={member.role} onChange={(event) => action.mutate({ id: member.id, operation: 'role', role: event.target.value })}><option value="owner">Owner</option><option value="administrator">Administrator</option><option value="coordinator">Coordinator</option></select></TableCell><TableCell>{member.pending_invitation ? 'Invitation pending' : 'Active'}</TableCell><TableCell><div className="flex justify-end gap-1">{member.pending_invitation && <><Button size="sm" variant="outline" onClick={() => action.mutate({ id: member.id, operation: 'resend' })}>Resend</Button><Button size="sm" variant="outline" onClick={() => action.mutate({ id: member.id, operation: 'revoke' })}>Revoke</Button></>}<Button size="sm" variant="outline" onClick={() => action.mutate({ id: member.id, operation: 'remove' })}>Remove</Button></div></TableCell></TableRow>
+}

--- a/frontend/src/features/settings/useSettings.ts
+++ b/frontend/src/features/settings/useSettings.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { resourceApi } from '@/lib/apiResources'
+
+export const vocabularyKey = ['vocabulary'] as const
+export const administratorsKey = ['administrators'] as const
+
+export function useVocabulary() {
+  return useQuery({ queryKey: vocabularyKey, queryFn: () => resourceApi.getVocabulary(true) })
+}
+
+function useInvalidateVocabulary() {
+  const queryClient = useQueryClient()
+  return () => queryClient.invalidateQueries({ queryKey: vocabularyKey })
+}
+
+export function useVocabularyMutation<T>(mutationFn: (value: T) => Promise<unknown>) {
+  const invalidate = useInvalidateVocabulary()
+  return useMutation({ mutationFn, onSuccess: invalidate })
+}
+
+export function useAdministrators(enabled: boolean) {
+  return useQuery({ enabled, queryKey: administratorsKey, queryFn: resourceApi.listAdministrators })
+}
+
+export function useAdministratorMutation<T>(mutationFn: (value: T) => Promise<unknown>) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn,
+    onSuccess: async () => queryClient.invalidateQueries({ queryKey: administratorsKey }),
+  })
+}

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -44,3 +44,25 @@ describe('ApiClient authentication', () => {
     await expect(client.claimInvitation('invitation-token')).resolves.toMatchObject({ role: 'Owner' })
   })
 })
+import { describe, expect, it, vi } from 'vitest'
+
+import { ApiClient, ApiError } from './api'
+
+describe('ApiClient resource errors', () => {
+  it('turns RFC 9457 field errors into an ApiError for inline rendering', async () => {
+    const fetcher = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      type: 'validation-error',
+      title: 'Invalid request',
+      detail: 'The request contains invalid fields.',
+      errors: [{ location: 'body.label', message: 'Label is required.' }],
+    }), { status: 422, headers: { 'Content-Type': 'application/problem+json' } }))
+    const client = new ApiClient({ baseUrl: 'http://api.test', fetch: fetcher })
+
+    await expect(client.requestJson('/api/school-years', { method: 'POST', body: JSON.stringify({ label: '' }) })).rejects.toMatchObject({
+      code: 'validation-error',
+      status: 422,
+      fieldErrors: [{ location: 'body.label', message: 'Label is required.' }],
+    } satisfies Partial<ApiError>)
+    expect(fetcher).toHaveBeenCalledWith('http://api.test/api/school-years', expect.objectContaining({ method: 'POST' }))
+  })
+})

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { ApiClient } from './api'
+import { ApiClient, ApiError } from './api'
 
 describe('ApiClient authentication', () => {
   it('adds the current Supabase access token to Go requests', async () => {
@@ -44,9 +44,6 @@ describe('ApiClient authentication', () => {
     await expect(client.claimInvitation('invitation-token')).resolves.toMatchObject({ role: 'Owner' })
   })
 })
-import { describe, expect, it, vi } from 'vitest'
-
-import { ApiClient, ApiError } from './api'
 
 describe('ApiClient resource errors', () => {
   it('turns RFC 9457 field errors into an ApiError for inline rendering', async () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,17 +17,25 @@ export type SchoolYear = {
 
 export type ApiErrorKind = 'http' | 'network'
 
+export type ApiFieldError = {
+  location?: string
+  message?: string
+  value?: unknown
+}
+
 export class ApiError extends Error {
   readonly kind: ApiErrorKind
   readonly status?: number
   readonly code?: string
+  readonly fieldErrors: ApiFieldError[]
 
-  constructor(kind: ApiErrorKind, message: string, status?: number, code?: string) {
+  constructor(kind: ApiErrorKind, message: string, status?: number, code?: string, fieldErrors: ApiFieldError[] = []) {
     super(message)
     this.name = 'ApiError'
     this.kind = kind
     this.status = status
     this.code = code
+    this.fieldErrors = fieldErrors
   }
 }
 
@@ -156,6 +164,42 @@ export class ApiClient {
     const message = error?.detail ?? error?.title ?? `The API request failed with status ${response.status}`
     return new ApiError('http', message, response.status, error?.type)
   }
+
+  async requestJson<T>(path: string, init: RequestInit = {}): Promise<T> {
+    let response: Response
+    try {
+      const headers = new Headers(init.headers)
+      if (init.body !== undefined && !headers.has('Content-Type')) {
+        headers.set('Content-Type', 'application/json')
+      }
+      response = await this.fetcher(`${this.baseUrl}${path}`, { ...init, headers })
+    } catch {
+      throw new ApiError('network', 'Unable to reach the API')
+    }
+
+    let payload: unknown
+    try {
+      payload = response.status === 204 ? undefined : await response.json()
+    } catch {
+      if (!response.ok) {
+        throw new ApiError('http', `The API request failed with status ${response.status}`, response.status)
+      }
+      throw new ApiError('http', 'The API returned an invalid response.', response.status)
+    }
+
+    if (!response.ok) {
+      const problem = isProblem(payload) ? payload : undefined
+      throw new ApiError(
+        'http',
+        problem?.detail ?? problem?.title ?? `The API request failed with status ${response.status}`,
+        response.status,
+        problem?.type,
+        problem?.errors ?? [],
+      )
+    }
+
+    return payload as T
+  }
 }
 
 export const apiClient = new ApiClient()
@@ -190,4 +234,15 @@ function isSchoolYear(value: unknown): value is SchoolYear {
     typeof candidate.created_at === 'string' &&
     typeof candidate.updated_at === 'string'
   )
+}
+
+type ProblemPayload = {
+  type?: string
+  title?: string
+  detail?: string
+  errors?: ApiFieldError[] | null
+}
+
+function isProblem(value: unknown): value is ProblemPayload {
+  return Boolean(value && typeof value === 'object')
 }

--- a/frontend/src/lib/apiResources.test.ts
+++ b/frontend/src/lib/apiResources.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { activeGradeLevels, activeHomerooms, type VocabularyResponse } from './apiResources'
+
+const vocabulary: VocabularyResponse = {
+  organization_id: 'org-test',
+  homeroom_label: 'homeroom',
+  grade_levels: [
+    { id: 'g2', organization_id: 'org-test', code: '2', label: 'Second grade', ordinal: 2, created_at: '', updated_at: '' },
+    { id: 'g1', organization_id: 'org-test', code: '1', label: 'First grade', ordinal: 1, created_at: '', updated_at: '' },
+    { id: 'g0', organization_id: 'org-test', code: 'K', label: 'Kindergarten', ordinal: 0, retired_at: '2026-01-01', created_at: '', updated_at: '' },
+  ],
+  homerooms: [
+    { id: 'h1', organization_id: 'org-test', name: 'Blue', created_at: '', updated_at: '' },
+    { id: 'h2', organization_id: 'org-test', name: 'Green', retired_at: '2026-01-01', created_at: '', updated_at: '' },
+  ],
+}
+
+describe('vocabulary picker helpers', () => {
+  it('excludes retired entries and orders grades by their server ordinal', () => {
+    expect(activeGradeLevels(vocabulary).map((grade) => grade.id)).toEqual(['g1', 'g2'])
+    expect(activeHomerooms(vocabulary).map((homeroom) => homeroom.id)).toEqual(['h1'])
+  })
+})

--- a/frontend/src/lib/apiResources.ts
+++ b/frontend/src/lib/apiResources.ts
@@ -1,0 +1,122 @@
+import { apiClient } from './api'
+
+export type SchoolYearState = 'setup' | 'active' | 'closed'
+
+export type SchoolYear = {
+  id: string
+  organization_id: string
+  label: string
+  state: SchoolYearState
+  created_at: string
+  updated_at: string
+}
+
+export type GradeLevel = {
+  id: string
+  organization_id: string
+  code: string
+  label: string
+  ordinal: number
+  retired_at?: string
+  created_at: string
+  updated_at: string
+}
+
+export type Homeroom = {
+  id: string
+  organization_id: string
+  name: string
+  retired_at?: string
+  created_at: string
+  updated_at: string
+}
+
+export type VocabularyResponse = {
+  organization_id: string
+  homeroom_label: string
+  grade_levels: GradeLevel[]
+  homerooms: Homeroom[]
+}
+
+export type Administrator = {
+  id: string
+  email: string
+  role: string
+  pending_invitation: boolean
+  invitation_expires_at?: string
+}
+
+export type AdministratorInvitation = {
+  member: Administrator
+  claim_url: string
+  expires_at: string
+  generation: number
+}
+
+export type Account = {
+  role: string
+  principal?: { id: string; email: string }
+  organization?: { id: string; name: string }
+}
+
+function body<T>(value: T): RequestInit {
+  return { body: JSON.stringify(value), method: 'POST' }
+}
+
+export const resourceApi = {
+  listSchoolYears: () => apiClient.requestJson<SchoolYear[]>('/api/school-years'),
+  createSchoolYear: (label: string) => apiClient.requestJson<SchoolYear>('/api/school-years', body({ label })),
+  updateSchoolYear: (id: string, update: { label?: string; state?: SchoolYearState; reason?: string }) =>
+    apiClient.requestJson<SchoolYear>(`/api/school-years/${encodeURIComponent(id)}`, {
+      body: JSON.stringify(update),
+      method: 'PATCH',
+    }),
+  getSchoolYear: (id: string) => apiClient.requestJson<SchoolYear>(`/api/school-years/${encodeURIComponent(id)}`),
+
+  getVocabulary: (includeRetired = true) =>
+    apiClient.requestJson<VocabularyResponse>(`/api/vocabularies?include_retired=${includeRetired}`),
+  createGradeLevel: (value: { code: string; label: string }) =>
+    apiClient.requestJson<GradeLevel>('/api/grade-levels', body(value)),
+  updateGradeLevel: (id: string, value: { code?: string; label?: string; retired?: boolean }) =>
+    apiClient.requestJson<GradeLevel>(`/api/grade-levels/${encodeURIComponent(id)}`, {
+      body: JSON.stringify(value),
+      method: 'PATCH',
+    }),
+  reorderGradeLevels: (ids: string[]) =>
+    apiClient.requestJson<GradeLevel[]>('/api/grade-levels/reorder', body({ ids })),
+  createHomeroom: (name: string) => apiClient.requestJson<Homeroom>('/api/homerooms', body({ name })),
+  updateHomeroom: (id: string, value: { name?: string; retired?: boolean }) =>
+    apiClient.requestJson<Homeroom>(`/api/homerooms/${encodeURIComponent(id)}`, {
+      body: JSON.stringify(value),
+      method: 'PATCH',
+    }),
+  updateHomeroomLabel: (homeroom_label: string) =>
+    apiClient.requestJson<{ organization_id: string; homeroom_label: string }>('/api/vocabularies/settings', {
+      body: JSON.stringify({ homeroom_label }),
+      method: 'PATCH',
+    }),
+
+  getAccount: () => apiClient.requestJson<Account>('/api/me'),
+  listAdministrators: () => apiClient.requestJson<{ members: Administrator[] }>('/api/administrators'),
+  inviteAdministrator: (value: { email: string; role?: string }) =>
+    apiClient.requestJson<AdministratorInvitation>('/api/administrators', body(value)),
+  resendInvitation: (id: string) =>
+    apiClient.requestJson<AdministratorInvitation>(`/api/administrators/${encodeURIComponent(id)}/invitation/resend`, { method: 'POST' }),
+  revokeInvitation: (id: string) =>
+    apiClient.requestJson<void>(`/api/administrators/${encodeURIComponent(id)}/invitation/revoke`, { method: 'POST' }),
+  changeAdministratorRole: (id: string, role: string) =>
+    apiClient.requestJson<Administrator>(`/api/administrators/${encodeURIComponent(id)}`, {
+      body: JSON.stringify({ role }),
+      method: 'PATCH',
+    }),
+  removeAdministrator: (id: string) =>
+    apiClient.requestJson<void>(`/api/administrators/${encodeURIComponent(id)}`, { method: 'DELETE' }),
+}
+
+export function activeGradeLevels(vocabulary: VocabularyResponse): GradeLevel[] {
+  return vocabulary.grade_levels.filter((grade) => !grade.retired_at).sort((a, b) => a.ordinal - b.ordinal)
+}
+
+export function activeHomerooms(vocabulary: VocabularyResponse): Homeroom[] {
+  return vocabulary.homerooms.filter((homeroom) => !homeroom.retired_at)
+}

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -11,7 +11,7 @@ const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 export let supabase: SupabaseClient | null = null
 
 if (supabaseUrl && supabaseAnonKey) {
-  ;(async () => {
+  void (async () => {
     const mod = await import('@supabase/supabase-js')
     supabase = mod.createClient(supabaseUrl, supabaseAnonKey, {
       auth: {

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,18 +1,27 @@
-import { createClient, type AuthChangeEvent, type AuthError, type Session, type SupabaseClient } from '@supabase/supabase-js'
+import type { AuthChangeEvent, AuthError, Session, SupabaseClient } from '@supabase/supabase-js'
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
-export const supabase: SupabaseClient | null =
-  supabaseUrl && supabaseAnonKey
-    ? createClient(supabaseUrl, supabaseAnonKey, {
-        auth: {
-          autoRefreshToken: true,
-          detectSessionInUrl: true,
-          persistSession: true,
-        },
-      })
-    : null
+// Export a runtime-initialized client. We avoid a static import of the
+// Supabase runtime to prevent test tooling (vitest/vite) from attempting to
+// resolve the module at transform time when it's not needed (for example in
+// unit tests that mock auth). The actual client is created asynchronously if
+// the required env vars are present.
+export let supabase: SupabaseClient | null = null
+
+if (supabaseUrl && supabaseAnonKey) {
+  ;(async () => {
+    const mod = await import('@supabase/supabase-js')
+    supabase = mod.createClient(supabaseUrl, supabaseAnonKey, {
+      auth: {
+        autoRefreshToken: true,
+        detectSessionInUrl: true,
+        persistSession: true,
+      },
+    })
+  })()
+}
 
 export type AuthClient = Pick<SupabaseClient, 'auth'>
 export type { AuthChangeEvent, AuthError, Session }


### PR DESCRIPTION
Fixes #61

Implements SPEC §§11.1, 10.1, and 6.6.

Summary:
- Adds the school-year landing page and route-scoped detail view with creation, lifecycle transitions, owner-only reasoned reopen, closed-year read-only state, and clear RFC 9457 errors.
- Adds settings for grade levels, homerooms, the organisation homeroom label, and Owner-only administrator management.
- Excludes retired vocabulary entries from picker helpers while preserving them for existing-record rendering.
- Uses semantic tables and server-returned field errors without zod, client-side validation schemas, or a table library.

Validation:
- `cd frontend && bun install --frozen-lockfile && bun run test -- --run` — passed (14 tests).
- `cd frontend && bun run build` — passed.
- `cd frontend && bun run lint` — passed.
- `cd backend && make test` — passed; PostgreSQL integration tests skipped because test database URLs are unavailable locally.
- `cd backend && make lint` — passed.
- `cd backend && make format` — passed.
- Generated backend artifacts unchanged after generation; local sqlc binary reports v1.31.1 while the repository pins v1.27.0, so only version-header drift was observed and restored to the committed pinned output.
- `git diff --check` — passed.
- `cd backend && ./scripts/migration-round-trip.sh` — attempted; `POSTGRES_ADMIN_DATABASE_URL` is not set in this worker.
