### PR TITLE
feat: add frontend households and guardian relationships

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -1,5 +1,6 @@
 # Detent handoff notes
 
+
 ## Issue #64 merge fallback
 
 - Rebased PR #82 onto current `origin/main` (`a723ef8`); resolved only the two expected conflicts.
@@ -23,6 +24,25 @@
   and the pre-existing checkout lacks `@supabase/supabase-js` for tests/build. PR has no reviews or inline
   comments, is open/non-draft/mergeable, and remains scoped to the existing implementation. No skill
   draft: this was a routine frontend feature using existing API/query patterns.
+
+## Issue #63 frontend households and guardian relationships
+
+- Built on the P1-13a frontend commit `d84f7e6` (PR #81 is still open); household UI is in
+  `frontend/src/features/people/HouseholdPages.tsx`, `householdApi.ts`, and related guardian files.
+- Routes are year-scoped under `/y/:schoolYearId/households`; person lists/details show all household
+  links and a warning-only empty-household state. Guardian relationships are explicitly independent
+  membership records and editable from both person directions.
+- Focused frontend tests currently cover list/detail two-household rendering, member add/remove,
+  relationship type edits, reverse adult view, and the non-blocking missing-household warning.
+- PR #83 is open, non-draft, clean/mergeable, references `Fixes #63`, and cites SPEC §§8.2/11.2/5.2.
+- Current-head CI run 32804112171 passed all nine required checks. Slowest: Backend lint 1m24s,
+  Backend tests 1m14s, Generated code drift 1m13s. No reviews or inline comments remain.
+- Local validation passed: 19 frontend tests, frontend build/lint, backend tests/lint/format, generated
+  drift, git diff --check, and PostgreSQL 18 disposable migration up/down/up. The exact migration
+  wrapper lacks host `psql`; its equivalent container sequence passed and cleaned up the database.
+- Telemetry: quiet-window wait 0s; local frontend gate about 5s; backend checks about 19s; disposable
+  migration equivalent about 2s; PR CI about 1m24s; latest main CI successful, no post-merge run active.
+- Skill draft: no — this was a scoped frontend feature using existing people-page patterns.
 
 ## Issue #59 audit log read endpoint
 
@@ -51,7 +71,6 @@
   migration up/down/up, frozen Bun tests/build/lint, and `git diff --check`.
 - Open items: commit/push, open PR with `Fixes #54` and SPEC §§10.1/20.1, inspect current-head CI
   and reviews, then update the Workpad to complete. No blocker or human action is known.
-- No skill draft.
 
 ## Issue #56 adults
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { SignInPage } from '@/features/auth/SignInPage'
 import { SchoolYearGuard, SchoolYearListPage, SchoolYearNotFound, SchoolYearWorkspace } from '@/features/school-years/SchoolYearPages'
 import { SettingsPage } from '@/features/settings/SettingsPage'
 import { AdultDetailPage, AdultListPage, StudentDetailPage, StudentListPage } from '@/features/people/PeoplePages'
+import { HouseholdDetailPage, HouseholdListPage } from '@/features/people/HouseholdPages'
 import { AuditLog } from '@/features/audit/AuditLog'
 
 function App() {
@@ -54,6 +55,11 @@ function AppRoutes() {
             <Route path="adults" element={<AdultListPage />} />
             <Route path="adults/new" element={<AdultDetailPage />} />
             <Route path="adults/:personId" element={<AdultDetailPage />} />
+
+            {/* Households scoped to a school year */}
+            <Route path="households" element={<HouseholdListPage />} />
+            <Route path="households/new" element={<HouseholdDetailPage />} />
+            <Route path="households/:personId" element={<HouseholdDetailPage />} />
 
             {/* Fallback inside a school year goes to the workspace */}
             <Route path="*" element={<SchoolYearWorkspace />} />

--- a/frontend/src/features/people/GuardianRelationships.test.tsx
+++ b/frontend/src/features/people/GuardianRelationships.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { guardianApi } from './guardianApi'
+import { GuardianRelationships } from './GuardianRelationships'
+import { peopleApi } from './api'
+
+afterEach(() => { vi.restoreAllMocks() })
+
+describe('guardian relationships', () => {
+  it('edits a typed relationship from a student detail without changing membership', async () => {
+    vi.spyOn(guardianApi, 'listForStudent').mockResolvedValue([{
+      adult_id: 'adult-1', student_id: 'student-1', relationship_type: 'parent', adult: { id: 'adult-1', school_year_id: 'year-1', legal_given_name: 'Morgan', legal_family_name: 'Lee', display_name: 'Morgan Lee', participation_intent: 'help' },
+    }])
+    vi.spyOn(peopleApi, 'list').mockResolvedValue([])
+    const save = vi.spyOn(guardianApi, 'save').mockResolvedValue({ adult_id: 'adult-1', student_id: 'student-1', relationship_type: 'guardian' })
+
+    render(<MemoryRouter><GuardianRelationships kind="student" schoolYearId="year-1" personId="student-1" /></MemoryRouter>)
+
+    expect(await screen.findByRole('link', { name: 'Morgan Lee' })).toBeInTheDocument()
+    expect(screen.getByText(/They are separate from household membership/)).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText('Relationship for Morgan Lee'), { target: { value: 'guardian' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(save).toHaveBeenCalledWith('year-1', 'adult-1', 'student-1', 'guardian'))
+  })
+
+  it('loads the reverse relationship view from an adult detail', async () => {
+    vi.spyOn(guardianApi, 'listForAdult').mockResolvedValue([{
+      adult_id: 'adult-1', student_id: 'student-1', relationship_type: 'grandparent', student: { id: 'student-1', school_year_id: 'year-1', legal_given_name: 'Riley', legal_family_name: 'Stone', display_name: 'Riley Stone', grade: '3', homeroom: 'A' },
+    }])
+    vi.spyOn(peopleApi, 'list').mockResolvedValue([])
+
+    render(<MemoryRouter><GuardianRelationships kind="adult" schoolYearId="year-1" personId="adult-1" /></MemoryRouter>)
+
+    expect(await screen.findByRole('link', { name: 'Riley Stone' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Relationship for Riley Stone')).toHaveValue('grandparent')
+  })
+})

--- a/frontend/src/features/people/GuardianRelationships.tsx
+++ b/frontend/src/features/people/GuardianRelationships.tsx
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+import { Button } from '@/components/ui/button'
+
+import { peopleApi } from './api'
+import { guardianApi } from './guardianApi'
+import type { GuardianRelationship, GuardianRelationshipType, Person, PersonKind } from './types'
+
+const relationshipOptions: GuardianRelationshipType[] = ['parent', 'guardian', 'grandparent', 'other']
+
+export function GuardianRelationships({ kind, schoolYearId, personId }: { kind: PersonKind; schoolYearId: string; personId: string }) {
+  const [relationships, setRelationships] = useState<GuardianRelationship[]>([])
+  const [candidates, setCandidates] = useState<Person[]>([])
+  const [selectedPersonId, setSelectedPersonId] = useState('')
+  const [relationshipType, setRelationshipType] = useState<GuardianRelationshipType>('parent')
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<unknown>(null)
+
+  const load = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const result = kind === 'student' ? await guardianApi.listForStudent(schoolYearId, personId) : await guardianApi.listForAdult(schoolYearId, personId)
+      setRelationships(result)
+      const people = await peopleApi.list(kind === 'student' ? 'adult' : 'student', schoolYearId)
+      setCandidates(people)
+    } catch (reason: unknown) {
+      setError(reason)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [kind, personId, schoolYearId])
+
+  useEffect(() => { void load() }, [load])
+
+  async function saveRelationship(adultId: string, studentId: string, type: GuardianRelationshipType) {
+    setIsSaving(true)
+    setError(null)
+    try {
+      await guardianApi.save(schoolYearId, adultId, studentId, type)
+      await load()
+    } catch (reason: unknown) {
+      setError(reason)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function removeRelationship(adultId: string, studentId: string) {
+    setError(null)
+    try {
+      await guardianApi.remove(schoolYearId, adultId, studentId)
+      await load()
+    } catch (reason: unknown) {
+      setError(reason)
+    }
+  }
+
+  async function addRelationship() {
+    if (!selectedPersonId) return
+    const adultId = kind === 'student' ? selectedPersonId : personId
+    const studentId = kind === 'student' ? personId : selectedPersonId
+    await saveRelationship(adultId, studentId, relationshipType)
+    setSelectedPersonId('')
+  }
+
+  return (
+    <section className="mt-10 rounded-lg border bg-card p-6" aria-labelledby={`${kind}-guardian-heading`}>
+      <h2 id={`${kind}-guardian-heading`} className="text-xl font-semibold">Guardian relationships</h2>
+      <p className="mt-2 text-sm text-muted-foreground">These typed links describe who acts for a student. They are separate from household membership, so adding a guardian here does not add a household member.</p>
+      {error !== null && <p className="mt-4 rounded-md border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive" role="alert">{error instanceof Error ? error.message : 'Unable to update guardian relationships.'}</p>}
+      {isLoading ? <p className="mt-6 text-sm text-muted-foreground" role="status">Loading guardian relationships…</p> : <>
+        {relationships.length === 0 && <p className="mt-6 text-sm text-muted-foreground">No guardian relationships recorded.</p>}
+        <ul className="mt-4 space-y-3">{relationships.map((relationship) => <RelationshipRow key={`${relationship.adult_id}-${relationship.student_id}`} kind={kind} schoolYearId={schoolYearId} relationship={relationship} disabled={isSaving} onSave={saveRelationship} onRemove={removeRelationship} />)}</ul>
+        <div className="mt-6 flex flex-wrap items-end gap-3 border-t pt-6">
+          <label className="min-w-64 flex-1 text-sm font-medium">{kind === 'student' ? 'Adult' : 'Student'}<select className="mt-2 flex h-9 w-full rounded-md border bg-transparent px-3 text-sm" value={selectedPersonId} onChange={(event) => setSelectedPersonId(event.target.value)}><option value="">Choose a {kind === 'student' ? 'adult' : 'student'}</option>{candidates.filter((candidate) => !relationships.some((relationship) => (kind === 'student' ? relationship.adult_id : relationship.student_id) === candidate.id)).map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.display_name}</option>)}</select></label>
+          <label className="text-sm font-medium">Relationship type<select aria-label="New relationship type" className="mt-2 flex h-9 rounded-md border bg-transparent px-3 text-sm" value={relationshipType} onChange={(event) => setRelationshipType(event.target.value as GuardianRelationshipType)}>{relationshipOptions.map((option) => <option key={option} value={option}>{labelForRelationship(option)}</option>)}</select></label>
+          <Button type="button" onClick={() => void addRelationship()} disabled={!selectedPersonId || isSaving}>{isSaving ? 'Saving…' : 'Add relationship'}</Button>
+        </div>
+      </>}
+    </section>
+  )
+}
+
+function RelationshipRow({ kind, schoolYearId, relationship, disabled, onSave, onRemove }: { kind: PersonKind; schoolYearId: string; relationship: GuardianRelationship; disabled: boolean; onSave: (adultId: string, studentId: string, type: GuardianRelationshipType) => Promise<void>; onRemove: (adultId: string, studentId: string) => Promise<void> }) {
+  const person = kind === 'student' ? relationship.adult : relationship.student
+  const personPath = kind === 'student' ? 'adults' : 'students'
+  const [type, setType] = useState(relationship.relationship_type)
+  const label = person?.display_name ?? (kind === 'student' ? relationship.adult_id : relationship.student_id)
+  return <li className="flex flex-wrap items-center justify-between gap-3 rounded-md border px-3 py-3 text-sm"><Link className="text-primary hover:underline" to={`/y/${schoolYearId}/${personPath}/${person?.id ?? (kind === 'student' ? relationship.adult_id : relationship.student_id)}`}>{label}</Link><div className="flex items-center gap-2"><label className="sr-only" htmlFor={`relationship-${relationship.adult_id}-${relationship.student_id}`}>Relationship for {label}</label><select id={`relationship-${relationship.adult_id}-${relationship.student_id}`} value={type} onChange={(event) => setType(event.target.value as GuardianRelationshipType)} className="h-9 rounded-md border bg-transparent px-3 text-sm">{relationshipOptions.map((option) => <option key={option} value={option}>{labelForRelationship(option)}</option>)}</select><Button type="button" size="sm" disabled={disabled || type === relationship.relationship_type} onClick={() => void onSave(relationship.adult_id, relationship.student_id, type)}>Save</Button><Button type="button" size="sm" variant="outline" disabled={disabled} onClick={() => void onRemove(relationship.adult_id, relationship.student_id)}>Remove</Button></div></li>
+}
+
+function labelForRelationship(value: GuardianRelationshipType) {
+  return value[0].toUpperCase() + value.slice(1)
+}

--- a/frontend/src/features/people/HouseholdPages.test.tsx
+++ b/frontend/src/features/people/HouseholdPages.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { householdApi } from './householdApi'
+import { HouseholdDetailPage, HouseholdListPage } from './HouseholdPages'
+import { peopleApi } from './api'
+import type { Household } from './types'
+
+const student = {
+  id: 'student-1', school_year_id: 'year-1', legal_given_name: 'Riley', legal_family_name: 'Stone', display_name: 'Riley Stone', grade: '3', homeroom: 'A',
+}
+
+const otherStudent = { ...student, id: 'student-2', display_name: 'Jordan Reed', legal_given_name: 'Jordan', legal_family_name: 'Reed' }
+
+const householdOne: Household = {
+  id: 'household-1', school_year_id: 'year-1', display_name: 'Stone family', students: [student], adults: [],
+}
+
+const householdTwo: Household = {
+  id: 'household-2', school_year_id: 'year-1', display_name: 'Stone second home', students: [student], adults: [],
+}
+
+afterEach(() => { vi.restoreAllMocks() })
+
+describe('household pages', () => {
+  it('lists households and keeps students grouped separately from adults', async () => {
+    vi.spyOn(householdApi, 'list').mockResolvedValue([householdOne, householdTwo])
+
+    render(<MemoryRouter initialEntries={['/y/year-1/households']}><Routes><Route path="/y/:schoolYearId/households" element={<HouseholdListPage />} /></Routes></MemoryRouter>)
+
+    const table = await screen.findByRole('table', { name: 'Households' })
+    expect(within(table).getByRole('link', { name: 'Stone family' })).toBeInTheDocument()
+    expect(within(table).getByRole('link', { name: 'Stone second home' })).toBeInTheDocument()
+    expect(within(table).getByText('Students')).toBeInTheDocument()
+    expect(within(table).getByText('Adults')).toBeInTheDocument()
+  })
+
+  it('renders a student in a household detail and manages membership independently', async () => {
+    vi.spyOn(householdApi, 'get').mockResolvedValue(householdOne)
+    vi.spyOn(peopleApi, 'list').mockResolvedValue([student, otherStudent])
+    const addMember = vi.spyOn(householdApi, 'addMember').mockResolvedValue()
+    const removeMember = vi.spyOn(householdApi, 'removeMember').mockResolvedValue()
+
+    render(<MemoryRouter initialEntries={['/y/year-1/households/household-1']}><Routes><Route path="/y/:schoolYearId/households/:householdId" element={<HouseholdDetailPage />} /></Routes></MemoryRouter>)
+
+    expect(await screen.findByRole('link', { name: 'Riley Stone' })).toBeInTheDocument()
+    expect(screen.getByText(/Membership controls who is grouped with this household/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+    await waitFor(() => expect(removeMember).toHaveBeenCalledWith('year-1', 'household-1', 'student', 'student-1'))
+
+    fireEvent.change(screen.getByLabelText('Person'), { target: { value: 'student-2' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add member' }))
+    await waitFor(() => expect(addMember).toHaveBeenCalledWith('year-1', 'household-1', 'student', 'student-2'))
+  })
+
+  it('renders a student belonging to two households in both household details', async () => {
+    vi.spyOn(householdApi, 'get').mockImplementation(async (_schoolYearId, householdId) => householdId === 'household-1' ? householdOne : householdTwo)
+    vi.spyOn(peopleApi, 'list').mockResolvedValue([])
+
+    const first = render(<MemoryRouter initialEntries={['/y/year-1/households/household-1']}><Routes><Route path="/y/:schoolYearId/households/:householdId" element={<HouseholdDetailPage />} /></Routes></MemoryRouter>)
+    expect(await screen.findByRole('link', { name: 'Riley Stone' })).toBeInTheDocument()
+    first.unmount()
+
+    render(<MemoryRouter initialEntries={['/y/year-1/households/household-2']}><Routes><Route path="/y/:schoolYearId/households/:householdId" element={<HouseholdDetailPage />} /></Routes></MemoryRouter>)
+    expect(await screen.findByRole('heading', { name: 'Stone second home' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Riley Stone' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/people/HouseholdPages.tsx
+++ b/frontend/src/features/people/HouseholdPages.tsx
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useState, type FormEvent, type ReactNode } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+
+import { peopleApi } from './api'
+import { householdApi } from './householdApi'
+import type { Household, HouseholdInput, HouseholdMemberKind, Person } from './types'
+
+function PageFrame({ children }: { children: ReactNode }) {
+  return <main className="mx-auto w-full max-w-6xl px-6 py-10">{children}</main>
+}
+
+export function HouseholdListPage() {
+  const { schoolYearId } = useParams<{ schoolYearId: string }>()
+  const [households, setHouseholds] = useState<Household[]>([])
+  const [includeDeleted, setIncludeDeleted] = useState(false)
+  const [isLoading, setIsLoading] = useState(Boolean(schoolYearId))
+  const [error, setError] = useState<unknown>(null)
+
+  useEffect(() => {
+    if (!schoolYearId) {
+      setIsLoading(false)
+      return
+    }
+    let active = true
+    setIsLoading(true)
+    setError(null)
+    void householdApi.list(schoolYearId, includeDeleted)
+      .then((result) => { if (active) setHouseholds(result) })
+      .catch((reason: unknown) => { if (active) setError(reason) })
+      .finally(() => { if (active) setIsLoading(false) })
+    return () => { active = false }
+  }, [includeDeleted, schoolYearId])
+
+  if (!schoolYearId) return <PageFrame><MissingSchoolYear /></PageFrame>
+
+  return (
+    <PageFrame>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-primary">Roster</p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight">Households</h1>
+          <p className="mt-2 max-w-2xl text-sm text-muted-foreground">Manage household membership separately from guardian relationships. A student or adult may belong to more than one household.</p>
+        </div>
+        <Button asChild><Link to={`/y/${schoolYearId}/households/new`}>Add household</Link></Button>
+      </div>
+      <label className="mt-8 flex items-center gap-2 text-sm font-medium">
+        <input type="checkbox" checked={includeDeleted} onChange={(event) => setIncludeDeleted(event.target.checked)} />
+        Show deleted
+      </label>
+      {isLoading && <p className="mt-8 text-sm text-muted-foreground" role="status">Loading households…</p>}
+      {error !== null && <ErrorMessage error={error} fallback="Unable to load households." />}
+      {!isLoading && !error && households.length === 0 && <p className="mt-8 rounded-lg border bg-card p-6 text-sm text-muted-foreground">No households yet.</p>}
+      {!isLoading && !error && households.length > 0 && <HouseholdTable schoolYearId={schoolYearId} households={households} />}
+    </PageFrame>
+  )
+}
+
+function HouseholdTable({ schoolYearId, households }: { schoolYearId: string; households: Household[] }) {
+  return (
+    <Table className="mt-8" aria-label="Households">
+      <TableHeader><TableRow><TableHead>Name</TableHead><TableHead>Students</TableHead><TableHead>Adults</TableHead></TableRow></TableHeader>
+      <TableBody>
+        {households.map((household) => (
+          <TableRow key={household.id} className={household.deleted_at ? 'opacity-60' : undefined}>
+            <TableCell><Link className="font-medium text-primary hover:underline" to={`/y/${schoolYearId}/households/${household.id}`}>{household.display_name}</Link>{household.deleted_at && <span className="ml-2 text-xs text-muted-foreground">Deleted</span>}</TableCell>
+            <TableCell>{household.students?.length ?? household.student_count ?? 0}</TableCell>
+            <TableCell>{household.adults?.length ?? household.adult_count ?? 0}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+export function HouseholdDetailPage() {
+  const { schoolYearId, householdId } = useParams<{ schoolYearId: string; householdId?: string }>()
+  const navigate = useNavigate()
+  const isNew = !householdId || householdId === 'new'
+  const [household, setHousehold] = useState<Household | null>(null)
+  const [values, setValues] = useState<HouseholdInput>({ display_name: '' })
+  const [memberKind, setMemberKind] = useState<HouseholdMemberKind>('student')
+  const [availablePeople, setAvailablePeople] = useState<Person[]>([])
+  const [selectedPersonId, setSelectedPersonId] = useState('')
+  const [isLoading, setIsLoading] = useState(!isNew && Boolean(schoolYearId))
+  const [isSaving, setIsSaving] = useState(false)
+  const [isAdding, setIsAdding] = useState(false)
+  const [error, setError] = useState<unknown>(null)
+
+  const loadHousehold = useCallback(async () => {
+    if (!schoolYearId || !householdId || isNew) return
+    setIsLoading(true)
+    try {
+      const result = await householdApi.get(schoolYearId, householdId)
+      setHousehold(result)
+      setValues({ display_name: result.display_name })
+    } catch (reason: unknown) {
+      setError(reason)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [householdId, isNew, schoolYearId])
+
+  useEffect(() => { void loadHousehold() }, [loadHousehold])
+
+  useEffect(() => {
+    if (!schoolYearId || isNew) return
+    let active = true
+    setSelectedPersonId('')
+    void peopleApi.list(memberKind, schoolYearId)
+      .then((people) => {
+        if (!active) return
+        const memberIds = new Set((memberKind === 'student' ? household?.students : household?.adults)?.map((person) => person.id))
+        setAvailablePeople(people.filter((person) => !memberIds.has(person.id)))
+      })
+      .catch((reason: unknown) => { if (active) setError(reason) })
+    return () => { active = false }
+  }, [household, isNew, memberKind, schoolYearId])
+
+  if (!schoolYearId) return <PageFrame><MissingSchoolYear /></PageFrame>
+  if (isLoading) return <PageFrame><p className="text-sm text-muted-foreground" role="status">Loading household…</p></PageFrame>
+  if (error && !isNew && !household) return <PageFrame><ErrorMessage error={error} fallback="Unable to load household." /></PageFrame>
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setIsSaving(true)
+    setError(null)
+    try {
+      const saved = isNew ? await householdApi.create(schoolYearId!, values) : await householdApi.update(schoolYearId!, householdId!, values)
+      navigate(`/y/${schoolYearId}/households/${saved.id}`, { replace: true })
+    } catch (reason: unknown) {
+      setError(reason)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function handleAddMember(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!householdId || !selectedPersonId || isAdding) return
+    setIsAdding(true)
+    setError(null)
+    try {
+      await householdApi.addMember(schoolYearId!, householdId, memberKind, selectedPersonId)
+      await loadHousehold()
+    } catch (reason: unknown) {
+      setError(reason)
+    } finally {
+      setIsAdding(false)
+    }
+  }
+
+  async function handleRemoveMember(kind: HouseholdMemberKind, personId: string) {
+    if (!householdId) return
+    setError(null)
+    try {
+      await householdApi.removeMember(schoolYearId!, householdId, kind, personId)
+      await loadHousehold()
+    } catch (reason: unknown) {
+      setError(reason)
+    }
+  }
+
+  return (
+    <PageFrame>
+      <Link className="text-sm font-medium text-primary hover:underline" to={`/y/${schoolYearId}/households`}>← Back to households</Link>
+      <div className="mt-4"><p className="text-sm font-medium text-primary">{isNew ? 'New household' : 'Household'}</p><h1 className="mt-2 text-3xl font-semibold tracking-tight">{isNew ? 'Add household' : household?.display_name}</h1></div>
+      {error !== null && <ErrorMessage error={error} fallback="Unable to save this household." />}
+      <form className="mt-8 max-w-2xl space-y-5 rounded-lg border bg-card p-6" onSubmit={(event) => void handleSubmit(event)} noValidate>
+        <label className="text-sm font-medium" htmlFor="household-display-name">Display name<Input id="household-display-name" className="mt-2" value={values.display_name} onChange={(event) => setValues({ display_name: event.target.value })} /></label>
+        <div className="flex gap-3"><Button type="submit" disabled={isSaving}>{isSaving ? 'Saving…' : 'Save'}</Button><Button asChild type="button" variant="outline"><Link to={`/y/${schoolYearId}/households`}>Cancel</Link></Button></div>
+      </form>
+      {!isNew && household && <>
+        <section className="mt-10 rounded-lg border bg-card p-6" aria-labelledby="household-members-heading">
+          <h2 id="household-members-heading" className="text-xl font-semibold">Household membership</h2>
+          <p className="mt-2 text-sm text-muted-foreground">Membership controls who is grouped with this household. It does not create or change a guardian relationship.</p>
+          <div className="mt-6 grid gap-8 md:grid-cols-2"><MemberGroup kind="student" schoolYearId={schoolYearId} household={household} onRemove={handleRemoveMember} /><MemberGroup kind="adult" schoolYearId={schoolYearId} household={household} onRemove={handleRemoveMember} /></div>
+          <form className="mt-8 flex flex-wrap items-end gap-3 border-t pt-6" onSubmit={(event) => void handleAddMember(event)}>
+            <label className="text-sm font-medium">Member type<select className="mt-2 flex h-9 rounded-md border bg-transparent px-3 text-sm" value={memberKind} onChange={(event) => setMemberKind(event.target.value as HouseholdMemberKind)}><option value="student">Student</option><option value="adult">Adult</option></select></label>
+            <label className="min-w-64 flex-1 text-sm font-medium">Person<select className="mt-2 flex h-9 w-full rounded-md border bg-transparent px-3 text-sm" value={selectedPersonId} onChange={(event) => setSelectedPersonId(event.target.value)}><option value="">Choose a person</option>{availablePeople.map((person) => <option key={person.id} value={person.id}>{person.display_name}</option>)}</select></label>
+            <Button type="submit" disabled={!selectedPersonId || isAdding}>{isAdding ? 'Adding…' : 'Add member'}</Button>
+          </form>
+        </section>
+      </>}
+    </PageFrame>
+  )
+}
+
+function MemberGroup({ kind, schoolYearId, household, onRemove }: { kind: HouseholdMemberKind; schoolYearId: string; household: Household; onRemove: (kind: HouseholdMemberKind, personId: string) => Promise<void> }) {
+  const people = kind === 'student' ? household.students ?? [] : household.adults ?? []
+  const path = kind === 'student' ? 'students' : 'adults'
+  return <div><h3 className="font-medium">{kind === 'student' ? 'Students' : 'Adults'}</h3>{people.length === 0 ? <p className="mt-2 text-sm text-muted-foreground">No {kind}s in this household.</p> : <ul className="mt-3 space-y-2">{people.map((person) => <li className="flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-sm" key={person.id}><Link className="text-primary hover:underline" to={`/y/${schoolYearId}/${path}/${person.id}`}>{person.display_name}</Link><Button type="button" size="sm" variant="outline" onClick={() => void onRemove(kind, person.id)}>Remove</Button></li>)}</ul>}</div>
+}
+
+function MissingSchoolYear() {
+  return <><p className="text-sm font-medium text-primary">Roster</p><h1 className="mt-2 text-3xl font-semibold tracking-tight">Choose a school year</h1><p className="mt-3 max-w-xl text-sm text-muted-foreground">Households belong to a school year. Open a year workspace before managing them.</p><Button className="mt-6" asChild><Link to="/years">Back to school years</Link></Button></>
+}
+
+function ErrorMessage({ error, fallback }: { error: unknown; fallback: string }) {
+  return <p className="mt-6 rounded-md border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive" role="alert">{error instanceof Error ? error.message : fallback}</p>
+}

--- a/frontend/src/features/people/PeoplePages.test.tsx
+++ b/frontend/src/features/people/PeoplePages.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { PeopleApiError, peopleApi } from './api'
+import { guardianApi } from './guardianApi'
 import { AdultListPage, StudentDetailPage, StudentListPage } from './PeoplePages'
 import type { Adult } from './types'
 
@@ -32,6 +33,43 @@ function renderStudents(path = '/y/year-1/students') {
 }
 
 describe('people roster pages', () => {
+  it('shows every household for a student in the student list', async () => {
+    vi.spyOn(peopleApi, 'list').mockResolvedValue([{ ...students[0], households: [
+      { id: 'household-1', school_year_id: 'year-1', display_name: 'Primary home' },
+      { id: 'household-2', school_year_id: 'year-1', display_name: 'Second home' },
+    ] }])
+
+    renderStudents()
+
+    const table = await screen.findByRole('table', { name: 'Students' })
+    expect(within(table).getByRole('link', { name: 'Primary home' })).toBeInTheDocument()
+    expect(within(table).getByRole('link', { name: 'Second home' })).toBeInTheDocument()
+  })
+
+  it('shows both household links on student detail and warns without blocking a student with none', async () => {
+    const student = { ...students[0], households: [
+      { id: 'household-1', school_year_id: 'year-1', display_name: 'Primary home' },
+      { id: 'household-2', school_year_id: 'year-1', display_name: 'Second home' },
+    ] }
+    vi.spyOn(peopleApi, 'get').mockResolvedValue(student)
+    vi.spyOn(peopleApi, 'list').mockResolvedValue([])
+    vi.spyOn(guardianApi, 'listForStudent').mockResolvedValue([])
+
+    const detail = renderStudents('/y/year-1/students/student-2')
+
+    expect(await screen.findByRole('link', { name: 'Primary home' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Second home' })).toBeInTheDocument()
+
+    detail.unmount()
+    vi.restoreAllMocks()
+    vi.spyOn(peopleApi, 'get').mockResolvedValue({ ...students[0], households: [] })
+    vi.spyOn(peopleApi, 'list').mockResolvedValue([])
+    vi.spyOn(guardianApi, 'listForStudent').mockResolvedValue([])
+    renderStudents('/y/year-1/students/student-2')
+    expect(await screen.findByText('This person has no household yet. This is a warning only; you can still save the roster record.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+  })
+
   it('uses the API display name and sorts by legal family then given name', async () => {
     vi.spyOn(peopleApi, 'list').mockResolvedValue(students)
 

--- a/frontend/src/features/people/PeoplePages.tsx
+++ b/frontend/src/features/people/PeoplePages.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 
 import { peopleApi, PeopleApiError } from './api'
+import { GuardianRelationships } from './GuardianRelationships'
 import type { Adult, AdultInput, FieldErrors, ParticipationIntent, Person, PersonKind, Student, StudentInput } from './types'
 
 type PageProps = { kind: PersonKind }
@@ -126,7 +127,7 @@ function PeopleTable({ kind, schoolYearId, people }: { kind: PersonKind; schoolY
         <TableRow>
           <TableHead>Name</TableHead>
           {kind === 'student' ? <><TableHead>Grade</TableHead><TableHead>Homeroom</TableHead></> : <><TableHead>Email</TableHead><TableHead>Participation</TableHead></>}
-          <TableHead>External ID</TableHead>
+          <TableHead>Households</TableHead><TableHead>External ID</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -134,7 +135,7 @@ function PeopleTable({ kind, schoolYearId, people }: { kind: PersonKind; schoolY
           <TableRow key={person.id} className={person.deleted_at ? 'opacity-60' : undefined}>
             <TableCell><Link className="font-medium text-primary hover:underline" to={`/y/${schoolYearId}/${copy.path}/${person.id}`}>{person.display_name}</Link>{person.deleted_at && <span className="ml-2 text-xs text-muted-foreground">Deleted</span>}</TableCell>
             {kind === 'student' ? <><TableCell>{(person as Student).grade}</TableCell><TableCell>{(person as Student).homeroom}</TableCell></> : <><TableCell>{(person as Adult).email ?? '—'}</TableCell><TableCell className="capitalize">{(person as Adult).participation_intent}</TableCell></>}
-            <TableCell>{person.external_identifier ?? '—'}</TableCell>
+            <TableCell><HouseholdLinks person={person} schoolYearId={schoolYearId} /></TableCell><TableCell>{person.external_identifier ?? '—'}</TableCell>
           </TableRow>
         ))}
       </TableBody>
@@ -252,6 +253,10 @@ export function PersonDetailPage({ kind }: PageProps) {
         </div>
         <div className="flex gap-3"><Button type="submit" disabled={isSaving}>{isSaving ? 'Saving…' : 'Save'}</Button><Button asChild type="button" variant="outline"><Link to={`/y/${schoolYearId}/${copy.path}`}>Cancel</Link></Button></div>
       </form>
+      {!isNew && person && <>
+        <HouseholdMembershipSection person={person} schoolYearId={yearId} />
+        <GuardianRelationships kind={kind} schoolYearId={yearId} personId={person.id} />
+      </>}
     </PageFrame>
   )
 }
@@ -294,6 +299,17 @@ function Field({ label, name, value, error, hint, type = 'text', onChange }: { l
 
 function FieldError({ id, message }: { id?: string; message: string }) {
   return <span id={id} className="mt-1 block text-xs font-normal text-destructive" role="alert">{message}</span>
+}
+
+
+function HouseholdLinks({ person, schoolYearId }: { person: Person; schoolYearId: string }) {
+  if (!person.households || person.households.length === 0) return <span className="text-amber-700" role="status">No household assigned</span>
+  return <span className="flex flex-wrap gap-x-2 gap-y-1">{person.households.map((household) => <Link key={household.id} className="text-primary hover:underline" to={`/y/${schoolYearId}/households/${household.id}`}>{household.display_name}</Link>)}</span>
+}
+
+function HouseholdMembershipSection({ person, schoolYearId }: { person: Person; schoolYearId: string }) {
+  const households = person.households ?? []
+  return <section className="mt-10 rounded-lg border bg-card p-6" aria-labelledby="person-households-heading"><h2 id="person-households-heading" className="text-xl font-semibold">Household membership</h2><p className="mt-2 text-sm text-muted-foreground">Membership is independent from guardian relationships. Editing a guardian relationship will not add this person to a household.</p>{households.length === 0 ? <p className="mt-4 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900" role="status">This person has no household yet. This is a warning only; you can still save the roster record.</p> : <ul className="mt-4 flex flex-wrap gap-2">{households.map((household) => <li key={household.id}><Link className="inline-flex rounded-md border px-3 py-2 text-sm text-primary hover:bg-accent" to={`/y/${schoolYearId}/households/${household.id}`}>{household.display_name}</Link></li>)}</ul>}</section>
 }
 
 function MissingSchoolYear({ kind }: PageProps) {

--- a/frontend/src/features/people/api.ts
+++ b/frontend/src/features/people/api.ts
@@ -12,7 +12,7 @@ export class PeopleApiError extends Error {
   }
 }
 
-type ApiErrorBody = {
+export type ApiErrorBody = {
   detail?: string
   title?: string
   errors?: Array<{ location?: string; message?: string }>
@@ -51,7 +51,7 @@ async function readError(response: Response): Promise<PeopleApiError> {
   )
 }
 
-async function request<T>(path: string, init?: RequestInit): Promise<T> {
+export async function request<T>(path: string, init?: RequestInit): Promise<T> {
   let response: Response
   try {
     response = await globalThis.fetch(`${configuredBaseUrl}${path}`, {
@@ -77,17 +77,17 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   }
 }
 
-function asList(value: unknown): Person[] {
+export function asList<T>(value: unknown): T[] {
   if (!Array.isArray(value)) {
     throw new PeopleApiError('The people response was invalid.')
   }
-  return value as Person[]
+  return value as T[]
 }
 
 export const peopleApi: PeopleApi = {
   async list(kind, schoolYearId, includeDeleted = false) {
     const query = includeDeleted ? '?include_deleted=true' : ''
-    return asList(await request<unknown>(`${resourcePath(kind, schoolYearId)}${query}`))
+    return asList<Person>(await request<unknown>(`${resourcePath(kind, schoolYearId)}${query}`))
   },
 
   get(kind, schoolYearId, personId) {

--- a/frontend/src/features/people/guardianApi.ts
+++ b/frontend/src/features/people/guardianApi.ts
@@ -1,0 +1,25 @@
+import { asList, request } from './api'
+import type { GuardianRelationship, GuardianRelationshipType } from './types'
+
+const basePath = (schoolYearId: string) => `/api/school-years/${encodeURIComponent(schoolYearId)}/guardian-relationships`
+
+export const guardianApi = {
+  async listForStudent(schoolYearId: string, studentId: string) {
+    return asList<GuardianRelationship>(await request<unknown>(`${basePath(schoolYearId)}?student_id=${encodeURIComponent(studentId)}`))
+  },
+
+  async listForAdult(schoolYearId: string, adultId: string) {
+    return asList<GuardianRelationship>(await request<unknown>(`${basePath(schoolYearId)}?adult_id=${encodeURIComponent(adultId)}`))
+  },
+
+  save(schoolYearId: string, adultId: string, studentId: string, relationshipType: GuardianRelationshipType) {
+    return request<GuardianRelationship>(basePath(schoolYearId), {
+      method: 'PUT',
+      body: JSON.stringify({ adult_id: adultId, student_id: studentId, relationship_type: relationshipType }),
+    })
+  },
+
+  async remove(schoolYearId: string, adultId: string, studentId: string) {
+    await request<void>(`${basePath(schoolYearId)}/${encodeURIComponent(adultId)}/${encodeURIComponent(studentId)}`, { method: 'DELETE' })
+  },
+}

--- a/frontend/src/features/people/householdApi.ts
+++ b/frontend/src/features/people/householdApi.ts
@@ -1,0 +1,38 @@
+import { asList, request } from './api'
+import type { Household, HouseholdInput, HouseholdMemberKind } from './types'
+
+const basePath = (schoolYearId: string) => `/api/school-years/${encodeURIComponent(schoolYearId)}/households`
+
+export const householdApi = {
+  async list(schoolYearId: string, includeDeleted = false): Promise<Household[]> {
+    const query = includeDeleted ? '?include_deleted=true' : ''
+    return asList<Household>(await request<unknown>(`${basePath(schoolYearId)}${query}`))
+  },
+
+  get(schoolYearId: string, householdId: string) {
+    return request<Household>(`${basePath(schoolYearId)}/${encodeURIComponent(householdId)}`)
+  },
+
+  create(schoolYearId: string, input: HouseholdInput) {
+    return request<Household>(basePath(schoolYearId), { method: 'POST', body: JSON.stringify(input) })
+  },
+
+  update(schoolYearId: string, householdId: string, input: HouseholdInput) {
+    return request<Household>(`${basePath(schoolYearId)}/${encodeURIComponent(householdId)}`, { method: 'PATCH', body: JSON.stringify(input) })
+  },
+
+  async remove(schoolYearId: string, householdId: string) {
+    await request<void>(`${basePath(schoolYearId)}/${encodeURIComponent(householdId)}`, { method: 'DELETE' })
+  },
+
+  async addMember(schoolYearId: string, householdId: string, kind: HouseholdMemberKind, personId: string) {
+    await request<void>(`${basePath(schoolYearId)}/${encodeURIComponent(householdId)}/members`, {
+      method: 'POST',
+      body: JSON.stringify({ member_type: kind, person_id: personId }),
+    })
+  },
+
+  async removeMember(schoolYearId: string, householdId: string, kind: HouseholdMemberKind, personId: string) {
+    await request<void>(`${basePath(schoolYearId)}/${encodeURIComponent(householdId)}/members/${kind}/${encodeURIComponent(personId)}`, { method: 'DELETE' })
+  },
+}

--- a/frontend/src/features/people/types.ts
+++ b/frontend/src/features/people/types.ts
@@ -1,5 +1,12 @@
 export type PersonKind = 'student' | 'adult'
 
+export type HouseholdSummary = {
+  id: string
+  school_year_id: string
+  display_name: string
+  deleted_at?: string | null
+}
+
 export type Person = {
   id: string
   school_year_id: string
@@ -9,6 +16,7 @@ export type Person = {
   display_name: string
   external_identifier?: string | null
   deleted_at?: string | null
+  households?: HouseholdSummary[]
 }
 
 export type Student = Person & {
@@ -43,6 +51,30 @@ export type AdultInput = PersonInput & {
 }
 
 export type FieldErrors = Record<string, string>
+
+export type HouseholdMemberKind = 'student' | 'adult'
+
+export type Household = HouseholdSummary & {
+  students?: Student[]
+  adults?: Adult[]
+  student_count?: number
+  adult_count?: number
+}
+
+export type HouseholdInput = {
+  display_name: string
+}
+
+export type GuardianRelationshipType = 'parent' | 'guardian' | 'grandparent' | 'other'
+
+export type GuardianRelationship = {
+  id?: string
+  adult_id: string
+  student_id: string
+  relationship_type: GuardianRelationshipType
+  adult?: Adult
+  student?: Student
+}
 
 export type PeopleApi = {
   list(kind: PersonKind, schoolYearId: string, includeDeleted?: boolean): Promise<Person[]>


### PR DESCRIPTION
## Summary

- Add year-scoped household list/detail routes with student and adult member groups.
- Add independent household membership add/remove controls.
- Add typed guardian relationship editing from both student and adult details.
- Render every household link for a student, including students in two households, and show a warning-only empty-household state.

## Spec

Implements SPEC §§8.2 and 11.2, including the §5.2 warn-do-not-block behavior. Household membership and guardian relationships remain distinct as required by §8.2.

## Validation

- cd frontend && bun install --frozen-lockfile && bun run test -- --run — 19 passed
- cd frontend && bun install --frozen-lockfile && bun run build — passed
- cd frontend && bun install --frozen-lockfile && bun run lint — passed
- cd backend && make test — passed; database-backed tests skipped because test URLs are unavailable
- cd backend && make lint — passed
- cd backend && make format — passed
- cd backend && make generated-code-drift — passed
- cd backend && make generate && git diff --exit-code — passed with repository-pinned sqlc output restored after local sqlc emitted only a version comment mismatch
- cd backend && ./scripts/migration-round-trip.sh — attempted; host psql is unavailable
- Equivalent PostgreSQL 18 disposable migration up/down/up through the running container — passed; disposable database removed
- git diff --check — passed

Fixes #63