### PR TITLE
90 dx 3 local admin identity and dev token lifetime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,28 @@
 # Top-level development Makefile for miniclass.
 #
-# Deliberately minimal: it exposes setup and points at the two development
+# Deliberately minimal: it exposes the handful of commands that get a checkout
+# to a working, logged-in local stack and points at the two development
 # processes. The full root entry point, including `make check`, is DX-4.
-.PHONY: setup dev
+#
+# See QUICKSTART.md for the ordered path, and
+# docs/adr/0011-local-development-orchestration-and-environment-contract.md for
+# why each step is a script rather than a recipe.
+.PHONY: setup seed login dev reset
 
 setup: ## Prepare the local development environment
 	@./scripts/setup.sh
+
+seed: ## Create the synthetic organisation and bind the local admin identity
+	@$(MAKE) -C backend seed
+
+login: ## Mint or refresh the local development bearer token in .env
+	@./scripts/login.sh
+
+reset: ## Drop and rebuild the local database, then re-seed and re-login (requires CONFIRM=1)
+	@if [ "$(CONFIRM)" != "1" ]; then echo "Refusing to reset the database. Re-run with CONFIRM=1."; exit 1; fi
+	@echo "Stop the API first if it is running: its connection pool outlives the schema this replaces."
+	@$(MAKE) -C backend reset-db RESET_DB_CONFIRM=1
+	@DEV_TOKEN_FORCE=1 ./scripts/login.sh
 
 dev: ## Print how to run the development processes
 	@echo "MiniClass runs as two long-lived processes, one per terminal:"
@@ -13,4 +30,5 @@ dev: ## Print how to run the development processes
 	@echo "  make -C backend dev          API with hot reload"
 	@echo "  cd frontend && bun run dev   app with hot reload"
 	@echo ""
-	@echo "Run 'make setup' first. Verify the stack with ./scripts/smoke-test.sh."
+	@echo "Run 'make setup', 'make seed' and 'make login' first; see QUICKSTART.md."
+	@echo "Verify the stack with ./scripts/smoke-test.sh."

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,111 @@
+# Quickstart
+
+From a fresh clone to a running stack with a logged-in local administrator, in four commands.
+
+For *why* any of this is shaped the way it is, read
+[ADR 0011](./docs/adr/0011-local-development-orchestration-and-environment-contract.md). This file is
+the ordered path; it deliberately explains nothing that the ADR already argues.
+
+## Prerequisites
+
+| Tool | Used for |
+| --- | --- |
+| Docker with Compose, daemon running | PostgreSQL and Adminer |
+| Go 1.26+ | the API, migrations, and the `cmd/*` tools |
+| Bun 1.3+ | the frontend |
+| `openssl`, `awk`, `curl`, `psql`, `make` | the setup, login and reset scripts |
+
+`make setup` checks for most of these and names whatever is missing, so you do not need to audit
+this list by hand.
+
+## The four commands
+
+```sh
+git clone https://github.com/christophergm/miniclass.git
+cd miniclass
+
+make setup   # .env, signing keys, bun install, PostgreSQL, migrations
+make seed    # a synthetic organisation, its roster, and a bound Owner login
+make login   # a 30-day bearer token for that Owner, written into .env
+```
+
+Then run the two long-lived processes, one per terminal:
+
+```sh
+make -C backend dev          # API on http://localhost:8080
+cd frontend && bun run dev   # app on http://localhost:5173
+```
+
+Open <http://localhost:5173>. You are signed in as `owner@example.test` in **Synthetic Academy**,
+with the Owner role and a roster of 139 synthetic students.
+
+Verify the whole stack, including the authenticated route, with:
+
+```sh
+./scripts/smoke-test.sh
+```
+
+## What each command actually does
+
+**`make setup`** copies `.env.example` to `.env` (never overwriting an existing one), generates an
+ES256 keypair into a gitignored `.secrets/`, installs frontend dependencies, starts PostgreSQL, and
+applies migrations. It is idempotent, and it reports keys that `.env.example` has gained since your
+`.env` was copied rather than letting them read as empty.
+
+**`make seed`** creates a fresh organisation with the deterministic synthetic corpus, issues its
+Owner invitation, and immediately claims that invitation for the local provider subject — so a
+usable login exists without anyone clicking a link. It refuses to run twice for the same subject,
+*before* writing anything, because a second organisation would give that subject two memberships and
+break the login it already had.
+
+**`make login`** mints a bearer token for the same subject and writes it into `.env` as
+`VITE_DEV_TOKEN`. It re-mints only when the existing token is missing, unreadable, or expiring
+within 24 hours, and it prints which of those applied. If the API is running it then calls
+`GET /api/me` and tells you whether the token actually resolves to a principal.
+
+### One identity, derived not configured
+
+`.env` defines a single address:
+
+```
+DEV_ADMIN_EMAIL=owner@example.test
+```
+
+Everything else is derived from it — the seed's invited email, the token's `email` claim, and the
+provider subject `local:owner@example.test`. Claiming an invitation compares the invited address
+against the verified token address, so if those were configured separately anywhere they would
+eventually disagree, the claim would be refused, and you would be left with a token that
+authenticates and an account that does not exist. Change the address in `.env` and re-run
+`make reset CONFIRM=1`; do not change it in only one place.
+
+`.test` is a reserved TLD, and the roster is generated, so nothing here can reach a real person.
+Never load real roster data into a local database.
+
+## Resetting
+
+```sh
+make reset CONFIRM=1
+```
+
+Drops and rebuilds the schema, re-applies migrations, re-seeds, and mints a fresh token. This is the
+remedy `make seed` names when it refuses a second run.
+
+## When something is wrong
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| The app shows a red "Local development authentication has no token" banner | `VITE_DEV_TOKEN` is absent or expired | `make login`, then **restart the Vite dev server** |
+| You ran `make login` and the app still shows the banner | `VITE_*` values are inlined when Vite starts | restart `bun run dev` |
+| `403 no-organization` from the API | the token's subject is not bound to a membership | `make seed` |
+| `409 multiple-organizations` | the subject was bound twice | `make reset CONFIRM=1` |
+| `401 invalid-token` | the token is expired, or `.secrets/` was regenerated after it was minted | `./scripts/login.sh --force` |
+| `make seed` refuses immediately | the subject already has a membership | `make reset CONFIRM=1`, or seed an unclaimed invitation with `make -C backend seed SEED_OWNER_SUBJECT=` |
+| `permission denied for table organizations` | the database predates the migrator-owned schema | `make reset CONFIRM=1` |
+| `sh: EC: command not found` from a script | a `.env` value contains whitespace | see the invariant at the top of `.env.example` |
+| `address already in use` | a previous API or Vite process is still running | stop it, or change `PORT` / `VITE_PORT` in `.env` |
+
+`GET /api/health` is unauthenticated by design, so it answers even when your login is broken. If it
+reports `healthy` and `connected`, the problem is identity, not the stack — start at the table above.
+
+Adminer, for looking at the data directly, is at <http://localhost:8081> (server `postgres`, the
+credentials in `.env`); start it with `docker compose up -d adminer`.

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -39,15 +39,24 @@ migrate-create: ## Create a new migration (usage: make migrate-create NAME=creat
 	goose -dir migrations create $(NAME) sql
 
 SEED_ORGANIZATION_NAME ?= Synthetic Academy
-SEED_OWNER_EMAIL ?= owner@example.test
+# The one local identity. .env supplies DEV_ADMIN_EMAIL through the include
+# above; the fallback keeps `make seed` working in a checkout with no .env yet.
+# The subject is derived rather than configured separately, because the invited
+# email and the token's email claim must agree or the claim is refused and the
+# login silently does not exist. Set SEED_OWNER_SUBJECT= (empty) to seed an
+# unclaimed invitation, as a human-claimed flow would.
+DEV_ADMIN_EMAIL ?= owner@example.test
+SEED_OWNER_EMAIL ?= $(DEV_ADMIN_EMAIL)
+SEED_OWNER_SUBJECT ?= local:$(SEED_OWNER_EMAIL)
 SEED_HOMEROOM_LABEL ?= homeroom
 SEED_CLAIM_BASE_URL ?= http://localhost:5173/claim
 
-seed: ## Create a fresh synthetic organization, roster, and Owner invitation
+seed: ## Create a fresh synthetic organization and roster, and bind the Owner login
 	@echo "Creating fresh synthetic seed organization..."
 	go run ./cmd/seed \
 		-organization-name "$(SEED_ORGANIZATION_NAME)" \
 		-owner-email "$(SEED_OWNER_EMAIL)" \
+		-owner-subject "$(SEED_OWNER_SUBJECT)" \
 		-homeroom-label "$(SEED_HOMEROOM_LABEL)" \
 		-claim-base-url "$(SEED_CLAIM_BASE_URL)"
 

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -36,6 +36,7 @@ func run(ctx context.Context, args []string, databaseURL string, output io.Write
 	defaults := seed.DefaultOptions()
 	organizationName := flags.String("organization-name", defaults.OrganizationName, "fresh organization name")
 	ownerEmail := flags.String("owner-email", defaults.OwnerEmail, "Owner invitation email")
+	ownerSubject := flags.String("owner-subject", defaults.OwnerSubject, "verified provider subject to bind to the Owner invitation; empty leaves the invitation to be claimed by hand")
 	homeroomLabel := flags.String("homeroom-label", defaults.HomeroomLabel, "organization homeroom label")
 	claimBaseURL := flags.String("claim-base-url", defaultClaimBaseURL, "absolute invitation claim page URL")
 	invitationTTL := flags.Duration("invitation-ttl", 48*time.Hour, "Owner invitation lifetime")
@@ -48,8 +49,8 @@ func run(ctx context.Context, args []string, databaseURL string, output io.Write
 	}
 	defer database.Close()
 	result, err := seed.Load(ctx, database, seed.Options{
-		OrganizationName: *organizationName, OwnerEmail: *ownerEmail, HomeroomLabel: *homeroomLabel,
-		ClaimBaseURL: *claimBaseURL, InvitationTTL: *invitationTTL,
+		OrganizationName: *organizationName, OwnerEmail: *ownerEmail, OwnerSubject: *ownerSubject,
+		HomeroomLabel: *homeroomLabel, ClaimBaseURL: *claimBaseURL, InvitationTTL: *invitationTTL,
 	})
 	if err != nil {
 		return err
@@ -59,5 +60,11 @@ func run(ctx context.Context, args []string, databaseURL string, output io.Write
 	_, _ = fmt.Fprintf(output, "Roster: %d students, %d adults, %d households\n", result.Students, result.Adults, result.Households)
 	_, _ = fmt.Fprintf(output, "Owner invitation claim URL: %s\n", result.ClaimURL)
 	_, _ = fmt.Fprintf(output, "Expires: %s\n", result.ExpiresAt.UTC().Format(time.RFC3339))
+	if bound := result.BoundOwner; bound != nil {
+		_, _ = fmt.Fprintf(output, "Bound provider subject: %s\n", bound.ProviderSubject)
+		_, _ = fmt.Fprintf(output, "Bound email: %s\n", bound.Email)
+		_, _ = fmt.Fprintf(output, "Bound organization: %s (%s)\n", bound.OrganizationName, bound.OrganizationID)
+		_, _ = fmt.Fprintf(output, "Bound role: %s\n", bound.Role)
+	}
 	return nil
 }

--- a/backend/internal/api/auth_test.go
+++ b/backend/internal/api/auth_test.go
@@ -186,12 +186,18 @@ func TestInvitationClaimAllowsAnUnresolvedVerifiedSubject(t *testing.T) {
 }
 
 func TestEveryRegisteredOperationDeclaresCapabilityMetadata(t *testing.T) {
+	// Exhaustive list of operations that may be reached with no principal.
+	// Every entry is a decision to expose an endpoint to the internet, so this
+	// test fails on a new public operation until someone adds it here.
+	allowedPublicOperations := map[string]bool{"GET /api/health": true}
+
 	document := NewOpenAPI(RouterOptions{})
 	encoded, err := json.Marshal(document)
 	require.NoError(t, err)
 	var raw map[string]any
 	require.NoError(t, json.Unmarshal(encoded, &raw))
 	paths := raw["paths"].(map[string]any)
+	declaredPublic := map[string]bool{}
 	for path, value := range paths {
 		operations := value.(map[string]any)
 		for method, operation := range operations {
@@ -199,10 +205,67 @@ func TestEveryRegisteredOperationDeclaresCapabilityMetadata(t *testing.T) {
 				continue
 			}
 			op := operation.(map[string]any)
-			require.NotEmpty(t, op[auth.RequiredCapabilityExtension], "%s %s has no required capability", method, path)
-			require.NotEmpty(t, op["security"], "%s %s has no bearer security declaration", method, path)
+			capability, _ := op[auth.RequiredCapabilityExtension].(string)
+			require.NotEmpty(t, capability, "%s %s has no required capability", method, path)
+			if capability == string(auth.CapabilityPublic) {
+				declaredPublic[strings.ToUpper(method)+" "+path] = true
+				require.Equal(t, []any{}, op["security"], "%s %s is public but does not state an empty security requirement", method, path)
+				continue
+			}
+			require.Equal(t, []any{map[string]any{"bearerAuth": []any{}}}, op["security"], "%s %s has no bearer security declaration", method, path)
 		}
 	}
+	require.Equal(t, allowedPublicOperations, declaredPublic, "the set of unauthenticated operations changed")
+}
+
+func TestHealthEndpointIsReachableWithoutAPrincipal(t *testing.T) {
+	verifier, resolver, token := testAuth(t)
+
+	t.Run("no authorization header", func(t *testing.T) {
+		router := NewRouter(RouterOptions{Database: routeHealthDatabase{}, Version: "1.2.3", Verifier: verifier, Identity: resolver})
+		recording := httptest.NewRecorder()
+		router.ServeHTTP(recording, httptest.NewRequest(http.MethodGet, "/api/health", nil))
+
+		require.Equal(t, http.StatusOK, recording.Code)
+		var response map[string]string
+		require.NoError(t, json.NewDecoder(recording.Body).Decode(&response))
+		require.Equal(t, "healthy", response["status"])
+		require.Equal(t, "connected", response["database"])
+	})
+
+	t.Run("verified subject with no membership", func(t *testing.T) {
+		router := NewRouter(RouterOptions{Database: routeHealthDatabase{}, Verifier: verifier, Identity: errorResolver{err: auth.ErrNoOrganization}})
+		request := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+		request.Header.Set("Authorization", "Bearer "+token)
+		recording := httptest.NewRecorder()
+		router.ServeHTTP(recording, request)
+
+		require.Equal(t, http.StatusOK, recording.Code)
+	})
+
+	t.Run("unhealthy database without a token still reports the failure", func(t *testing.T) {
+		router := NewRouter(RouterOptions{Database: failingHealthDatabase{}, Verifier: verifier, Identity: resolver})
+		recording := httptest.NewRecorder()
+		router.ServeHTTP(recording, httptest.NewRequest(http.MethodGet, "/api/health", nil))
+
+		require.Equal(t, http.StatusServiceUnavailable, recording.Code)
+		require.Equal(t, "application/problem+json", recording.Header().Get("Content-Type"))
+		var response huma.ErrorModel
+		require.NoError(t, json.NewDecoder(recording.Body).Decode(&response))
+		require.Equal(t, string(problems.DatabaseUnavailable), response.Type)
+	})
+}
+
+func TestPublicHealthDoesNotExemptOtherOperations(t *testing.T) {
+	verifier, resolver, _ := testAuth(t)
+	router := NewRouter(RouterOptions{Verifier: verifier, Identity: resolver})
+	recording := httptest.NewRecorder()
+	router.ServeHTTP(recording, httptest.NewRequest(http.MethodGet, "/api/me", nil))
+
+	require.Equal(t, http.StatusUnauthorized, recording.Code)
+	var response huma.ErrorModel
+	require.NoError(t, json.NewDecoder(recording.Body).Decode(&response))
+	require.Equal(t, string(problems.AuthenticationRequired), response.Type)
 }
 
 func TestAdministratorManagementRejectsAdministratorAndCoordinator(t *testing.T) {

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -125,7 +125,7 @@ func registerOperations(api huma.API, options RouterOptions) {
 		Path:        apiBasePath + "/health",
 		Summary:     "Check API and database health",
 		Errors:      []int{http.StatusServiceUnavailable},
-	}, auth.CapabilityAuthenticated, false, health.Handle)
+	}, auth.CapabilityPublic, false, health.Handle)
 
 	registerOperation(api, huma.Operation{
 		OperationID: "get-me",
@@ -403,7 +403,14 @@ func registerOperation[I, O any](api huma.API, operation huma.Operation, capabil
 		operation.Extensions[auth.AllowUnresolvedPrincipalExtension] = true
 		operation.Metadata[auth.AllowUnresolvedPrincipalExtension] = true
 	}
-	operation.Security = []map[string][]string{{"bearerAuth": {}}}
+	// A public operation states "no security" explicitly rather than leaving
+	// Security nil, which would let it inherit any future document-level
+	// default and quietly advertise a token it will never read.
+	if capability == auth.CapabilityPublic {
+		operation.Security = []map[string][]string{}
+	} else {
+		operation.Security = []map[string][]string{{"bearerAuth": {}}}
+	}
 	huma.Register(api, operation, handler)
 }
 

--- a/backend/internal/auth/capabilities.go
+++ b/backend/internal/auth/capabilities.go
@@ -8,7 +8,7 @@ import (
 
 // Capability is a closed authorization permission. The first eight values
 // are the §6.6 matrix; Authenticated is the non-domain gate used by identity
-// and operational endpoints.
+// and operational endpoints; Public is the absence of a gate, stated out loud.
 type Capability string
 
 const (
@@ -21,6 +21,14 @@ const (
 	CapabilityManagePublishing     Capability = "manage_publishing"
 	CapabilityReadAuditLog         Capability = "read_audit_log"
 	CapabilityAuthenticated        Capability = "authenticated"
+	// CapabilityPublic declares that an operation is deliberately
+	// unauthenticated. It exists so that "no authentication" is something an
+	// operation must say, rather than something it can achieve by saying
+	// nothing: the middleware still rejects an operation with no declared
+	// capability, and the operation-enumeration test still requires every
+	// operation to carry one. It is a property of the operation and never of a
+	// principal, so it is absent from the §6.6 matrix and no role grants it.
+	CapabilityPublic Capability = "public"
 )
 
 // OrganizationRole is the role vocabulary used by the identity schema and
@@ -95,6 +103,12 @@ func MatrixCapabilities() []Capability {
 // HasRoleCapability answers one closed-matrix cell. Unknown roles and
 // capabilities are default-deny.
 func HasRoleCapability(role OrganizationRole, capability Capability) bool {
+	if capability == CapabilityPublic {
+		// Denied for every role on purpose. Public is an operation's declaration
+		// that it needs no principal, so granting it to a principal would turn a
+		// route annotation into an authorization grant.
+		return false
+	}
 	if capability == CapabilityAuthenticated {
 		return role == RoleOwner || role == RoleAdministrator || role == RoleCoordinator
 	}

--- a/backend/internal/auth/capabilities_test.go
+++ b/backend/internal/auth/capabilities_test.go
@@ -1,0 +1,19 @@
+package auth
+
+import "testing"
+
+func TestPublicCapabilityIsNeitherGrantedNorPartOfTheMatrix(t *testing.T) {
+	for _, role := range MatrixRoles() {
+		if HasRoleCapability(role, CapabilityPublic) {
+			t.Fatalf("role %q was granted the public capability", role)
+		}
+	}
+	for _, capability := range MatrixCapabilities() {
+		if capability == CapabilityPublic {
+			t.Fatal("the public capability is part of the §6.6 matrix")
+		}
+	}
+	if HasRoleCapability(OrganizationRole("unknown"), CapabilityPublic) {
+		t.Fatal("an unknown role was granted the public capability")
+	}
+}

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -91,6 +91,17 @@ func Middleware(verifier Verifier, resolver AccountResolver, writeError ErrorWri
 			writeError(ctx, Failure{Status: http.StatusInternalServerError, Code: FailureMissingCapability, Detail: "required capability is not declared"})
 			return
 		}
+		// A public operation has declared that it needs no principal, so there is
+		// nothing to verify or resolve and no reason to require the auth
+		// dependencies to be configured. This branch is reached only after the
+		// declaration check above, so it cannot be entered by omitting the
+		// declaration. Any Authorization header is ignored rather than rejected:
+		// a liveness probe must not start failing because a caller sent a stale
+		// token.
+		if Capability(strings.TrimSpace(capability)) == CapabilityPublic {
+			next(ctx)
+			return
+		}
 
 		if verifier == nil || resolver == nil {
 			writeError(ctx, Failure{Status: http.StatusInternalServerError, Code: FailureAuthUnavailable, Detail: "authentication is not configured"})

--- a/backend/internal/seed/loader.go
+++ b/backend/internal/seed/loader.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/chrismott/miniclass/internal/audit"
+	"github.com/chrismott/miniclass/internal/auth"
 	"github.com/chrismott/miniclass/internal/data"
 	"github.com/chrismott/miniclass/internal/identity"
 	"github.com/chrismott/miniclass/internal/ids"
@@ -21,8 +23,14 @@ type Options struct {
 	OrganizationName string
 	HomeroomLabel    string
 	OwnerEmail       string
-	ClaimBaseURL     string
-	InvitationTTL    time.Duration
+	// OwnerSubject, when set, is the verified provider subject the seed binds
+	// to the Owner invitation it just created, so a non-interactive caller
+	// reaches a usable login without opening ClaimURL. The claim reuses
+	// OwnerEmail from this same value, which is why no separate claim email
+	// exists to disagree with the invited one.
+	OwnerSubject  string
+	ClaimBaseURL  string
+	InvitationTTL time.Duration
 }
 
 // Result is the operator-facing outcome of a successful seed.
@@ -35,6 +43,21 @@ type Result struct {
 	Students         int
 	Adults           int
 	Households       int
+	// BoundOwner is nil unless Options.OwnerSubject was set.
+	BoundOwner *BoundAccount
+}
+
+// BoundAccount describes the login the seed bound to the Owner invitation. It
+// is read back from the claim rather than copied from Options, so what is
+// reported is what a later token exchange will actually resolve to.
+type BoundAccount struct {
+	ProviderSubject  string
+	Email            string
+	UserID           string
+	MembershipID     string
+	OrganizationID   string
+	OrganizationName string
+	Role             string
 }
 
 // DefaultOptions provides a safe, synthetic local-development configuration.
@@ -50,6 +73,8 @@ func DefaultOptions() Options {
 
 // Load creates a new organization, its Owner invitation, and the complete
 // synthetic corpus. It intentionally never reuses an existing organization.
+// With Options.OwnerSubject set it also claims that invitation, so a
+// non-interactive caller ends with a usable login rather than a URL to click.
 func Load(ctx context.Context, database *data.DB, options Options) (Result, error) {
 	if database == nil {
 		return Result{}, errors.New("seed: database is nil")
@@ -70,12 +95,23 @@ func Load(ctx context.Context, database *data.DB, options Options) (Result, erro
 	if options.InvitationTTL == 0 {
 		options.InvitationTTL = defaults.InvitationTTL
 	}
+	options.OwnerSubject = strings.TrimSpace(options.OwnerSubject)
+
+	store := identity.NewStore(database)
+	if options.OwnerSubject != "" {
+		// Refuse before the organization is created: Load commits it on its own,
+		// so a refusal afterwards would leave an orphan organization and a full
+		// roster behind.
+		if err := CheckOwnerSubjectAvailable(ctx, database, options.OwnerSubject); err != nil {
+			return Result{}, err
+		}
+	}
 
 	corpus := Generate()
 	if err := corpus.Validate(); err != nil {
 		return Result{}, fmt.Errorf("seed: validate corpus: %w", err)
 	}
-	bootstrap, err := identity.Bootstrap(ctx, identity.NewStore(database), identity.BootstrapInput{
+	bootstrap, err := identity.Bootstrap(ctx, store, identity.BootstrapInput{
 		OrganizationName: options.OrganizationName,
 		HomeroomLabel:    options.HomeroomLabel,
 		OwnerEmail:       options.OwnerEmail,
@@ -84,6 +120,32 @@ func Load(ctx context.Context, database *data.DB, options Options) (Result, erro
 	})
 	if err != nil {
 		return Result{}, fmt.Errorf("seed: bootstrap organization: %w", err)
+	}
+
+	// Claim before the corpus so a failure to bind does not leave a roster
+	// behind either.
+	var boundOwner *BoundAccount
+	if options.OwnerSubject != "" {
+		// The invited email and the claimed email are the same field of the same
+		// Options value, so the pair cannot disagree; the claim still compares
+		// them exactly as it does for a human. The seed is both inviter and
+		// claimant, so the verified-email precondition holds by construction
+		// rather than by trusting a caller.
+		account, err := store.ClaimAdminInvitation(ctx, auth.InvitationClaimInput{
+			Bearer:          bootstrap.TokenValue,
+			ProviderSubject: options.OwnerSubject,
+			Email:           options.OwnerEmail,
+			EmailVerified:   true,
+		})
+		if err != nil {
+			return Result{}, fmt.Errorf("seed: claim owner invitation for %q: %w", options.OwnerSubject, err)
+		}
+		boundOwner = &BoundAccount{
+			ProviderSubject: account.User.ProviderSubject, Email: account.User.Email,
+			UserID: string(account.User.ID), MembershipID: string(account.Membership.ID),
+			OrganizationID:   string(account.Membership.OrganizationID),
+			OrganizationName: account.Membership.OrganizationName, Role: account.Membership.Role,
+		}
 	}
 
 	actor := audit.Actor{Type: audit.ActorTypeSystem, Label: "deterministic seed corpus"}
@@ -167,7 +229,33 @@ func Load(ctx context.Context, database *data.DB, options Options) (Result, erro
 		OrganizationID: string(bootstrap.Organization.ID), OrganizationName: bootstrap.Organization.Name,
 		SchoolYearID: string(year.ID), ClaimURL: bootstrap.ClaimURL, ExpiresAt: bootstrap.Token.ExpiresAt,
 		Students: len(studentIDs), Adults: len(adultIDs), Households: len(householdIDs),
+		BoundOwner: boundOwner,
 	}, nil
+}
+
+// CheckOwnerSubjectAvailable refuses a seed whose owner subject already holds a
+// membership. Load never reuses an existing organization, so binding an
+// already-bound subject would commit a second organization and then leave that
+// subject with two memberships, which ResolveAccount treats as a hard error:
+// the working login would break rather than gain a tenant. Callers that seed
+// without going through Load should run this first.
+func CheckOwnerSubjectAvailable(ctx context.Context, database *data.DB, providerSubject string) error {
+	if database == nil {
+		return errors.New("seed: database is nil")
+	}
+	providerSubject = strings.TrimSpace(providerSubject)
+	if providerSubject == "" {
+		return errors.New("seed: owner subject is empty")
+	}
+	_, err := identity.NewStore(database).ResolveAccount(ctx, providerSubject)
+	switch {
+	case errors.Is(err, auth.ErrNoOrganization):
+		return nil
+	case err == nil, errors.Is(err, auth.ErrMultipleOrganizations):
+		return fmt.Errorf("seed: provider subject %q already has an organization membership; the seed only ever creates a new organization, so start from an empty database: make reset CONFIRM=1", providerSubject)
+	default:
+		return fmt.Errorf("seed: resolve owner subject: %w", err)
+	}
 }
 
 func mustXID(value string) ids.XID { return ids.XID(value) }

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2687,13 +2687,9 @@
             "description": "Service Unavailable"
           }
         },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
+        "security": [],
         "summary": "Check API and database health",
-        "x-required-capability": "authenticated"
+        "x-required-capability": "public"
       }
     },
     "/api/homerooms": {

--- a/backend/tests/integration/health_test.go
+++ b/backend/tests/integration/health_test.go
@@ -107,9 +107,10 @@ func TestHealthIntegration(t *testing.T) {
 	httpServer := httptest.NewServer(server.Handler())
 	t.Cleanup(httpServer.Close)
 
+	// Deliberately no Authorization header: the liveness endpoint must be
+	// reachable by an orchestrator that holds no token.
 	request, err := http.NewRequest(http.MethodGet, httpServer.URL+"/api/health", nil)
 	require.NoError(t, err)
-	request.Header.Set("Authorization", "Bearer integration")
 	response, err := http.DefaultClient.Do(request)
 	require.NoError(t, err)
 	if err != nil {
@@ -139,7 +140,6 @@ func TestHealthFailureUsesProblemDetails(t *testing.T) {
 
 	request, err := http.NewRequest(http.MethodGet, httpServer.URL+"/api/health", nil)
 	require.NoError(t, err)
-	request.Header.Set("Authorization", "Bearer integration")
 	response, err := http.DefaultClient.Do(request)
 	require.NoError(t, err)
 	if err != nil {

--- a/backend/tests/integration/seed_test.go
+++ b/backend/tests/integration/seed_test.go
@@ -2,9 +2,14 @@ package integration
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 	"testing"
+	"time"
 
+	"github.com/chrismott/miniclass/internal/auth"
 	"github.com/chrismott/miniclass/internal/data"
+	"github.com/chrismott/miniclass/internal/identity"
 	"github.com/chrismott/miniclass/internal/ids"
 	"github.com/chrismott/miniclass/internal/people"
 	"github.com/chrismott/miniclass/internal/seed"
@@ -26,6 +31,7 @@ func TestSeedCorpusLoadsWithAppendixDistributionAndEdgeCases(t *testing.T) {
 	require.Equal(t, seed.HouseholdCount, result.Households)
 	require.NotEmpty(t, result.OrganizationID)
 	require.Contains(t, result.ClaimURL, "http://localhost:5173/claim")
+	require.Nil(t, result.BoundOwner, "a seed without an owner subject bound a login")
 
 	students, err := people.New(harness.Database).ListStudents(ctx, result.OrganizationID, resultSchoolYearID(result))
 	require.NoError(t, err)
@@ -126,8 +132,84 @@ func TestSeedCorpusLoadsWithAppendixDistributionAndEdgeCases(t *testing.T) {
 	require.Equal(t, 1, twoWordSurname)
 }
 
+func TestSeedBindsOwnerSubjectAndRefusesToRebindIt(t *testing.T) {
+	harness := testharness.Open(t)
+	ctx := harness.Context
+	store := identity.NewStore(harness.Database)
+	subject := fmt.Sprintf("local|seed-owner-%d", time.Now().UnixNano())
+	options := seed.DefaultOptions()
+	options.OrganizationName = fmt.Sprintf("Synthetic Seed Bind %d", time.Now().UnixNano())
+	options.OwnerEmail = "seed-bind-owner@example.test"
+	options.OwnerSubject = subject
+
+	result, err := seed.Load(ctx, harness.Database, options)
+	require.NoError(t, err)
+	require.NotNil(t, result.BoundOwner)
+	require.Equal(t, subject, result.BoundOwner.ProviderSubject)
+	require.Equal(t, options.OwnerEmail, result.BoundOwner.Email)
+	require.Equal(t, "owner", result.BoundOwner.Role)
+	require.Equal(t, result.OrganizationID, result.BoundOwner.OrganizationID)
+	require.Equal(t, options.OrganizationName, result.BoundOwner.OrganizationName)
+
+	// ResolveAccount refuses zero and multiple memberships outright, so a
+	// successful resolve is the assertion that exactly one exists.
+	account, err := store.ResolveAccount(ctx, subject)
+	require.NoError(t, err)
+	require.Equal(t, subject, account.User.ProviderSubject)
+	require.Equal(t, options.OwnerEmail, account.User.Email)
+	require.Equal(t, ids.XID(result.OrganizationID), account.Membership.OrganizationID)
+	require.Equal(t, options.OrganizationName, account.Membership.OrganizationName)
+	require.Equal(t, "owner", account.Membership.Role)
+
+	bearer := claimURLToken(t, result.ClaimURL)
+	token, err := store.GetAccessTokenByBearer(ctx, bearer)
+	require.NoError(t, err)
+	require.NotNil(t, token.ConsumedAt, "the automatic claim did not consume the invitation")
+	_, err = store.ClaimAdminInvitation(ctx, auth.InvitationClaimInput{
+		Bearer: bearer, ProviderSubject: subject + "-replay",
+		Email: options.OwnerEmail, EmailVerified: true,
+	})
+	require.ErrorIs(t, err, auth.ErrInvitationInvalid, "the printed claim URL is still replayable")
+
+	organizations := countOrganizationsNamed(t, harness, options.OrganizationName)
+	require.Equal(t, 1, organizations)
+
+	second, err := seed.Load(ctx, harness.Database, options)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "make reset CONFIRM=1")
+	require.Empty(t, second.OrganizationID)
+	require.Nil(t, second.BoundOwner)
+	require.Equal(t, organizations, countOrganizationsNamed(t, harness, options.OrganizationName),
+		"the refused seed created an organization before failing")
+
+	// The refusal left the first login usable instead of turning it into the
+	// multiple-organizations case.
+	again, err := store.ResolveAccount(ctx, subject)
+	require.NoError(t, err)
+	require.Equal(t, account.Membership.ID, again.Membership.ID)
+}
+
 func resultSchoolYearID(result seed.Result) (id ids.XID) {
 	return ids.XID(result.SchoolYearID)
+}
+
+func claimURLToken(t *testing.T, claimURL string) string {
+	t.Helper()
+	parsed, err := url.Parse(claimURL)
+	require.NoError(t, err)
+	token := parsed.Query().Get("token")
+	require.NotEmpty(t, token)
+	return token
+}
+
+// countOrganizationsNamed is scoped to one test's unique organization name;
+// the suite shares a database, so a global count would see other tests' rows.
+func countOrganizationsNamed(t *testing.T, harness *testharness.Harness, name string) int {
+	t.Helper()
+	var count int
+	require.NoError(t, harness.Migrator.QueryRow(harness.Context,
+		`select count(*) from organizations where name = $1`, name).Scan(&count))
+	return count
 }
 
 func allStudentMemberships(t *testing.T, harness *testharness.Harness, organizationID string) []data.HouseholdStudent {

--- a/docs/adr/0011-local-development-orchestration-and-environment-contract.md
+++ b/docs/adr/0011-local-development-orchestration-and-environment-contract.md
@@ -158,7 +158,9 @@ setup cannot drift into two different notions of "PostgreSQL is ready".
 Local tokens are minted with a **30-day** lifetime. `cmd/devtoken` defaults to five minutes, which is
 right for a test and wrong for a person, who otherwise re-mints a token several times an hour and
 learns to distrust every authentication failure. A local token is signed by a key on the developer's
-own disk, so its lifetime is not a security boundary. Seed and token behaviour is DX-3.
+own disk, so its lifetime is not a security boundary. Seed and token behaviour is DX-3, which
+implements this as `scripts/login.sh`: the lifetime stays a caller's argument rather than becoming
+`cmd/devtoken`'s default, since the five-minute default is the correct one for a test.
 
 ### `make check` is the CI equivalent
 
@@ -229,9 +231,13 @@ copy, keys are files and the two processes run in two terminals, nothing is left
 - Nothing yet enforces the invariant at review time; it is enforced when a script loads the file.
   A CI check belongs with DX-5.
 - Two defects were found by running the smoke test against a correct `.env` for the first time, and
-  are left for their owning issues rather than fixed here. `GET /api/health` is registered with
-  `CapabilityAuthenticated` and no unresolved-principal exemption, so the smoke test cannot reach it
-  without seeded identity data; and `cmd/seed` fails with `permission denied for table organizations`
-  under the `miniclass_migrator` role that `.env.example` prescribes. Both are seed and token
-  behaviour, which is DX-3. Until they are resolved the smoke test stops at the health check, now
-  quoting the API's problem document so the cause is visible.
+  were left for their owning issue rather than fixed here. `GET /api/health` was registered with
+  `CapabilityAuthenticated` and no unresolved-principal exemption, so the smoke test could not reach
+  it without seeded identity data; and `cmd/seed` failed with `permission denied for table
+  organizations`. Both were resolved in DX-3. Health now declares `CapabilityPublic`, a capability
+  that exists so that "no authentication" is something an operation must state rather than something
+  it can achieve by omission. The permission failure turned out not to be a property of the
+  `miniclass_migrator` role at all: it reproduces only on a database whose objects were created by
+  the superuser under the pre-this-ADR `DATABASE_URL`, leaving the migrator with neither ownership
+  nor grants. On a database created by `scripts/setup.sh` the tables are migrator-owned and the seed
+  succeeds, so the remedy is `make reset CONFIRM=1` rather than a code change.

--- a/frontend/src/features/auth/LocalDevAuthBanner.tsx
+++ b/frontend/src/features/auth/LocalDevAuthBanner.tsx
@@ -1,0 +1,34 @@
+import type { DevTokenStatus } from '@/lib/auth'
+
+function reason(status: DevTokenStatus): string {
+  switch (status.kind) {
+    case 'expired':
+      return `VITE_DEV_TOKEN expired on ${status.expiresAt.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })}.`
+    case 'unreadable':
+      return 'VITE_DEV_TOKEN is not a readable token.'
+    default:
+      return 'no VITE_DEV_TOKEN is set.'
+  }
+}
+
+// Shown in place of the sign-in form when the local fake-auth client has no
+// usable token. The form is not merely useless there, it is misleading: the
+// fake client accepts any password and then hands back no session.
+export function LocalDevAuthBanner({ status }: { status: DevTokenStatus }) {
+  return (
+    <div className="rounded-md border-2 border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive" role="alert">
+      <p className="text-base font-semibold">Local development authentication has no token</p>
+      <p className="mt-2">
+        This build uses the local fake-auth client, and {reason(status)} An email and password cannot sign
+        you in here, so the form is hidden.
+      </p>
+      <p className="mt-3">
+        Mint a usable token from the repository root with <code className="rounded bg-destructive/15 px-1 py-0.5 font-mono font-semibold">make login</code>.
+      </p>
+      <p className="mt-3">
+        Then restart the Vite dev server. VITE_* values are inlined when the dev server starts, so a new
+        .env value is not picked up by an HMR update alone.
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/features/auth/SignInPage.test.tsx
+++ b/frontend/src/features/auth/SignInPage.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AuthClient, DevTokenStatus } from '@/lib/auth'
+import { AuthProvider } from '@/lib/hooks/AuthProvider'
+
+import { SignInPage } from './SignInPage'
+
+// A configured client with no session: what the local fake-auth client looks
+// like when VITE_DEV_TOKEN yields nothing usable.
+function sessionlessClient(): AuthClient {
+  return {
+    auth: {
+      getSession: vi.fn(async () => ({ data: { session: null }, error: null })),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+      signInWithPassword: vi.fn(async () => ({ data: { session: null, user: null }, error: null })),
+    },
+  } as unknown as AuthClient
+}
+
+function renderSignIn(props: { localDevAuth: boolean; devToken: DevTokenStatus }) {
+  return render(
+    <MemoryRouter initialEntries={['/sign-in']}>
+      <AuthProvider client={sessionlessClient()}>
+        <SignInPage {...props} />
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('sign-in page under local development auth', () => {
+  it('replaces the form with a banner naming make login when no token is set', async () => {
+    renderSignIn({ localDevAuth: true, devToken: { kind: 'missing' } })
+
+    const banner = await screen.findByRole('alert')
+    expect(banner).toHaveTextContent('Local development authentication has no token')
+    expect(banner).toHaveTextContent('no VITE_DEV_TOKEN is set.')
+    expect(banner).toHaveTextContent('make login')
+    expect(banner).toHaveTextContent(/restart the Vite dev server/)
+
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Email')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Sign in' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Forgot password?' })).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'System health' })).toHaveAttribute('href', '/health')
+  })
+
+  it('says the token is unreadable when it cannot be decoded', async () => {
+    renderSignIn({ localDevAuth: true, devToken: { kind: 'unreadable' } })
+
+    const banner = await screen.findByRole('alert')
+    expect(banner).toHaveTextContent('VITE_DEV_TOKEN is not a readable token.')
+    expect(banner).toHaveTextContent('make login')
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument()
+  })
+
+  it('names the expiry when the token has expired', async () => {
+    renderSignIn({ localDevAuth: true, devToken: { kind: 'expired', expiresAt: new Date('2020-01-02T03:04:05Z') } })
+
+    const banner = await screen.findByRole('alert')
+    expect(banner).toHaveTextContent(/VITE_DEV_TOKEN expired on .*2020/)
+    expect(banner).toHaveTextContent('make login')
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument()
+  })
+
+  it('renders the ordinary form when the dev token is usable', async () => {
+    renderSignIn({ localDevAuth: true, devToken: { kind: 'valid', expiresAt: new Date('2099-01-01T00:00:00Z') } })
+
+    expect(await screen.findByLabelText('Password')).toBeInTheDocument()
+    expect(screen.getByLabelText('Email')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Forgot password?' })).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('renders the ordinary form on the real Supabase path regardless of the dev token', async () => {
+    renderSignIn({ localDevAuth: false, devToken: { kind: 'missing' } })
+
+    expect(await screen.findByLabelText('Password')).toBeInTheDocument()
+    expect(screen.getByLabelText('Email')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/auth/SignInPage.tsx
+++ b/frontend/src/features/auth/SignInPage.tsx
@@ -3,16 +3,25 @@ import { Link, useLocation, useNavigate } from 'react-router-dom'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { devTokenStatus, isLocalDevAuth, type DevTokenStatus } from '@/lib/auth'
 import { useAuth } from '@/lib/hooks/useAuth'
 
 import { AuthErrorMessage, AuthLayout } from './AuthLayout'
+import { LocalDevAuthBanner } from './LocalDevAuthBanner'
 import { errorMessage } from './auth-utils'
 
 function safeRedirect(value: string | null): string {
   return value && value.startsWith('/') && !value.startsWith('//') ? value : '/years'
 }
 
-export function SignInPage() {
+// The dev-token state is taken from props so it can be exercised without
+// mocking import.meta.env; the defaults are the values this build was made with.
+type SignInPageProps = {
+  localDevAuth?: boolean
+  devToken?: DevTokenStatus
+}
+
+export function SignInPage({ localDevAuth = isLocalDevAuth, devToken = devTokenStatus }: SignInPageProps = {}) {
   const { authConfigured, authError, isLoading, signIn } = useAuth()
   const location = useLocation()
   const navigate = useNavigate()
@@ -36,6 +45,10 @@ export function SignInPage() {
     }
   }
 
+  // With no auth client at all there is nothing to explain about a dev token:
+  // the missing configuration is the accurate message.
+  const devTokenBlocks = localDevAuth && authConfigured && devToken.kind !== 'valid'
+
   return (
     <AuthLayout>
       <div>
@@ -49,24 +62,39 @@ export function SignInPage() {
         {error && <AuthErrorMessage message={error} />}
       </div>
 
-      <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
-        <label className="block space-y-2 text-sm font-medium" htmlFor="sign-in-email">
-          Email
-          <Input id="sign-in-email" name="email" type="email" autoComplete="email" required value={email} onChange={(event) => setEmail(event.target.value)} />
-        </label>
-        <label className="block space-y-2 text-sm font-medium" htmlFor="sign-in-password">
-          Password
-          <Input id="sign-in-password" name="password" type="password" autoComplete="current-password" required value={password} onChange={(event) => setPassword(event.target.value)} />
-        </label>
-        <Button className="w-full" type="submit" disabled={isLoading || isSubmitting || !authConfigured}>
-          {isSubmitting ? 'Signing in…' : 'Sign in'}
-        </Button>
-      </form>
+      {devTokenBlocks ? (
+        <>
+          <div className="mt-6">
+            <LocalDevAuthBanner status={devToken} />
+          </div>
 
-      <div className="mt-6 flex justify-between text-sm">
-        <Link className="font-medium text-primary hover:underline" to="/reset-password">Forgot password?</Link>
-        <Link className="text-muted-foreground hover:text-foreground" to="/health">System health</Link>
-      </div>
+          {/* /health is the one route that works without a session. */}
+          <div className="mt-6 flex justify-end text-sm">
+            <Link className="text-muted-foreground hover:text-foreground" to="/health">System health</Link>
+          </div>
+        </>
+      ) : (
+        <>
+          <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+            <label className="block space-y-2 text-sm font-medium" htmlFor="sign-in-email">
+              Email
+              <Input id="sign-in-email" name="email" type="email" autoComplete="email" required value={email} onChange={(event) => setEmail(event.target.value)} />
+            </label>
+            <label className="block space-y-2 text-sm font-medium" htmlFor="sign-in-password">
+              Password
+              <Input id="sign-in-password" name="password" type="password" autoComplete="current-password" required value={password} onChange={(event) => setPassword(event.target.value)} />
+            </label>
+            <Button className="w-full" type="submit" disabled={isLoading || isSubmitting || !authConfigured}>
+              {isSubmitting ? 'Signing in…' : 'Sign in'}
+            </Button>
+          </form>
+
+          <div className="mt-6 flex justify-between text-sm">
+            <Link className="font-medium text-primary hover:underline" to="/reset-password">Forgot password?</Link>
+            <Link className="text-muted-foreground hover:text-foreground" to="/health">System health</Link>
+          </div>
+        </>
+      )}
     </AuthLayout>
   )
 }

--- a/frontend/src/features/people/api.test.ts
+++ b/frontend/src/features/people/api.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getAccessToken } from '@/lib/auth'
+
+import { peopleApi, request } from './api'
+
+// The token source is mocked, not the request assembly: what regressed was the
+// header, and it regressed because nothing ever called this module's fetch.
+vi.mock('@/lib/auth', () => ({ getAccessToken: vi.fn() }))
+
+const accessToken = vi.mocked(getAccessToken)
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } })
+}
+
+describe('roster API authentication', () => {
+  let sent: Array<{ url: string; headers: Headers; init: RequestInit }>
+  let nextBody: unknown
+
+  beforeEach(() => {
+    accessToken.mockResolvedValue('test-access-token')
+    sent = []
+    nextBody = []
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init: RequestInit = {}) => {
+      sent.push({ url: String(input), headers: new Headers(init.headers), init })
+      return jsonResponse(nextBody)
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('sends the bearer token on a roster read', async () => {
+    await peopleApi.list('student', 'year-1')
+
+    expect(sent[0].url).toContain('/api/school-years/year-1/students')
+    expect(sent[0].headers.get('Authorization')).toBe('Bearer test-access-token')
+  })
+
+  it('sends the bearer token on a write', async () => {
+    nextBody = { id: 'student-1' }
+    await peopleApi.create('student', 'year-1', { legal_given_name: 'A', legal_family_name: 'B' } as never)
+
+    expect(sent[0].headers.get('Authorization')).toBe('Bearer test-access-token')
+    expect(sent[0].headers.get('Content-Type')).toBe('application/json')
+    expect(sent[0].init.method).toBe('POST')
+  })
+
+  // Guards the spread order. With `...init` applied last, any caller-supplied
+  // header replaced the whole headers object and dropped the token.
+  it('keeps the bearer token when the caller supplies its own header', async () => {
+    await request('/api/anything', { headers: { 'X-Test': 'yes' } })
+
+    expect(sent[0].headers.get('Authorization')).toBe('Bearer test-access-token')
+    expect(sent[0].headers.get('X-Test')).toBe('yes')
+  })
+
+  it('omits the header entirely when there is no session', async () => {
+    accessToken.mockResolvedValue(null)
+    await request('/api/anything')
+
+    expect(sent[0].headers.has('Authorization')).toBe(false)
+  })
+})

--- a/frontend/src/features/people/api.ts
+++ b/frontend/src/features/people/api.ts
@@ -1,3 +1,5 @@
+import { getAccessToken } from '@/lib/auth'
+
 import type { AdultInput, FieldErrors, PeopleApi, Person, PersonKind, StudentInput } from './types'
 
 export class PeopleApiError extends Error {
@@ -51,12 +53,24 @@ async function readError(response: Response): Promise<PeopleApiError> {
   )
 }
 
+// Every roster call goes through here, so this is the one place that has to
+// attach the bearer token. It did not, which made students, adults, households
+// and guardian relationships answer "a bearer token is required" while the rest
+// of the app worked — the tests mock peopleApi's methods, so nothing exercised
+// this function. The headers are spread after init deliberately: with `...init`
+// last, a caller passing any header at all would replace this object wholesale
+// and silently drop the Authorization header again.
 export async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = await getAccessToken()
   let response: Response
   try {
     response = await globalThis.fetch(`${configuredBaseUrl}${path}`, {
-      headers: { 'Content-Type': 'application/json', ...init?.headers },
       ...init,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...init?.headers,
+      },
     })
   } catch {
     throw new PeopleApiError('Unable to reach the API')

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,7 @@
 import createClient from 'openapi-fetch'
 
 import type { paths } from './api.generated'
-import { supabase } from './auth'
+import { getAccessToken } from './auth'
 
 export type HealthResponse = paths['/api/health']['get']['responses'][200]['content']['application/json']
 export type MeResponse = paths['/api/me']['get']['responses'][200]['content']['application/json']
@@ -57,7 +57,7 @@ export class ApiClient {
   constructor(options: ApiClientOptions = {}) {
     this.baseUrl = options.baseUrl ?? configuredBaseUrl
     this.fetcher = options.fetch ?? ((input, init) => globalThis.fetch(input, init))
-    this.getAccessToken = options.getAccessToken ?? getSupabaseAccessToken
+    this.getAccessToken = options.getAccessToken ?? getAccessToken
     this.client = createClient<paths>({
       baseUrl: this.baseUrl,
       fetch: this.authenticatedFetch,
@@ -223,14 +223,6 @@ export class ApiClient {
 
 export const apiClient = new ApiClient()
 
-async function getSupabaseAccessToken(): Promise<string | null> {
-  if (!supabase) {
-    return null
-  }
-
-  const { data } = await supabase.auth.getSession()
-  return data.session?.access_token ?? null
-}
 
 function parseSchoolYear(value: unknown): SchoolYear {
   if (!isSchoolYear(value)) {

--- a/frontend/src/lib/auth.test.ts
+++ b/frontend/src/lib/auth.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { inspectDevToken } from './auth'
+
+function base64url(value: unknown): string {
+  return btoa(JSON.stringify(value)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+// No signature verification happens client-side, so a fixed fake header and
+// signature are indistinguishable from a real devtoken here.
+function token(payload: Record<string, unknown>): string {
+  return `${base64url({ alg: 'ES256', kid: 'local', typ: 'JWT' })}.${base64url(payload)}.c2lnbmF0dXJl`
+}
+
+const now = new Date('2026-08-25T12:00:00Z')
+
+describe('inspectDevToken', () => {
+  it('reports a missing token for an unset or blank value', () => {
+    expect(inspectDevToken(undefined, now)).toEqual({ kind: 'missing' })
+    expect(inspectDevToken('', now)).toEqual({ kind: 'missing' })
+    expect(inspectDevToken('   ', now)).toEqual({ kind: 'missing' })
+  })
+
+  it('reports an unreadable token instead of throwing on anything undecodable', () => {
+    expect(inspectDevToken('not-a-jwt', now)).toEqual({ kind: 'unreadable' })
+    expect(inspectDevToken('header.$$$not-base64$$$.signature', now)).toEqual({ kind: 'unreadable' })
+    expect(inspectDevToken(`header.${base64url('a string, not an object')}.signature`, now)).toEqual({ kind: 'unreadable' })
+    expect(inspectDevToken(token({ sub: 'local:dev' }), now)).toEqual({ kind: 'unreadable' })
+    expect(inspectDevToken(token({ exp: '1774440000' }), now)).toEqual({ kind: 'unreadable' })
+  })
+
+  it('reports an expired token with its expiry', () => {
+    const expiresAt = new Date('2026-08-25T11:59:00Z')
+    expect(inspectDevToken(token({ exp: expiresAt.getTime() / 1000 }), now)).toEqual({ kind: 'expired', expiresAt })
+  })
+
+  it('treats a token expiring exactly now as expired', () => {
+    expect(inspectDevToken(token({ exp: now.getTime() / 1000 }), now)).toEqual({ kind: 'expired', expiresAt: now })
+  })
+
+  it('reports a valid token with its expiry', () => {
+    const expiresAt = new Date('2026-08-25T13:00:00Z')
+    expect(inspectDevToken(token({ exp: expiresAt.getTime() / 1000, email: 'dev@example.test' }), now)).toEqual({ kind: 'valid', expiresAt })
+  })
+})

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -4,6 +4,53 @@ const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 const devToken = import.meta.env.VITE_DEV_TOKEN
 
+// This exact anon key value selects the local fake-auth client below; see the
+// Frontend section of the root .env.
+export const isLocalDevAuth = supabaseAnonKey === 'localdevkey'
+
+export type DevTokenStatus =
+  | { kind: 'missing' }
+  | { kind: 'unreadable' }
+  | { kind: 'expired'; expiresAt: Date }
+  | { kind: 'valid'; expiresAt: Date }
+
+// Reads a JWT payload without verifying the signature, which a browser cannot
+// do and the API does on every request anyway.
+function decodeTokenPayload(token: string): Record<string, unknown> | null {
+  const segment = token.split('.')[1]
+  if (!segment) {
+    return null
+  }
+  try {
+    const payload: unknown = JSON.parse(atob(segment.replace(/-/g, '+').replace(/_/g, '/')))
+    return typeof payload === 'object' && payload !== null ? payload as Record<string, unknown> : null
+  } catch {
+    return null
+  }
+}
+
+// Pure, so the sign-in surface can be told what is wrong with a dev token
+// instead of failing silently. `now` is a parameter to keep it testable.
+export function inspectDevToken(token: string | undefined, now: Date): DevTokenStatus {
+  if (!token || token.trim() === '') {
+    return { kind: 'missing' }
+  }
+  const exp = decodeTokenPayload(token)?.exp
+  if (typeof exp !== 'number' || !Number.isFinite(exp)) {
+    return { kind: 'unreadable' }
+  }
+  const expiresAt = new Date(exp * 1000)
+  return expiresAt.getTime() <= now.getTime()
+    ? { kind: 'expired', expiresAt }
+    : { kind: 'valid', expiresAt }
+}
+
+// Evaluated once, like every other VITE_* read: the token is inlined when the
+// dev server starts. A token that expires mid-session therefore still produces
+// unexplained 401s until a reload; the banner addresses the common case of
+// starting the dev server without a usable token.
+export const devTokenStatus = inspectDevToken(devToken, new Date())
+
 // Export a runtime-initialized client. For local development we support a
 // lightweight fake-auth client when the special dev anon key is used. This
 // lets you run the app locally without a Supabase project.
@@ -11,12 +58,16 @@ export let supabase: SupabaseClient | null = null
 
 // Minimal fake client implementing the small supabase auth surface the app
 // uses. It stores a single session derived from a provided JWT (VITE_DEV_TOKEN).
-function makeFakeClient(token: string | undefined) {
-  const session: Session | null = token
+function makeFakeClient(token: string | undefined, status: DevTokenStatus) {
+  // Only a usable token becomes a session. There is no refresh path here, so a
+  // fabricated session for an expired or unreadable token would present as an
+  // authenticated app whose every request fails with 401 invalid-token.
+  const session: Session | null = token && status.kind === 'valid'
     ? {
         access_token: token,
         token_type: 'bearer',
-        expires_in: 3600,
+        expires_at: Math.floor(status.expiresAt.getTime() / 1000),
+        expires_in: Math.max(0, Math.round((status.expiresAt.getTime() - Date.now()) / 1000)),
         refresh_token: 'dev-refresh',
         provider_token: null,
         // user is partial; the app only reads email in many places
@@ -24,15 +75,10 @@ function makeFakeClient(token: string | undefined) {
       }
     : null
 
-  // try to decode email from JWT payload if present
-  if (token) {
-    try {
-      const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')))
-      if (payload && typeof payload.email === 'string') {
-        session!.user = { ...session!.user, email: payload.email }
-      }
-    } catch {
-      // ignore
+  if (session && token) {
+    const email = decodeTokenPayload(token)?.email
+    if (typeof email === 'string') {
+      session.user = { ...session.user, email }
     }
   }
 
@@ -62,11 +108,11 @@ function makeFakeClient(token: string | undefined) {
   } as unknown as Pick<SupabaseClient, 'auth'>
 }
 
-if (supabaseAnonKey === 'localdevkey') {
+if (isLocalDevAuth) {
   // Use a fake client in dev when the dev anon key is present. This avoids
   // attempting to reach a Supabase project while letting the UI behave like
   // an authenticated app when a VITE_DEV_TOKEN is provided.
-  supabase = makeFakeClient(devToken) as unknown as SupabaseClient
+  supabase = makeFakeClient(devToken, devTokenStatus) as unknown as SupabaseClient
 } else if (supabaseUrl && supabaseAnonKey) {
   void (async () => {
     const mod = await import('@supabase/supabase-js')

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -126,5 +126,17 @@ if (isLocalDevAuth) {
   })()
 }
 
+// The one place the bearer token is read. Both API clients call this, so a new
+// caller cannot acquire the habit of fetching without one — which is exactly
+// how the roster pages ended up unauthenticated.
+export async function getAccessToken(): Promise<string | null> {
+  if (!supabase) {
+    return null
+  }
+
+  const { data } = await supabase.auth.getSession()
+  return data.session?.access_token ?? null
+}
+
 export type AuthClient = Pick<SupabaseClient, 'auth'>
 export type { AuthChangeEvent, AuthError, Session }

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -83,6 +83,81 @@ env_violations() {
   ' "$file"
 }
 
+# env_set writes NAME=value into the given file, replacing the first existing
+# assignment in place and appending only when the name is absent. Every other
+# line, including comments and ordering, is preserved byte for byte, because a
+# developer's .env is a file they edit and this is a tool that edits it behind
+# their back.
+#
+# The invariant is checked here rather than trusted: a value with whitespace or
+# '#' would make the whole file unloadable for every consumer, and the write is
+# the last moment at which that can be refused by name.
+env_set() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  local temporary
+
+  [[ -f "$file" ]] || die "missing $file; run ./scripts/setup.sh first"
+  case "$value" in
+    *[[:space:]]* | *"#"*)
+      die "refusing to write $key: the value contains whitespace or '#', which no .env parser reads identically"
+      ;;
+  esac
+
+  temporary="$(mktemp "${TMPDIR:-/tmp}/miniclass-env.XXXXXX")" || die "could not create a temporary file"
+  awk -v key="$key" -v value="$value" '
+    BEGIN { written = 0 }
+    index($0, key "=") == 1 {
+      if (!written) { print key "=" value; written = 1 }
+      next
+    }
+    { print }
+    END { if (!written) print key "=" value }
+  ' "$file" >"$temporary" || die "could not rewrite $key in $file"
+
+  # Copy over the original rather than moving the temporary onto it, so the
+  # file keeps its inode and permissions instead of inheriting mktemp's 0600.
+  cat "$temporary" >"$file" || die "could not write $file"
+  rm -f "$temporary"
+}
+
+# jwt_expiry prints the exp claim of a JWT as a Unix timestamp, and fails for
+# anything it cannot read. No signature is checked: the caller is deciding
+# whether to re-mint a token it is about to hand to a verifier that will check
+# the signature properly.
+jwt_expiry() {
+  local token="$1"
+  local payload
+  local decoded
+  local expiry
+
+  [[ "$(printf '%s' "$token" | awk -F. '{ print NF }')" == "3" ]] || return 1
+  payload="$(printf '%s' "$token" | cut -d. -f2 | tr '_-' '/+')"
+  [[ -n "$payload" ]] || return 1
+  while [[ $(( ${#payload} % 4 )) -ne 0 ]]; do
+    payload="${payload}="
+  done
+
+  decoded="$(printf '%s' "$payload" | openssl base64 -d -A 2>/dev/null)" || return 1
+  expiry="$(printf '%s' "$decoded" | sed -n 's/.*"exp"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p')"
+  [[ -n "$expiry" ]] || return 1
+  printf '%s\n' "$expiry"
+}
+
+# dev_admin_subject prints the local provider subject for DEV_ADMIN_EMAIL.
+#
+# One derivation, in one place. The seed's invitation email, the token's email
+# claim and the token's subject all have to agree or the claim is refused and
+# the login silently does not exist; deriving the subject from the address
+# rather than configuring it separately is what makes disagreement impossible.
+dev_admin_subject() {
+  local email="${1:-${DEV_ADMIN_EMAIL:-}}"
+
+  [[ -n "$email" ]] || die "DEV_ADMIN_EMAIL is not set; add it to .env (see .env.example)"
+  printf 'local:%s\n' "$email"
+}
+
 # env_keys prints the variable names assigned in the given file, in order.
 env_keys() {
   local file="$1"
@@ -123,12 +198,17 @@ load_env() {
 
 # port_in_use reports whether anything is listening on a local TCP port. bash's
 # /dev/tcp is used rather than lsof or nc so that no extra prerequisite appears.
+#
+# The probe runs in a subshell, whose exit both closes the descriptor and
+# supplies this function's status. Do not "tidy up" afterwards with
+# `exec 3>&- 2>/dev/null`: an exec with redirections and no command applies them
+# to the calling shell permanently, so that line sent stderr to /dev/null for
+# the remainder of every script that called this function, and warnings and
+# `set -x` traces vanished for no visible reason.
 port_in_use() {
   local port="$1"
 
-  (exec 3<>"/dev/tcp/127.0.0.1/$port") >/dev/null 2>&1 || return 1
-  exec 3>&- 2>/dev/null || true
-  return 0
+  (exec 3<>"/dev/tcp/127.0.0.1/$port") >/dev/null 2>&1
 }
 
 # require_free_port fails unless the given port is free.

--- a/scripts/login.sh
+++ b/scripts/login.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Put a usable local login in .env: mint a development bearer token for the
+# DEV_ADMIN_EMAIL identity, or keep the existing one when it is still fresh.
+#
+# Idempotent, and safe to make a prerequisite of anything: it re-mints only when
+# VITE_DEV_TOKEN is absent, unreadable, or close enough to expiry that a working
+# session would end mid-task, and it says which of those happened.
+#
+# See docs/adr/0011-local-development-orchestration-and-environment-contract.md.
+set -Eeuo pipefail
+
+MINICLASS_SCRIPT="scripts/login.sh"
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib.sh
+. "$ROOT_DIR/scripts/lib.sh"
+
+cd "$ROOT_DIR"
+
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
+# Thirty days. A local token is signed by a key on this machine and is refused
+# outright in production by auth.ErrLocalProduction, so its lifetime is not a
+# security boundary; cmd/devtoken's five-minute default is right for a test and
+# wrong for a person, who otherwise re-mints several times an hour and learns to
+# distrust every authentication failure.
+LIFETIME="${DEV_TOKEN_LIFETIME:-720h}"
+# Re-mint a day out rather than at expiry, so a token never dies mid-session.
+MINIMUM_REMAINING_SECONDS="${DEV_TOKEN_MINIMUM_REMAINING_SECONDS:-86400}"
+FORCE="${DEV_TOKEN_FORCE:-0}"
+
+usage() {
+  cat <<'USAGE'
+Usage: ./scripts/login.sh [--force]
+
+Refreshes VITE_DEV_TOKEN in .env when it is missing, unreadable, or expiring
+within 24 hours. --force always mints a new token.
+
+Environment overrides:
+  DEV_TOKEN_LIFETIME                    token lifetime passed to cmd/devtoken (default 720h)
+  DEV_TOKEN_MINIMUM_REMAINING_SECONDS   re-mint threshold (default 86400)
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force) FORCE=1 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *) die "unknown argument: $1" ;;
+  esac
+  shift
+done
+
+require_command go openssl awk curl
+
+load_env "$ENV_FILE"
+
+SUBJECT="$(dev_admin_subject)"
+EMAIL="$DEV_ADMIN_EMAIL"
+
+if [[ -z "${AUTH_LOCAL_PRIVATE_KEY_FILE:-}" && -z "${AUTH_LOCAL_PRIVATE_KEY:-}" ]]; then
+  die "no local signing key is configured; set AUTH_LOCAL_PRIVATE_KEY_FILE in .env and run ./scripts/setup.sh"
+fi
+
+# 1. Decide whether the token in .env is still worth keeping.
+
+now="$(date +%s)"
+reason=""
+existing="${VITE_DEV_TOKEN:-}"
+
+if [[ "$FORCE" == "1" ]]; then
+  reason="--force was given"
+elif [[ -z "$existing" ]]; then
+  reason="VITE_DEV_TOKEN is empty"
+elif ! expiry="$(jwt_expiry "$existing")"; then
+  reason="VITE_DEV_TOKEN is not a readable JWT"
+elif [[ "$expiry" -le "$now" ]]; then
+  reason="VITE_DEV_TOKEN expired $(( (now - expiry) / 3600 ))h ago"
+elif [[ $(( expiry - now )) -lt "$MINIMUM_REMAINING_SECONDS" ]]; then
+  reason="VITE_DEV_TOKEN expires in $(( (expiry - now) / 3600 ))h"
+fi
+
+if [[ -z "$reason" ]]; then
+  log "Keeping the existing dev token for $SUBJECT; it expires in $(( (expiry - now) / 86400 ))d."
+else
+  log "Minting a dev token for $SUBJECT ($reason)."
+  token="$(cd "$ROOT_DIR/backend" && go run ./cmd/devtoken \
+    -subject "$SUBJECT" \
+    -email "$EMAIL" \
+    -lifetime "$LIFETIME")" || die "could not mint a development token"
+  [[ -n "$token" ]] || die "cmd/devtoken produced no token"
+
+  env_set "$ENV_FILE" VITE_DEV_TOKEN "$token"
+  export VITE_DEV_TOKEN="$token"
+
+  if minted_expiry="$(jwt_expiry "$token")"; then
+    log "Wrote VITE_DEV_TOKEN to .env; it expires in $(( (minted_expiry - now) / 86400 ))d."
+  else
+    log "Wrote VITE_DEV_TOKEN to .env."
+  fi
+  log "Restart the Vite dev server to pick it up: VITE_* values are inlined when it starts."
+fi
+
+# 2. If the API happens to be running, say whether the token actually works.
+#
+# A token is only half of a login: it names a subject, and that subject reaches
+# an organisation only once the seed has bound it. Checking here is what turns
+# "403 no-organization" from a mystery into a named next command.
+
+PORT="${PORT:-8080}"
+API_BASE_URL="${API_BASE_URL:-http://localhost:$PORT}"
+API_BASE_URL="${API_BASE_URL%/}"
+API_BASE_URL="${API_BASE_URL%/api}"
+
+if ! port_in_use "$PORT"; then
+  log ""
+  log "The API is not running, so the token was not exercised. Next:"
+  log "  make -C backend dev          API on $API_BASE_URL"
+  log "  cd frontend && bun run dev   app on http://localhost:${VITE_PORT:-5173}"
+  log ""
+  log "If the API then answers 403 no-organization, run 'make seed' to bind $SUBJECT."
+  exit 0
+fi
+
+response="$(curl --silent --show-error --max-time 10 \
+  -H "Authorization: Bearer ${VITE_DEV_TOKEN}" \
+  "$API_BASE_URL/api/me" 2>/dev/null || true)"
+
+case "$response" in
+  *'"no-organization"'*)
+    log ""
+    warn "the token verifies, but $SUBJECT has no organization membership."
+    warn "run 'make seed' to create the synthetic organisation and bind it."
+    exit 1
+    ;;
+  *'"multiple-organizations"'*)
+    log ""
+    warn "$SUBJECT holds more than one membership, which resolves to no tenant at all."
+    warn "run 'make -C backend reset-db RESET_DB_CONFIRM=1' to start from one organisation."
+    exit 1
+    ;;
+  *'"role"'*)
+    log ""
+    log "GET $API_BASE_URL/api/me: $response"
+    ;;
+  "")
+    log ""
+    warn "GET $API_BASE_URL/api/me returned nothing; is the API still starting?"
+    ;;
+  *)
+    log ""
+    warn "GET $API_BASE_URL/api/me did not return a principal: $response"
+    warn "if the database was just reset, the running API is pooling connections to the schema that was replaced; restart it."
+    exit 1
+    ;;
+esac

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -140,13 +140,42 @@ curl --fail --silent --show-error "$FRONTEND_URL/api/health" >"$LOG_DIR/proxied-
 grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"' "$LOG_DIR/proxied-api-health.json" \
   || die "GET $FRONTEND_URL/api/health did not report a healthy API"
 
+# GET /api/health is deliberately unauthenticated, so everything above proves
+# only that the process is up. Exercising one authenticated route is what proves
+# the whole local identity chain — signing key, token subject, seeded
+# organisation, bound membership — actually lines up. It is conditional because
+# the smoke test must not mutate the developer's database by seeding.
+authenticated_check="skipped: VITE_DEV_TOKEN is empty (run 'make login')"
+if [[ -n "${VITE_DEV_TOKEN:-}" ]]; then
+  echo "Checking an authenticated route..."
+  curl --silent --show-error --max-time 10 \
+    -H "Authorization: Bearer ${VITE_DEV_TOKEN}" \
+    "$API_BASE_URL/api/me" >"$LOG_DIR/api-me.json" 2>"$LOG_DIR/api-me.err" \
+    || die "GET $API_BASE_URL/api/me could not be reached"
+  me_response="$(cat "$LOG_DIR/api-me.json")"
+  case "$me_response" in
+    *'"no-organization"'*)
+      die "GET $API_BASE_URL/api/me returned no-organization; the dev token's subject is not bound. Run 'make seed'."
+      ;;
+    *'"invalid-token"'*)
+      die "GET $API_BASE_URL/api/me rejected the dev token; it is expired or signed by another key. Run 'make login --force'."
+      ;;
+    *'"role"'*) ;;
+    *)
+      die "GET $API_BASE_URL/api/me did not return a principal; it returned: ${me_response:-<no response>}"
+      ;;
+  esac
+  authenticated_check="$API_BASE_URL/api/me resolves the seeded principal: $me_response"
+fi
+
 echo
 echo "Automated checks passed:"
 echo "  - PostgreSQL is ready and migrations are applied"
-echo "  - $API_BASE_URL/api/health reports healthy/connected"
+echo "  - $API_BASE_URL/api/health reports healthy/connected without a token"
 echo "  - $FRONTEND_URL/health is served by Vite"
 echo "  - frontend health page contains 'All systems operational'"
 echo "  - $FRONTEND_URL/api/health is proxied to the API, so connect-src 'self' suffices"
+echo "  - $authenticated_check"
 echo
 echo "Manual browser check: open $FRONTEND_URL/health and confirm"
 echo "  'All systems operational', 'Connected', and the current API version are visible."


### PR DESCRIPTION
<!--
Keep this short. CI reports the quality gates; do not restate them here.
-->

## What this implements

**Spec:** SPEC §<!-- e.g. 9.2, 8.2 --> — <!-- one line: which requirement -->

**ADR:** <!-- e.g. ADR 0007, or "none" if this change makes no architectural choice -->

Closes #<!-- issue number -->

## Notes for review

<!--
Anything a reviewer cannot see from the diff: a decision you had to make, a rejected
alternative, a limitation you accepted. Delete this section if there is nothing.
-->

## Checks

- [ ] This change adds no tenant-scoped table, **or** each new one has a factory registered in the
      entity registry (`AGENTS.md` → Standing rules 2).
- [ ] This change adds no endpoint, **or** each new one declares its required capability.
- [ ] Out-of-scope discoveries were filed as tracker issues rather than fixed here.
