### PR TITLE
88 dx 1 administrator invitation claim links are dead

### DIFF
--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -58,13 +58,18 @@ func run(ctx context.Context, args []string, databaseURL string, output io.Write
 	_, _ = fmt.Fprintf(output, "Organization: %s (%s)\n", result.OrganizationName, result.OrganizationID)
 	_, _ = fmt.Fprintf(output, "School year: %s\n", result.SchoolYearID)
 	_, _ = fmt.Fprintf(output, "Roster: %d students, %d adults, %d households\n", result.Students, result.Adults, result.Households)
-	_, _ = fmt.Fprintf(output, "Owner invitation claim URL: %s\n", result.ClaimURL)
-	_, _ = fmt.Fprintf(output, "Expires: %s\n", result.ExpiresAt.UTC().Format(time.RFC3339))
 	if bound := result.BoundOwner; bound != nil {
 		_, _ = fmt.Fprintf(output, "Bound provider subject: %s\n", bound.ProviderSubject)
 		_, _ = fmt.Fprintf(output, "Bound email: %s\n", bound.Email)
 		_, _ = fmt.Fprintf(output, "Bound organization: %s (%s)\n", bound.OrganizationName, bound.OrganizationID)
 		_, _ = fmt.Fprintf(output, "Bound role: %s\n", bound.Role)
+		// Deliberately no claim URL. The binding above consumed the invitation, so
+		// the URL is a dead link, and now that claim links resolve again someone
+		// would click it and be told the invitation is invalid.
+		_, _ = fmt.Fprintln(output, "Owner invitation: consumed by the binding above; it cannot be claimed again")
+		return nil
 	}
+	_, _ = fmt.Fprintf(output, "Owner invitation claim URL: %s\n", result.ClaimURL)
+	_, _ = fmt.Fprintf(output, "Expires: %s\n", result.ExpiresAt.UTC().Format(time.RFC3339))
 	return nil
 }

--- a/backend/internal/identity/bootstrap_test.go
+++ b/backend/internal/identity/bootstrap_test.go
@@ -28,3 +28,39 @@ func TestAddTokenToURLRejectsRelativeURL(t *testing.T) {
 		t.Fatal("relative claim URL unexpectedly succeeded")
 	}
 }
+
+// THE CLAIM URL CONTRACT, backend half. The token is the `token` query parameter
+// and the path is whatever INVITATION_CLAIM_BASE_URL supplied, unchanged. The
+// frontend half is pinned by the "invitation claim route" suite in
+// frontend/src/App.test.tsx, which renders the router at this exact shape.
+//
+// A shared literal asserted from both sides is the best available check here:
+// nothing generates this URL, so neither side can be derived from the other. The
+// two halves therefore reference each other by name, and moving one without the
+// other fails the opposite test rather than only production.
+//
+// This is the regression test for the defect where the builder emitted
+// /claim?token=… and the router matched /claim/:token, so every administrator
+// invitation link in every environment resolved to a not-found page.
+func TestClaimURLShapeMatchesTheFrontendRoute(t *testing.T) {
+	const base = "http://localhost:5173/claim"
+
+	claimURL, err := addTokenToURL(base, "invitation-token-value")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claimURL != base+"?token=invitation-token-value" {
+		t.Fatalf("claim URL = %q, want %q", claimURL, base+"?token=invitation-token-value")
+	}
+
+	parsed, err := url.Parse(claimURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Path != "/claim" {
+		t.Fatalf("claim path = %q, want /claim; the token must not become a path segment", parsed.Path)
+	}
+	if parsed.Query().Get("token") != "invitation-token-value" {
+		t.Fatalf("token query = %q, want invitation-token-value", parsed.Query().Get("token"))
+	}
+}

--- a/detent.yaml
+++ b/detent.yaml
@@ -71,7 +71,7 @@ workspace:
 deliverable:
     merge_method: squash
 agent:
-    max_concurrent_agents: 2
+    max_concurrent_agents: 1
     # Optional per-role reasoning defaults. Unset roles retain backend behavior.
     # effort:
     #   merge: high

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -106,4 +106,44 @@ describe('App routing', () => {
     expect(await screen.findByRole('heading', { name: 'School year not found' })).toBeInTheDocument()
     await waitFor(() => expect(screen.getByRole('link', { name: 'Back to school years' })).toHaveAttribute('href', '/years'))
   })
+
+  it('reports an unknown address without blaming a school year', async () => {
+    renderApp('/nonexistent', authenticatedClient())
+
+    expect(await screen.findByRole('heading', { name: 'Page not found' })).toBeInTheDocument()
+    expect(screen.queryByText(/school year/i)).not.toBeInTheDocument()
+  })
+})
+
+// THE CLAIM URL CONTRACT, frontend half. identity.addTokenToURL puts the token
+// in the `token` query parameter; the backend half of this contract is pinned by
+// TestClaimURLShapeMatchesTheFrontendRoute in
+// backend/internal/identity/bootstrap_test.go. The two tests hardcode the same
+// URL shape on purpose: nothing generates it, so a shared literal asserted from
+// both sides is what makes a one-sided move fail.
+describe('invitation claim route', () => {
+  it('accepts the URL shape the backend generates', async () => {
+    renderApp('/claim?token=invitation-token-value', authenticatedClient())
+
+    expect(await screen.findByRole('heading', { name: 'Claim your administrator invitation' })).toBeInTheDocument()
+  })
+
+  it('preserves the token when the base URL carried other query parameters', async () => {
+    renderApp('/claim?next=%2Fwelcome&token=invitation-token-value', authenticatedClient())
+
+    expect(await screen.findByRole('heading', { name: 'Claim your administrator invitation' })).toBeInTheDocument()
+  })
+
+  it('explains a link that arrives with no token instead of asking for a password', async () => {
+    renderApp('/claim', authenticatedClient())
+
+    expect(await screen.findByRole('heading', { name: 'This invitation link is incomplete' })).toBeInTheDocument()
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument()
+  })
+
+  it('no longer resolves the old path-segment shape', async () => {
+    renderApp('/claim/invitation-token-value', authenticatedClient())
+
+    expect(await screen.findByRole('heading', { name: 'Page not found' })).toBeInTheDocument()
+  })
 })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,8 @@ import { HealthCheck } from '@/features/health/HealthCheck'
 import { ClaimInvitationPage } from '@/features/auth/ClaimInvitationPage'
 import { ResetPasswordPage } from '@/features/auth/ResetPasswordPage'
 import { SignInPage } from '@/features/auth/SignInPage'
-import { SchoolYearGuard, SchoolYearListPage, SchoolYearNotFound, SchoolYearWorkspace } from '@/features/school-years/SchoolYearPages'
+import { NotFoundPage } from '@/features/errors/NotFoundPage'
+import { SchoolYearGuard, SchoolYearListPage, SchoolYearWorkspace } from '@/features/school-years/SchoolYearPages'
 import { SettingsPage } from '@/features/settings/SettingsPage'
 import { AdultDetailPage, AdultListPage, StudentDetailPage, StudentListPage } from '@/features/people/PeoplePages'
 import { HouseholdDetailPage, HouseholdListPage } from '@/features/people/HouseholdPages'
@@ -37,7 +38,9 @@ function AppRoutes() {
       <Route path="/health" element={<HealthCheck />} />
       <Route path="/sign-in" element={<SignInPage />} />
       <Route path="/reset-password" element={<ResetPasswordPage />} />
-      <Route path="/claim/:token" element={<ClaimInvitationPage />} />
+      {/* The token is a query parameter, matching identity.addTokenToURL. See
+          the contract note in ClaimInvitationPage. */}
+      <Route path="/claim" element={<ClaimInvitationPage />} />
       <Route element={<ProtectedRoute />}>
         <Route element={<AppShell />}>
           <Route path="/years" element={<SchoolYearListPage />} />
@@ -75,7 +78,7 @@ function AppRoutes() {
           <Route path="/audit-log" element={<AuditLog />} />
         </Route>
       </Route>
-      <Route path="*" element={<SchoolYearNotFound />} />
+      <Route path="*" element={<NotFoundPage />} />
     </Routes>
   )
 }

--- a/frontend/src/features/auth/ClaimInvitationPage.tsx
+++ b/frontend/src/features/auth/ClaimInvitationPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -9,8 +9,14 @@ import { useAuth } from '@/lib/hooks/useAuth'
 import { AuthErrorMessage, AuthLayout } from './AuthLayout'
 import { errorMessage } from './auth-utils'
 
+// THE CLAIM URL CONTRACT: the token is the `token` query parameter, not a path
+// segment. identity.addTokenToURL builds it that way, and it does so while
+// preserving any other query parameters already on INVITATION_CLAIM_BASE_URL.
+// Both sides are pinned by tests that reference each other:
+// backend/internal/identity/bootstrap_test.go and App.test.tsx.
 export function ClaimInvitationPage() {
-  const { token } = useParams<{ token: string }>()
+  const [searchParams] = useSearchParams()
+  const token = searchParams.get('token')
   const { authConfigured, isLoading, session, signIn, signUp } = useAuth()
   const navigate = useNavigate()
   const [email, setEmail] = useState('')
@@ -60,6 +66,22 @@ export function ClaimInvitationPage() {
 
   if (isLoading) {
     return <AuthLayout><p className="text-sm text-muted-foreground" role="status">Checking your session…</p></AuthLayout>
+  }
+
+  // Said before the form rather than on submit: a truncated link is the common
+  // way to arrive here, and asking for a password first only to reject it
+  // afterwards teaches the wrong lesson about which part was wrong.
+  if (!token) {
+    return (
+      <AuthLayout>
+        <h1 className="text-2xl font-semibold tracking-tight">This invitation link is incomplete</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          The link is missing its invitation token, so there is nothing to claim. Open the full link
+          from your invitation email, or ask an administrator to resend it.
+        </p>
+        <p className="mt-6 text-sm text-muted-foreground"><Link className="font-medium text-primary hover:underline" to="/sign-in">Back to sign in</Link></p>
+      </AuthLayout>
+    )
   }
 
   return (

--- a/frontend/src/features/errors/NotFoundPage.tsx
+++ b/frontend/src/features/errors/NotFoundPage.tsx
@@ -1,0 +1,25 @@
+import { Link } from 'react-router-dom'
+
+import { Button } from '@/components/ui/button'
+
+// The top-level catch-all. It used to render SchoolYearNotFound, so every
+// unmatched URL — including a claim link whose shape the router did not accept —
+// reported a school-year authorisation problem. That misdirection is what
+// disguised a dead invitation link as an access issue, so this page deliberately
+// says nothing about school years.
+//
+// SchoolYearNotFound remains correct inside /y/:schoolYearId, where a genuinely
+// missing or inaccessible year is the actual cause.
+export function NotFoundPage() {
+  return (
+    <main className="mx-auto w-full max-w-6xl px-6 py-10">
+      <p className="text-sm font-medium text-primary">Not found</p>
+      <h1 className="mt-2 text-3xl font-semibold tracking-tight">Page not found</h1>
+      <p className="mt-3 max-w-xl text-sm text-muted-foreground">
+        That address does not match anything in MiniClass. If you followed an invitation link, check
+        that it was copied in full.
+      </p>
+      <Button className="mt-6" asChild><Link to="/">Back to MiniClass</Link></Button>
+    </main>
+  )
+}


### PR DESCRIPTION
<!--
Keep this short. CI reports the quality gates; do not restate them here.
-->

## What this implements

**Spec:** SPEC §<!-- e.g. 9.2, 8.2 --> — <!-- one line: which requirement -->

**ADR:** <!-- e.g. ADR 0007, or "none" if this change makes no architectural choice -->

Closes #<!-- issue number -->

## Notes for review

<!--
Anything a reviewer cannot see from the diff: a decision you had to make, a rejected
alternative, a limitation you accepted. Delete this section if there is nothing.
-->

## Checks

- [ ] This change adds no tenant-scoped table, **or** each new one has a factory registered in the
      entity registry (`AGENTS.md` → Standing rules 2).
- [ ] This change adds no endpoint, **or** each new one declares its required capability.
- [ ] Out-of-scope discoveries were filed as tracker issues rather than fixed here.
