### PR TITLE
DX-5: add Developer tooling CI check

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -1,5 +1,13 @@
 # Detent handoff notes
 
+## Issue #92 developer tooling CI check
+
+- Added the tenth `Developer tooling` CI check, with `.env.example` sourcing validation, Compose/PostgreSQL role provisioning, `make setup`, unclaimed `make db-seed`, and `make smoke`; no path filters are used. Added it to `detent.yaml` and root `make check`, and updated `WORKFLOW.md`, README, and QUICKSTART documentation.
+- Extended `scripts/smoke-test.sh` to mint a temporary local JWT, follow the generated `/claim?token=...` URL through Vite, assert the frontend route/query contract, complete `POST /api/auth/claim` through the Vite proxy, and verify `/api/me` plus `/api/school-years`. It restores `.env` on exit and handles the normal already-bound Owner quickstart by inviting a synthetic administrator.
+- Focused validation passed: shell syntax, YAML parse, `.env.example` sourcing, Vite route-source runtime assertion, backend race tests (integration skipped without test DB URLs), backend lint/format, OpenAPI determinism, frontend tests (69), build, lint, and `git diff --check`.
+- Local full `make check` stopped at the pre-existing parent-checkout `miniclass-postgres` fixed-name conflict; migration round-trip lacks `MIGRATION_ROUNDTRIP_*`; local generation has sqlc v1.31.1 while the repository pins v1.27.0. CI must verify the isolated Developer tooling job and all ten checks.
+- PR/push and final current-head CI/review inspection remain open.
+
 
 ## Issue #64 merge fallback
 

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -6,7 +6,8 @@
 - Extended `scripts/smoke-test.sh` to mint a temporary local JWT, follow the generated `/claim?token=...` URL through Vite, assert the frontend route/query contract, complete `POST /api/auth/claim` through the Vite proxy, and verify `/api/me` plus `/api/school-years`. It restores `.env` on exit and handles the normal already-bound Owner quickstart by inviting a synthetic administrator.
 - Focused validation passed: shell syntax, YAML parse, `.env.example` sourcing, Vite route-source runtime assertion, backend race tests (integration skipped without test DB URLs), backend lint/format, OpenAPI determinism, frontend tests (69), build, lint, and `git diff --check`.
 - Local full `make check` stopped at the pre-existing parent-checkout `miniclass-postgres` fixed-name conflict; migration round-trip lacks `MIGRATION_ROUNDTRIP_*`; local generation has sqlc v1.31.1 while the repository pins v1.27.0. CI must verify the isolated Developer tooling job and all ten checks.
-- PR/push and final current-head CI/review inspection remain open.
+- PR #109 is open, non-draft, mergeable, references `Fixes #92`, and has no reviews or inline comments. Current-head CI run `33067515985` passed all ten checks, including Developer tooling; slowest were Generated code drift (1m30s), Backend tests (1m23s), and Backend lint (1m08s). Quiet-window wait was 0s; local merge-gate duration was about 0s after the already-running local checks; PR CI duration was about 1m34s; no post-merge main run is active.
+- This notes-only update must be pushed and its current-head checks rechecked before the final Workpad completion declaration.
 
 
 ## Issue #64 merge fallback

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,3 +204,42 @@ jobs:
         uses: actions/checkout@v4
       - name: Check diff formatting
         run: git diff --check
+
+  developer-tooling:
+    name: Developer tooling
+    runs-on: ubuntu-latest
+    env:
+      POSTGRES_ADMIN_DATABASE_URL: postgres://miniclass:miniclass_dev_password@localhost:5432/postgres?sslmode=disable
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - name: Check .env.example shell contract
+        run: ( set -a; . ./.env.example; set +a )
+      - name: Start PostgreSQL
+        run: docker compose up -d --wait postgres
+      - name: Provision database roles
+        run: |
+          psql "$POSTGRES_ADMIN_DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/scripts/init-roles.sql
+          psql "$POSTGRES_ADMIN_DATABASE_URL" -v ON_ERROR_STOP=1 -c "alter database miniclass owner to miniclass_migrator"
+      - name: Run setup
+        run: make setup
+      - name: Run db-seed and retain the claim URL
+        run: |
+          make db-seed SEED_OWNER_SUBJECT= | tee "$RUNNER_TEMP/seed-output.log"
+          claim_url="$(sed -n 's/^Owner invitation claim URL: //p' "$RUNNER_TEMP/seed-output.log")"
+          test -n "$claim_url"
+          echo "SMOKE_CLAIM_URL=$claim_url" >> "$GITHUB_ENV"
+      - name: Run smoke test
+        run: make smoke

--- a/Makefile
+++ b/Makefile
@@ -156,8 +156,8 @@ format: ## Check Go formatting and run the vet analyzer
 build-frontend: ## Type-check and build the production frontend bundle
 	@cd frontend && bun run build
 
-check: db-up ## Run all nine CI gates in CI order, failing fast
-	@echo "Running the nine gates CI publishes. Fail-fast; each failure names its CI check."
+check: db-up ## Run all ten CI gates in CI order, failing fast
+	@echo "Running the ten gates CI publishes. Fail-fast; each failure names its CI check."
 	$(call gate,Backend tests,$(MAKE) test-backend,fix the failing test)
 	$(call gate,Backend lint,$(MAKE) lint-backend,fix the reported findings then rerun 'make lint-backend')
 	$(call gate,Backend format,$(MAKE) format,run 'gofmt -w .' in backend/ and address the vet findings)
@@ -167,5 +167,6 @@ check: db-up ## Run all nine CI gates in CI order, failing fast
 	$(call gate,Frontend build,$(MAKE) build-frontend,fix the type or build error above)
 	$(call gate,Frontend lint,$(MAKE) lint-frontend,fix the reported findings then rerun 'make lint-frontend')
 	$(call gate,Repository formatting,git diff --check,remove the trailing whitespace or conflict marker it names)
+	$(call gate,Developer tooling,$(MAKE) smoke,fix the full-stack smoke-test failure)
 	@echo ""
-	@echo "All nine gates passed. This is what CI runs."
+	@echo "All ten gates passed. This is what CI runs."

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -43,13 +43,14 @@ make dev-frontend   # app on http://localhost:5173
 Open <http://localhost:5173>. You are signed in as `owner@example.test` in **Synthetic Academy**,
 with the Owner role and a roster of 139 synthetic students.
 
-Verify the whole stack, including the authenticated route, with:
+Verify the whole stack, including the invitation claim and authenticated routes, with:
 
 ```sh
 make smoke
 ```
 
-It starts its own API and Vite processes, so stop yours first.
+It starts its own API and Vite processes, so stop yours first. The check invites a synthetic
+administrator when the Owner created by `make db-seed` is already bound.
 
 ## What each command actually does
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ preference collection, constraint-based placement, and published class and dismi
 | [`PLAN.md`](./PLAN.md) | **When it gets built, and in what order.** Phases, milestones, exit criteria. |
 | [`docs/adr/`](./docs/adr/) | **Why it is built this way.** Architecture decisions, including the rejected alternatives. |
 | [`QUICKSTART.md`](./QUICKSTART.md) | The shortest path from a fresh clone to a logged-in local stack. |
-| [`WORKFLOW.md`](./WORKFLOW.md) | How agents pick up, validate and hand off work, and the nine quality gates. |
+| [`WORKFLOW.md`](./WORKFLOW.md) | How agents pick up, validate and hand off work, and the ten quality gates. |
 | [`AGENTS.md`](./AGENTS.md) | Repository rules that apply to every change. |
 | This file | How to run, drive and troubleshoot it locally. |
 
@@ -148,7 +148,10 @@ make smoke
 ```
 
 `make smoke` starts its own throwaway API and Vite processes, so stop yours first or it will report
-the ports as busy. It keeps logs in a temporary directory under `TMPDIR` and prints the path.
+the ports as busy. It follows an invitation claim URL through the frontend proxy and verifies the
+claimed account can list the seeded school year. On an empty migrated database it creates the
+unclaimed seed invitation itself; after `make db-seed` it invites a synthetic administrator instead.
+It keeps logs in a temporary directory under `TMPDIR` and prints the path.
 
 ## Development Commands
 
@@ -162,7 +165,7 @@ the ports as busy. It keeps logs in a temporary directory under `TMPDIR` and pri
 | `make setup` | Prepare a checkout: `.env`, signing keys, `bun install`, PostgreSQL, migrations |
 | `make tools-install` | Install the pinned Go tools (air, sqlc, goose, golangci-lint) |
 | `make generate` | Regenerate the committed backend artifacts (`internal/db/gen`, `openapi.json`) |
-| `make smoke` | Run the full-stack smoke test in throwaway processes |
+| `make smoke` | Run the full-stack smoke test in throwaway processes, including invitation claiming |
 
 **Database**
 
@@ -219,10 +222,11 @@ whether the token resolves to a principal.
 | `make lint-frontend` | Run ESLint |
 | `make format` | Check Go formatting and run the vet analyzer |
 | `make build-frontend` | Type-check and build the production frontend bundle |
-| `make check` | Run all nine CI gates in CI order, failing fast |
+| `make smoke` | Run the Developer tooling full-stack claim and login check |
+| `make check` | Run all ten CI gates in CI order, failing fast |
 
 `make format`, `make lint` and `make test` are the fast loop during work. `make check` is what to run
-before pushing: it reproduces the nine checks CI publishes, in CI order, and each failure names the
+before pushing: it reproduces the ten checks CI publishes, in CI order, and each failure names the
 CI check it maps to, for example:
 
 ```

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -12,7 +12,7 @@ declarations from that block; narrative sentences are never read as blockers.
 
 These are the project's required stage categories, each with the local command and
 the CI check name that satisfy it. Every local command runs from the repository
-root. `make check` runs all nine in this order, fails fast, and names the CI check
+root. `make check` runs all ten in this order, fails fast, and names the CI check
 each failure maps to; the rows below are for reproducing one gate on its own.
 Whichever change adds a check updates this table in the same pull request.
 
@@ -25,6 +25,7 @@ Whichever change adds a check updates this table in the same pull request.
 - Frontend build: local command `make build-frontend`; CI check `Frontend build`
 - Frontend lint: local command `make lint-frontend`; CI check `Frontend lint`
 - Repository formatting: local command `git diff --check`; CI check `Repository formatting`
+- Developer tooling: local command `make smoke`; CI check `Developer tooling`
 
 The local commands delegate to `backend/Makefile` and `frontend/package.json`,
 whose script names are unchanged, so the four CI jobs that run with

--- a/detent.yaml
+++ b/detent.yaml
@@ -165,6 +165,7 @@ gate:
         - Frontend build
         - Frontend lint
         - Repository formatting
+        - Developer tooling
     ci_failure_action: rework
     transient_ci_retry_limit: 2
     validator:

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -13,6 +13,10 @@ TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-60}"
 backend_pid=""
 frontend_pid=""
 compose_available=0
+env_backup=""
+env_modified=0
+seed_output=""
+claim_url="${SMOKE_CLAIM_URL:-}"
 
 cleanup() {
   status=$?
@@ -39,6 +43,10 @@ cleanup() {
     stop_process_tree "$pid"
   done
 
+  if [[ "$env_modified" -eq 1 && -n "$env_backup" && -f "$env_backup" ]]; then
+    cp "$env_backup" "$ENV_FILE" || true
+  fi
+
   exit "$status"
 }
 trap cleanup EXIT
@@ -51,6 +59,8 @@ compose_available=1
 # as an inline PEM key, is reported by name instead of reaching the shell as
 # "EC: command not found" and killing this script under set -e.
 load_env "$ENV_FILE"
+
+OWNER_EMAIL="${SMOKE_OWNER_EMAIL:-${DEV_ADMIN_EMAIL:-owner@example.test}}"
 
 POSTGRES_USER="${POSTGRES_USER:-miniclass}"
 POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-miniclass_dev_password}"
@@ -114,6 +124,22 @@ printf '%s' "$health_response" | grep -Eq '"database"[[:space:]]*:[[:space:]]*"c
   || die "GET $API_BASE_URL/api/health did not report a connected database; it returned: $health_response"
 echo "Backend health: $health_response"
 
+# Mint an unresolved local identity before starting Vite. The seed below binds
+# this identity through the same claim endpoint a browser uses. Keeping the
+# token in .env only for this process is necessary because frontend/package.json
+# sources that file before Vite starts; cleanup restores the developer's file.
+echo "Minting a temporary local identity for the claim check..."
+env_backup="$LOG_DIR/env.backup"
+cp "$ENV_FILE" "$env_backup" || die "could not back up $ENV_FILE"
+smoke_token="$(cd "$ROOT_DIR/backend" && go run ./cmd/devtoken \
+  -subject "$(dev_admin_subject "$OWNER_EMAIL")" \
+  -email "$OWNER_EMAIL" \
+  -lifetime 1h)" || die "could not mint the temporary claim-check token"
+[[ -n "$smoke_token" ]] || die "the temporary claim-check token was empty"
+env_modified=1
+env_set "$ENV_FILE" VITE_DEV_TOKEN "$smoke_token"
+export VITE_DEV_TOKEN="$smoke_token"
+
 echo "Starting frontend at $FRONTEND_URL..."
 (cd "$ROOT_DIR/frontend" && exec bun run dev -- --host 127.0.0.1) >"$LOG_DIR/frontend.log" 2>&1 &
 frontend_pid=$!
@@ -130,43 +156,94 @@ curl --fail --silent --show-error "$FRONTEND_URL/health" >"$LOG_DIR/frontend-hea
 grep -Fq 'All systems operational' "$ROOT_DIR/frontend/src/features/health/HealthCheck.tsx" \
   || die "frontend health page is missing the expected operational status"
 
-# The browser calls a relative /api because VITE_API_URL is empty, so the request
-# the client actually makes is same-origin on the Vite port and reaches the API
-# only through the dev proxy. Exercising that path here is what keeps the CSP's
-# connect-src at 'self' honest.
+if [[ -z "$claim_url" ]]; then
+  existing_me="$(curl --silent --show-error --max-time 10 \
+    -H "Authorization: Bearer $smoke_token" \
+    "$API_BASE_URL/api/me" 2>/dev/null || true)"
+  if printf '%s' "$existing_me" | grep -Eq '"role"[[:space:]]*:[[:space:]]*"'; then
+    # A normal developer run has already used make db-seed to bind the Owner.
+    # Invite a synthetic administrator so the smoke test remains repeatable
+    # without trying to create a second organization for the same subject.
+    claim_email="smoke-admin-$(date +%s)-$$@example.test"
+    echo "Creating a synthetic administrator invitation for the claim check..."
+    invitation_response="$(curl --fail --silent --show-error --max-time 10 \
+      -H "Authorization: Bearer $smoke_token" \
+      -H 'Content-Type: application/json' \
+      -d "{\"email\":\"$claim_email\",\"role\":\"administrator\"}" \
+      "$API_BASE_URL/api/administrators")" \
+      || die "could not create the smoke-test administrator invitation"
+    claim_url="$(printf '%s\n' "$invitation_response" | sed -n 's/.*"claim_url":"\([^"]*\)".*/\1/p')"
+    claim_bearer="$(cd "$ROOT_DIR/backend" && go run ./cmd/devtoken \
+      -subject "$(dev_admin_subject "$claim_email")" \
+      -email "$claim_email" \
+      -lifetime 1h)" || die "could not mint the synthetic administrator claim token"
+  else
+    echo "Seeding an unclaimed Owner invitation..."
+    seed_output="$(cd "$ROOT_DIR" && make db-seed SEED_OWNER_SUBJECT= 2>&1 | tee "$LOG_DIR/seed.log")" \
+      || die "could not create the smoke-test seed organization"
+    claim_url="$(printf '%s\n' "$seed_output" | sed -n 's/^Owner invitation claim URL: //p')"
+  fi
+fi
+[[ -n "$claim_url" ]] || die "the seed output did not contain an Owner invitation claim URL"
+
+claim_bearer="${claim_bearer:-$smoke_token}"
+claim_email="${claim_email:-$OWNER_EMAIL}"
+
+claim_token="$(printf '%s\n' "$claim_url" | sed -n 's/.*[?&]token=\([^&]*\).*/\1/p')"
+[[ -n "$claim_token" ]] || die "the claim URL has no token query parameter: $claim_url"
+
+# Vite's history fallback serves the application shell for the generated URL;
+# fetching it and its source modules proves the printed URL reaches the actual
+# claim route and that the route still reads the query parameter. This catches
+# the original backend/frontend path-vs-query regression before the API claim.
+echo "Following the invitation claim URL..."
+curl --fail --silent --show-error "$claim_url" >"$LOG_DIR/claim-page.html" 2>"$LOG_DIR/claim-page.err" \
+  || die "frontend did not serve the invitation claim URL $claim_url"
+grep -Fq '/src/main.tsx' "$LOG_DIR/claim-page.html" \
+  || die "the invitation claim URL did not return the frontend application shell"
+curl --fail --silent --show-error "$FRONTEND_URL/src/App.tsx" >"$LOG_DIR/app-source.tsx" 2>"$LOG_DIR/app-source.err" \
+  || die "could not inspect the frontend route source"
+grep -Fq '/claim"' "$LOG_DIR/app-source.tsx" \
+  || die "the frontend claim route no longer accepts the backend's /claim?token= URL"
+curl --fail --silent --show-error "$FRONTEND_URL/src/features/auth/ClaimInvitationPage.tsx" >"$LOG_DIR/claim-source.tsx" 2>"$LOG_DIR/claim-source.err" \
+  || die "could not inspect the frontend claim page source"
+grep -Fq 'useSearchParams' "$LOG_DIR/claim-source.tsx" \
+  || die "the frontend claim page no longer reads the invitation query parameter"
+
+echo "Completing the invitation claim through the Vite proxy..."
+curl --fail --silent --show-error --max-time 10 \
+  -H "Authorization: Bearer $claim_bearer" \
+  -H 'Content-Type: application/json' \
+  -d "{\"token\":\"$claim_token\"}" \
+  "$FRONTEND_URL/api/auth/claim" >"$LOG_DIR/claim-response.json" 2>"$LOG_DIR/claim-response.err" \
+  || die "the generated invitation claim could not be completed"
+
+echo "Checking the claimed identity and seeded school year through the Vite proxy..."
+curl --fail --silent --show-error --max-time 10 \
+  -H "Authorization: Bearer $claim_bearer" \
+  "$FRONTEND_URL/api/me" >"$LOG_DIR/api-me.json" 2>"$LOG_DIR/api-me.err" \
+  || die "GET $FRONTEND_URL/api/me failed after claiming the invitation"
+me_response="$(cat "$LOG_DIR/api-me.json")"
+printf '%s' "$me_response" | grep -Eq '"email"[[:space:]]*:[[:space:]]*"'"$claim_email"'"' \
+  || die "GET $FRONTEND_URL/api/me did not return the claimed email: $me_response"
+printf '%s' "$me_response" | grep -Eq '"role"[[:space:]]*:[[:space:]]*"(owner|administrator)"' \
+  || die "GET $FRONTEND_URL/api/me did not return an administrator membership: $me_response"
+curl --fail --silent --show-error --max-time 10 \
+  -H "Authorization: Bearer $claim_bearer" \
+  "$FRONTEND_URL/api/school-years" >"$LOG_DIR/school-years.json" 2>"$LOG_DIR/school-years.err" \
+  || die "GET $FRONTEND_URL/api/school-years failed after claiming the invitation"
+school_years_response="$(cat "$LOG_DIR/school-years.json")"
+printf '%s' "$school_years_response" | grep -Eq '"label"[[:space:]]*:[[:space:]]*"Synthetic School Year"' \
+  || die "GET $FRONTEND_URL/api/school-years did not return the seeded year: $school_years_response"
+
+# The browser calls a relative /api because VITE_API_URL is empty, so the
+# request the client actually makes is same-origin on the Vite port and reaches
+# the API only through this proxy.
 echo "Checking the Vite API proxy..."
 curl --fail --silent --show-error "$FRONTEND_URL/api/health" >"$LOG_DIR/proxied-api-health.json" 2>"$LOG_DIR/proxied-api-health.err" \
   || die "the Vite dev proxy did not forward $FRONTEND_URL/api/health to the API"
 grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"' "$LOG_DIR/proxied-api-health.json" \
   || die "GET $FRONTEND_URL/api/health did not report a healthy API"
-
-# GET /api/health is deliberately unauthenticated, so everything above proves
-# only that the process is up. Exercising one authenticated route is what proves
-# the whole local identity chain — signing key, token subject, seeded
-# organisation, bound membership — actually lines up. It is conditional because
-# the smoke test must not mutate the developer's database by seeding.
-authenticated_check="skipped: VITE_DEV_TOKEN is empty (run 'make token-mint')"
-if [[ -n "${VITE_DEV_TOKEN:-}" ]]; then
-  echo "Checking an authenticated route..."
-  curl --silent --show-error --max-time 10 \
-    -H "Authorization: Bearer ${VITE_DEV_TOKEN}" \
-    "$API_BASE_URL/api/me" >"$LOG_DIR/api-me.json" 2>"$LOG_DIR/api-me.err" \
-    || die "GET $API_BASE_URL/api/me could not be reached"
-  me_response="$(cat "$LOG_DIR/api-me.json")"
-  case "$me_response" in
-    *'"no-organization"'*)
-      die "GET $API_BASE_URL/api/me returned no-organization; the dev token's subject is not bound. Run 'make db-seed'."
-      ;;
-    *'"invalid-token"'*)
-      die "GET $API_BASE_URL/api/me rejected the dev token; it is expired or signed by another key. Run 'make token-mint FORCE=1'."
-      ;;
-    *'"role"'*) ;;
-    *)
-      die "GET $API_BASE_URL/api/me did not return a principal; it returned: ${me_response:-<no response>}"
-      ;;
-  esac
-  authenticated_check="$API_BASE_URL/api/me resolves the seeded principal: $me_response"
-fi
 
 echo
 echo "Automated checks passed:"
@@ -175,7 +252,10 @@ echo "  - $API_BASE_URL/api/health reports healthy/connected without a token"
 echo "  - $FRONTEND_URL/health is served by Vite"
 echo "  - frontend health page contains 'All systems operational'"
 echo "  - $FRONTEND_URL/api/health is proxied to the API, so connect-src 'self' suffices"
-echo "  - $authenticated_check"
+echo "  - $claim_url loads the frontend claim route"
+echo "  - the invitation claim completes through $FRONTEND_URL/api/auth/claim"
+echo "  - $FRONTEND_URL/api/me resolves the claimed administrator membership"
+echo "  - $FRONTEND_URL/api/school-years returns Synthetic School Year"
 echo
 echo "Manual browser check: open $FRONTEND_URL/health and confirm"
 echo "  'All systems operational', 'Connected', and the current API version are visible."


### PR DESCRIPTION
## Summary

- Add the tenth `Developer tooling` CI check, including the `.env.example` shell-sourcing assertion and Compose role provisioning.
- Extend the smoke test across the seed, generated invitation URL, frontend claim route, proxied claim API, `/api/me`, and seeded school-year list.
- Update root gates and developer documentation to agree with the ten CI checks.

## Validation

- Shell/YAML syntax, `.env.example` sourcing, Vite route-source assertion, and `git diff --check` pass.
- Backend race tests, lint, format, and OpenAPI determinism pass; frontend tests (69), build, and lint pass.
- The full Docker-backed smoke/migration path is for CI: this worker's parent checkout owns the fixed-name `miniclass-postgres` container, and its local checkout lacks the migration-round-trip URLs; local sqlc is v1.31.1 while the repository pins v1.27.0.

## Citation

ADR 0011 (local development orchestration and environment contract).

Fixes #92
