### PR TITLE
fix: connect API as miniclass_app

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -10,6 +10,22 @@
 - This notes-only update must be pushed and its current-head checks rechecked before the final Workpad completion declaration.
 
 
+## Issue #93 API database role separation
+
+- `DATABASE_URL` remains migrator-only for `cmd/migrate` and migration/reset operations. Added
+  required `APP_DATABASE_URL` for `cmd/api`, `cmd/seed`, and `cmd/bootstrap`.
+- `internal/data.NewApplicationFromURL` verifies `current_user = miniclass_app`, `nobypassrls`, and
+  no `CREATE` on `public`; `New` uses it. Generic `NewFromURL` remains for migrator/test paths.
+- Added config, startup, and integration coverage; updated `.env.example`, smoke script, and ADR 0011.
+- Full race backend suite, lint/depguard, format/vet, migration round-trip, generated OpenAPI drift,
+  shell syntax, and `git diff --check` pass. Root `make test-backend` was blocked by the shared fixed
+  `/miniclass-postgres` container name, while backend tests passed against that healthy PostgreSQL 18
+  service. Frontend tests/build/lint could not run because dependencies are absent and Bun temp writes
+  are denied; generated sqlc drift could not run because local sqlc is v1.31.1 vs pinned v1.27.0.
+- Open items: commit/push, open PR with `Fixes #93`, inspect current-head CI/reviews, then update the
+  Workpad and hand off. No skill draft planned; this is a scoped role/configuration fix.
+
+
 ## Issue #64 merge fallback
 
 - Rebased PR #82 onto current `origin/main` (`a723ef8`); resolved only the two expected conflicts.

--- a/.env.example
+++ b/.env.example
@@ -57,8 +57,9 @@ POSTGRES_PASSWORD=miniclass_dev_password
 POSTGRES_DB=miniclass
 POSTGRES_TEST_DB=miniclass_test
 
-# Database URLs: migrations/tests use the migrator role; the API uses the app role.
+# Database URLs: DATABASE_URL is migrator-only; the API, seed, and bootstrap use APP_DATABASE_URL.
 DATABASE_URL=postgres://miniclass_migrator:miniclass_migrator_dev_password@localhost:5432/miniclass?sslmode=disable
+APP_DATABASE_URL=postgres://miniclass_app:miniclass_app_dev_password@localhost:5432/miniclass?sslmode=disable
 TEST_DATABASE_URL=postgres://miniclass_migrator:miniclass_migrator_dev_password@localhost:5432/miniclass_test?sslmode=disable
 TEST_APP_DATABASE_URL=postgres://miniclass_app:miniclass_app_dev_password@localhost:5432/miniclass_test?sslmode=disable
 POSTGRES_ADMIN_DATABASE_URL=postgres://miniclass:miniclass_dev_password@localhost:5432/postgres?sslmode=disable

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -29,6 +29,7 @@ type httpServer interface {
 	Shutdown(context.Context) error
 }
 
+// main starts the API with the least-privileged miniclass_app database role.
 func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	if err := run(context.Background(), logger); err != nil {

--- a/backend/cmd/bootstrap/main.go
+++ b/backend/cmd/bootstrap/main.go
@@ -18,8 +18,10 @@ import (
 
 const defaultClaimBaseURL = "http://localhost:5173/claim"
 
+// main bootstraps application data through miniclass_app. Schema changes are
+// the separate responsibility of cmd/migrate and DATABASE_URL.
 func main() {
-	if err := run(context.Background(), os.Args[1:], os.Getenv("DATABASE_URL"), os.Stdout); err != nil {
+	if err := run(context.Background(), os.Args[1:], os.Getenv("APP_DATABASE_URL"), os.Stdout); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
@@ -27,7 +29,7 @@ func main() {
 
 func run(ctx context.Context, args []string, databaseURL string, output io.Writer) error {
 	if strings.TrimSpace(databaseURL) == "" {
-		return errors.New("bootstrap failed: DATABASE_URL is required")
+		return errors.New("bootstrap failed: APP_DATABASE_URL is required")
 	}
 	if output == nil {
 		return errors.New("bootstrap failed: output is nil")
@@ -52,12 +54,12 @@ func run(ctx context.Context, args []string, databaseURL string, output io.Write
 
 	// Validate the application configuration shape without creating an API
 	// server or acquiring any special database role.
-	cfg := config.Config{DatabaseURL: databaseURL, Port: "8080"}
+	cfg := config.Config{AppDatabaseURL: databaseURL, Port: "8080"}
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("bootstrap failed: %w", err)
 	}
 
-	database, err := data.NewFromURL(ctx, databaseURL)
+	database, err := data.NewApplicationFromURL(ctx, databaseURL)
 	if err != nil {
 		return fmt.Errorf("bootstrap failed: %w", err)
 	}

--- a/backend/cmd/migrate/main.go
+++ b/backend/cmd/migrate/main.go
@@ -1,4 +1,5 @@
-// Command migrate applies or rolls back Goose migrations.
+// Command migrate applies or rolls back Goose migrations through the
+// schema-owning miniclass_migrator role from DATABASE_URL.
 package main
 
 import (

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -17,8 +17,10 @@ import (
 
 const defaultClaimBaseURL = "http://localhost:5173/claim"
 
+// main loads application data through miniclass_app so seeding exercises the
+// same grants and row-level security as the API.
 func main() {
-	if err := run(context.Background(), os.Args[1:], os.Getenv("DATABASE_URL"), os.Stdout); err != nil {
+	if err := run(context.Background(), os.Args[1:], os.Getenv("APP_DATABASE_URL"), os.Stdout); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
@@ -26,7 +28,7 @@ func main() {
 
 func run(ctx context.Context, args []string, databaseURL string, output io.Writer) error {
 	if strings.TrimSpace(databaseURL) == "" {
-		return errors.New("seed failed: DATABASE_URL is required")
+		return errors.New("seed failed: APP_DATABASE_URL is required")
 	}
 	if output == nil {
 		return errors.New("seed failed: output is nil")
@@ -43,7 +45,7 @@ func run(ctx context.Context, args []string, databaseURL string, output io.Write
 	if err := flags.Parse(args); err != nil {
 		return fmt.Errorf("seed failed: %w", err)
 	}
-	database, err := data.NewFromURL(ctx, databaseURL)
+	database, err := data.NewApplicationFromURL(ctx, databaseURL)
 	if err != nil {
 		return fmt.Errorf("seed failed: connect database: %w", err)
 	}

--- a/backend/internal/auth/config_test.go
+++ b/backend/internal/auth/config_test.go
@@ -128,7 +128,7 @@ func setLocalAuthEnv(t *testing.T, values map[string]string) {
 	t.Setenv("AUTH_PROVIDER", "local")
 	t.Setenv("AUTH_ISSUER", "http://localhost:8080")
 	t.Setenv("AUTH_AUDIENCE", "authenticated")
-	t.Setenv("DATABASE_URL", "postgres://example")
+	t.Setenv("APP_DATABASE_URL", "postgres://example")
 }
 
 func loadConfig(t *testing.T) *config.Config {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	APIBaseURL             string
 	InvitationClaimBaseURL string
 	TrustedProxyCIDRs      []string
-	DatabaseURL            string
+	AppDatabaseURL         string
 	TestDatabaseURL        string
 	SupabaseURL            string
 	SupabaseAnonKey        string
@@ -100,7 +100,7 @@ func fromEnvironment() (*Config, error) {
 		APIBaseURL:             getEnv("API_BASE_URL", defaultAPIBaseURL),
 		InvitationClaimBaseURL: getEnv("INVITATION_CLAIM_BASE_URL", defaultInvitationClaimBaseURL),
 		TrustedProxyCIDRs:      getListEnv("TRUSTED_PROXY_CIDRS"),
-		DatabaseURL:            strings.TrimSpace(os.Getenv("DATABASE_URL")),
+		AppDatabaseURL:         strings.TrimSpace(os.Getenv("APP_DATABASE_URL")),
 		TestDatabaseURL:        strings.TrimSpace(os.Getenv("TEST_DATABASE_URL")),
 		SupabaseURL:            supabaseURL,
 		SupabaseAnonKey:        strings.TrimSpace(os.Getenv("SUPABASE_ANON_KEY")),
@@ -171,8 +171,8 @@ func getListEnv(key string) []string {
 
 // Validate checks the configuration required to start the API.
 func (c Config) Validate() error {
-	if strings.TrimSpace(c.DatabaseURL) == "" {
-		return fmt.Errorf("configuration error: DATABASE_URL is required")
+	if strings.TrimSpace(c.AppDatabaseURL) == "" {
+		return fmt.Errorf("configuration error: APP_DATABASE_URL is required")
 	}
 	if strings.TrimSpace(c.Port) == "" {
 		return fmt.Errorf("configuration error: PORT must not be empty")

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -13,12 +13,12 @@ const (
 )
 
 func TestLoadFromDotEnv(t *testing.T) {
-	for _, key := range []string{"APP_ENV", "APP_VERSION", "PORT", "API_BASE_URL", "INVITATION_CLAIM_BASE_URL", "TRUSTED_PROXY_CIDRS", "DATABASE_URL", "TEST_DATABASE_URL", "AUTH_PROVIDER", "AUTH_ISSUER", "AUTH_AUDIENCE", "AUTH_LOCAL_PUBLIC_KEY", "AUTH_LOCAL_PRIVATE_KEY", "AUTH_LOCAL_PUBLIC_KEY_FILE", "AUTH_LOCAL_PRIVATE_KEY_FILE", "AUTH_LOCAL_KEY_ID"} {
+	for _, key := range []string{"APP_ENV", "APP_VERSION", "PORT", "API_BASE_URL", "INVITATION_CLAIM_BASE_URL", "TRUSTED_PROXY_CIDRS", "DATABASE_URL", "APP_DATABASE_URL", "TEST_DATABASE_URL", "AUTH_PROVIDER", "AUTH_ISSUER", "AUTH_AUDIENCE", "AUTH_LOCAL_PUBLIC_KEY", "AUTH_LOCAL_PRIVATE_KEY", "AUTH_LOCAL_PUBLIC_KEY_FILE", "AUTH_LOCAL_PRIVATE_KEY_FILE", "AUTH_LOCAL_KEY_ID"} {
 		unsetEnv(t, key)
 	}
 
 	path := filepath.Join(t.TempDir(), ".env")
-	if err := os.WriteFile(path, []byte("APP_ENV=test\nPORT=9090\nDATABASE_URL=postgres://example\n"), 0600); err != nil {
+	if err := os.WriteFile(path, []byte("APP_ENV=test\nPORT=9090\nAPP_DATABASE_URL=postgres://example\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -26,7 +26,7 @@ func TestLoadFromDotEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadFrom() error = %v", err)
 	}
-	if cfg.AppEnv != "test" || cfg.Port != "9090" || cfg.DatabaseURL != "postgres://example" {
+	if cfg.AppEnv != "test" || cfg.Port != "9090" || cfg.AppDatabaseURL != "postgres://example" {
 		t.Fatalf("LoadFrom() = %#v", cfg)
 	}
 	if cfg.AppVersion != defaultAppVersion || cfg.APIBaseURL != defaultAPIBaseURL || cfg.InvitationClaimBaseURL != defaultInvitationClaimBaseURL {
@@ -37,10 +37,10 @@ func TestLoadFromDotEnv(t *testing.T) {
 func TestEnvironmentOverridesDotEnv(t *testing.T) {
 	unsetLocalAuthKeyFileEnv(t)
 	t.Setenv("PORT", "7070")
-	t.Setenv("DATABASE_URL", "postgres://environment")
+	t.Setenv("APP_DATABASE_URL", "postgres://environment")
 
 	path := filepath.Join(t.TempDir(), ".env")
-	if err := os.WriteFile(path, []byte("PORT=9090\nDATABASE_URL=postgres://file\n"), 0600); err != nil {
+	if err := os.WriteFile(path, []byte("PORT=9090\nAPP_DATABASE_URL=postgres://file\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -48,17 +48,17 @@ func TestEnvironmentOverridesDotEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadFrom() error = %v", err)
 	}
-	if cfg.Port != "7070" || cfg.DatabaseURL != "postgres://environment" {
+	if cfg.Port != "7070" || cfg.AppDatabaseURL != "postgres://environment" {
 		t.Fatalf("environment did not override dotenv: %#v", cfg)
 	}
 }
 
-func TestLoadRequiresDatabaseURL(t *testing.T) {
+func TestLoadRequiresAppDatabaseURL(t *testing.T) {
 	unsetLocalAuthKeyFileEnv(t)
-	unsetEnv(t, "DATABASE_URL")
+	unsetEnv(t, "APP_DATABASE_URL")
 
 	_, err := LoadFrom(filepath.Join(t.TempDir(), "missing.env"))
-	if err == nil || err.Error() != "configuration error: DATABASE_URL is required" {
+	if err == nil || err.Error() != "configuration error: APP_DATABASE_URL is required" {
 		t.Fatalf("LoadFrom() error = %v", err)
 	}
 }
@@ -73,7 +73,7 @@ func TestLoadReadsLocalAuthKeysFromFiles(t *testing.T) {
 	privateKeyPath := writeKeyFile(t, dir, "local_auth_private.pem", testPrivateKeyPEM)
 
 	path := filepath.Join(dir, ".env")
-	contents := "DATABASE_URL=postgres://example\n" +
+	contents := "APP_DATABASE_URL=postgres://example\n" +
 		"AUTH_LOCAL_PUBLIC_KEY_FILE=" + publicKeyPath + "\n" +
 		"AUTH_LOCAL_PRIVATE_KEY_FILE=" + privateKeyPath + "\n"
 	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
@@ -96,7 +96,7 @@ func TestLoadFallsBackToInlineLocalAuthKeys(t *testing.T) {
 	for _, key := range []string{"AUTH_LOCAL_PUBLIC_KEY_FILE", "AUTH_LOCAL_PRIVATE_KEY_FILE"} {
 		unsetEnv(t, key)
 	}
-	t.Setenv("DATABASE_URL", "postgres://example")
+	t.Setenv("APP_DATABASE_URL", "postgres://example")
 	t.Setenv("AUTH_LOCAL_PUBLIC_KEY", testPublicKeyPEM)
 	t.Setenv("AUTH_LOCAL_PRIVATE_KEY", testPrivateKeyPEM)
 
@@ -117,7 +117,7 @@ func TestLoadPrefersLocalAuthKeyFileOverInlineKey(t *testing.T) {
 	publicKeyPath := writeKeyFile(t, dir, "local_auth_public.pem", testPublicKeyPEM)
 	privateKeyPath := writeKeyFile(t, dir, "local_auth_private.pem", testPrivateKeyPEM)
 
-	t.Setenv("DATABASE_URL", "postgres://example")
+	t.Setenv("APP_DATABASE_URL", "postgres://example")
 	t.Setenv("AUTH_LOCAL_PUBLIC_KEY", "-----BEGIN PUBLIC KEY-----\naW5saW5l\n-----END PUBLIC KEY-----")
 	t.Setenv("AUTH_LOCAL_PRIVATE_KEY", "-----BEGIN EC PRIVATE KEY-----\naW5saW5l\n-----END EC PRIVATE KEY-----")
 	t.Setenv("AUTH_LOCAL_PUBLIC_KEY_FILE", publicKeyPath)
@@ -140,7 +140,7 @@ func TestLoadRejectsUnreadableLocalAuthKeyFile(t *testing.T) {
 	dir := t.TempDir()
 	missing := filepath.Join(dir, "absent.pem")
 
-	t.Setenv("DATABASE_URL", "postgres://example")
+	t.Setenv("APP_DATABASE_URL", "postgres://example")
 	t.Setenv("AUTH_LOCAL_PRIVATE_KEY", testPrivateKeyPEM)
 	t.Setenv("AUTH_LOCAL_PRIVATE_KEY_FILE", missing)
 
@@ -190,7 +190,7 @@ func unsetEnv(t *testing.T, key string) {
 }
 
 func TestConfigValidateRejectsEmptyPort(t *testing.T) {
-	err := (Config{DatabaseURL: "postgres://example"}).Validate()
+	err := (Config{AppDatabaseURL: "postgres://example"}).Validate()
 	if err == nil || err.Error() != "configuration error: PORT must not be empty" {
 		t.Fatalf("Validate() error = %v", err)
 	}
@@ -200,7 +200,7 @@ func TestLoadReadsTrustedProxyCIDRs(t *testing.T) {
 	unsetLocalAuthKeyFileEnv(t)
 	unsetEnv(t, "TRUSTED_PROXY_CIDRS")
 	path := filepath.Join(t.TempDir(), ".env")
-	if err := os.WriteFile(path, []byte("DATABASE_URL=postgres://example\nTRUSTED_PROXY_CIDRS=10.0.0.0/8, 192.0.2.10/32\n"), 0600); err != nil {
+	if err := os.WriteFile(path, []byte("APP_DATABASE_URL=postgres://example\nTRUSTED_PROXY_CIDRS=10.0.0.0/8, 192.0.2.10/32\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -214,7 +214,7 @@ func TestLoadReadsTrustedProxyCIDRs(t *testing.T) {
 }
 
 func TestConfigValidateRejectsInvalidTrustedProxyCIDR(t *testing.T) {
-	err := (Config{DatabaseURL: "postgres://example", Port: "8080", TrustedProxyCIDRs: []string{"not-a-cidr"}}).Validate()
+	err := (Config{AppDatabaseURL: "postgres://example", Port: "8080", TrustedProxyCIDRs: []string{"not-a-cidr"}}).Validate()
 	if err == nil || err.Error() != `configuration error: TRUSTED_PROXY_CIDRS contains invalid CIDR "not-a-cidr"` {
 		t.Fatalf("Validate() error = %v", err)
 	}

--- a/backend/internal/data/data.go
+++ b/backend/internal/data/data.go
@@ -40,12 +40,36 @@ func New(ctx context.Context, cfg *config.Config) (*DB, error) {
 		return nil, fmt.Errorf("create database: %w", err)
 	}
 
-	return NewFromURL(ctx, cfg.DatabaseURL)
+	return NewApplicationFromURL(ctx, cfg.AppDatabaseURL)
 }
 
 // NewFromURL creates and verifies a database connection pool from a PostgreSQL
-// connection string.
+// connection string. It is used by migration and test paths whose role is
+// intentionally not the API role.
 func NewFromURL(ctx context.Context, databaseURL string) (*DB, error) {
+	return newFromURL(ctx, databaseURL)
+}
+
+// NewApplicationFromURL creates an application connection pool and verifies
+// that it has the least-privileged API role. Keeping this check at connection
+// startup makes an API pointed at DATABASE_URL fail instead of silently
+// running with migrator privileges.
+func NewApplicationFromURL(ctx context.Context, databaseURL string) (*DB, error) {
+	if strings.TrimSpace(databaseURL) == "" {
+		return nil, errors.New("create application database: APP_DATABASE_URL is empty")
+	}
+	database, err := newFromURL(ctx, databaseURL)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyApplicationRole(ctx, database); err != nil {
+		database.Close()
+		return nil, fmt.Errorf("create application database: %w", err)
+	}
+	return database, nil
+}
+
+func newFromURL(ctx context.Context, databaseURL string) (*DB, error) {
 	if strings.TrimSpace(databaseURL) == "" {
 		return nil, errors.New("create database: DATABASE_URL is empty")
 	}
@@ -66,6 +90,31 @@ func NewFromURL(ctx context.Context, databaseURL string) (*DB, error) {
 	}
 
 	return database, nil
+}
+
+func verifyApplicationRole(ctx context.Context, database *DB) error {
+	var currentUser string
+	if err := database.pool.QueryRow(ctx, "select current_user").Scan(&currentUser); err != nil {
+		return fmt.Errorf("verify database role: %w", err)
+	}
+	if currentUser != "miniclass_app" {
+		return fmt.Errorf("verify database role: API must connect as miniclass_app, got %q", currentUser)
+	}
+
+	var bypassRLS, canCreateSchema bool
+	if err := database.pool.QueryRow(ctx, `
+		select r.rolbypassrls, has_schema_privilege(current_user, 'public', 'create')
+		from pg_roles r
+		where r.rolname = current_user`).Scan(&bypassRLS, &canCreateSchema); err != nil {
+		return fmt.Errorf("verify database role privileges: %w", err)
+	}
+	if bypassRLS {
+		return errors.New("verify database role: miniclass_app must not bypass row-level security")
+	}
+	if canCreateSchema {
+		return errors.New("verify database role: miniclass_app must not create objects in the public schema")
+	}
+	return nil
 }
 
 // PingDB verifies the database with the same query used by the health

--- a/backend/internal/data/data_test.go
+++ b/backend/internal/data/data_test.go
@@ -19,7 +19,7 @@ func TestNewRejectsInvalidConfiguration(t *testing.T) {
 	cfg := &config.Config{Port: "8080"}
 
 	_, err := New(context.Background(), cfg)
-	if err == nil || err.Error() != "create database: configuration error: DATABASE_URL is required" {
+	if err == nil || err.Error() != "create database: configuration error: APP_DATABASE_URL is required" {
 		t.Fatalf("New() error = %v", err)
 	}
 }

--- a/backend/internal/testing/harness.go
+++ b/backend/internal/testing/harness.go
@@ -80,7 +80,7 @@ func Open(t gotesting.TB) *Harness {
 	}
 	require.NoError(t, app.Ping(ctx))
 
-	database, err := data.NewFromURL(ctx, appSchemaURL)
+	database, err := data.NewApplicationFromURL(ctx, appSchemaURL)
 	require.NoError(t, err)
 	if err != nil {
 		return nil

--- a/backend/tests/integration/health_test.go
+++ b/backend/tests/integration/health_test.go
@@ -25,6 +25,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestApplicationDatabaseRequiresAppRole(t *testing.T) {
+	migratorURL := strings.TrimSpace(os.Getenv("TEST_DATABASE_URL"))
+	appURL := strings.TrimSpace(os.Getenv("TEST_APP_DATABASE_URL"))
+	if migratorURL == "" || appURL == "" {
+		t.Skip("TEST_DATABASE_URL and TEST_APP_DATABASE_URL are required for the PostgreSQL integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	applicationDatabase, err := data.NewApplicationFromURL(ctx, appURL)
+	require.NoError(t, err)
+	if err != nil {
+		return
+	}
+	t.Cleanup(applicationDatabase.Close)
+
+	var currentUser string
+	require.NoError(t, applicationDatabase.Pool().QueryRow(ctx, "select current_user").Scan(&currentUser))
+	require.Equal(t, "miniclass_app", currentUser)
+
+	_, err = data.NewApplicationFromURL(ctx, migratorURL)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "API must connect as miniclass_app")
+}
+
 func TestHealthIntegration(t *testing.T) {
 	testDatabaseURL := strings.TrimSpace(os.Getenv("TEST_DATABASE_URL"))
 	if testDatabaseURL == "" {

--- a/docs/adr/0011-local-development-orchestration-and-environment-contract.md
+++ b/docs/adr/0011-local-development-orchestration-and-environment-contract.md
@@ -77,8 +77,11 @@ makes `.env.example` and `.env` comparable, which is what lets `scripts/setup.sh
 exist in the example and are missing from a developer's older `.env` — the failure mode where a new
 variable reads as empty rather than as an error.
 
-`.env.example` is the single source of local defaults, including `DATABASE_URL` on
-`miniclass_migrator`. No script may restate a default that belongs in the example.
+`.env.example` is the single source of local defaults. `DATABASE_URL` is the
+`miniclass_migrator` connection used by `cmd/migrate` and database reset/round-trip
+operations. `APP_DATABASE_URL` is the `miniclass_app` connection used by `cmd/api`,
+`cmd/seed`, and `cmd/bootstrap`; those commands verify the role at startup. No
+script may restate a default that belongs in the example.
 
 ### Invariant: no `.env` value may contain whitespace or `#`
 
@@ -294,6 +297,9 @@ copy, keys are files and the two processes run in two terminals, nothing is left
   rather than `sh: EC: command not found` on one that was not.
 - A local `DATABASE_URL` now runs as `miniclass_migrator`, so row-level security is actually in force
   locally and an isolation defect can surface in development instead of first in CI.
+- The API, seed, and bootstrap commands use `APP_DATABASE_URL` and refuse a connection that is not
+  `miniclass_app` or that has bypass-RLS/schema-create privilege. Migrations and database reset stay
+  on `DATABASE_URL`, so schema ownership and application access are exercised separately.
 - Adding a variable means editing `.env.example`, and every developer's existing `.env` is then
   reported as missing it rather than silently reading it as empty.
 - **Any value that needs a space must become a file.** That is a real constraint on future

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -69,12 +69,13 @@ POSTGRES_PORT="${POSTGRES_PORT:-5432}"
 PORT="${PORT:-8080}"
 VITE_PORT="${VITE_PORT:-5173}"
 DATABASE_URL="${DATABASE_URL:-postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=disable}"
+[[ -n "${APP_DATABASE_URL:-}" ]] || die "APP_DATABASE_URL is required; see .env.example"
 API_BASE_URL="${API_BASE_URL:-http://localhost:${PORT}}"
 API_BASE_URL="${API_BASE_URL%/}"
 API_BASE_URL="${API_BASE_URL%/api}"
 FRONTEND_URL="http://localhost:${VITE_PORT}"
 
-export DATABASE_URL PORT API_BASE_URL
+export DATABASE_URL APP_DATABASE_URL PORT API_BASE_URL
 # The browser reaches the API through the Vite dev proxy, so the client's base
 # URL stays empty and only the node-side proxy target names the backend origin.
 # frontend/package.json's dev script re-sources .env, so these two agree with it


### PR DESCRIPTION
## Summary

- Add required `APP_DATABASE_URL` for API, seed, and bootstrap application connections.
- Keep `DATABASE_URL` explicitly migrator-only for migrations and database reset/round-trip operations.
- Verify application pools are `miniclass_app`, `nobypassrls`, and unable to create objects in `public`; reject migrator URLs at startup.
- Add configuration and PostgreSQL integration coverage and update the local environment ADR/smoke contract.

Fixes #93

## Specification and decisions

Implements the centralized, default-deny tenant guard in SPEC §9.2. Follows ADR 0007 (migrator/app role separation) and ADR 0011 (local environment contract).

## Validation

- Full race-enabled backend suite with PostgreSQL 18 and both roles: passed.
- Backend lint/depguard and format/vet: passed.
- Migration round-trip: passed.
- Generated OpenAPI drift, shell syntax, and `git diff --check`: passed.
- Local sqlc drift could not run because this worker has sqlc v1.31.1 while the repository pins v1.27.0.
- Frontend tests/build/lint could not run because frontend dependencies are absent and Bun cannot write its temp directory; CI will provide the frozen install.
