### PR TITLE
Fix local password reset under fake auth

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -1,5 +1,17 @@
 # Detent handoff notes
 
+## Issue #94 local fake-auth password reset
+
+- Added local-dev reset blocking in `frontend/src/features/auth/ResetPasswordPage.tsx`; it reuses
+  `LocalDevAuthBanner` with a no-email-path message and `make login` guidance. The real Supabase path
+  remains the existing reset form and success behavior.
+- Added parameterized coverage in `ResetPasswordPage.test.tsx` for valid/missing local tokens and a
+  real-Supabase submission.
+- `git diff --check` passes. Frontend test/build gates cannot start locally because the checkout lacks
+  the installed `openapi-typescript` dependency; frontend lint also hits Bun tempdir PermissionDenied.
+- Open items: commit/push, open PR with `Fixes #94` and ADR 0011 citation, inspect CI/reviews, and
+  update the Workpad after the required checks pass. Skill draft: no — routine auth-surface reuse.
+
 ## Issue #92 developer tooling CI check
 
 - Added the tenth `Developer tooling` CI check, with `.env.example` sourcing validation, Compose/PostgreSQL role provisioning, `make setup`, unclaimed `make db-seed`, and `make smoke`; no path filters are used. Added it to `detent.yaml` and root `make check`, and updated `WORKFLOW.md`, README, and QUICKSTART documentation.

--- a/frontend/src/features/auth/LocalDevAuthBanner.tsx
+++ b/frontend/src/features/auth/LocalDevAuthBanner.tsx
@@ -14,7 +14,22 @@ function reason(status: DevTokenStatus): string {
 // Shown in place of the sign-in form when the local fake-auth client has no
 // usable token. The form is not merely useless there, it is misleading: the
 // fake client accepts any password and then hands back no session.
-export function LocalDevAuthBanner({ status }: { status: DevTokenStatus }) {
+export function LocalDevAuthBanner({ status, passwordReset = false }: { status: DevTokenStatus; passwordReset?: boolean }) {
+  if (passwordReset) {
+    return (
+      <div className="rounded-md border-2 border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive" role="alert">
+        <p className="text-base font-semibold">Local development password reset is unavailable</p>
+        <p className="mt-2">
+          This build uses the local fake-auth client, which has no email path. Use <code className="rounded bg-destructive/15 px-1 py-0.5 font-mono font-semibold">make login</code> to obtain a local session instead.
+        </p>
+        <p className="mt-3">
+          Then restart the Vite dev server. VITE_* values are inlined when the dev server starts, so a new
+          .env value is not picked up by an HMR update alone.
+        </p>
+      </div>
+    )
+  }
+
   return (
     <div className="rounded-md border-2 border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive" role="alert">
       <p className="text-base font-semibold">Local development authentication has no token</p>

--- a/frontend/src/features/auth/ResetPasswordPage.test.tsx
+++ b/frontend/src/features/auth/ResetPasswordPage.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AuthClient, DevTokenStatus } from '@/lib/auth'
+import { AuthProvider } from '@/lib/hooks/AuthProvider'
+
+import { ResetPasswordPage } from './ResetPasswordPage'
+
+function authClient(): AuthClient {
+  return {
+    auth: {
+      getSession: vi.fn(async () => ({ data: { session: null }, error: null })),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+      resetPasswordForEmail: vi.fn(async () => ({ data: {}, error: null })),
+    },
+  } as unknown as AuthClient
+}
+
+function renderReset(props: { localDevAuth: boolean; devToken: DevTokenStatus }) {
+  return render(
+    <MemoryRouter initialEntries={['/reset-password']}>
+      <AuthProvider client={authClient()}>
+        <ResetPasswordPage {...props} />
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('reset-password page authentication paths', () => {
+  it.each([
+    { localDevAuth: true, devToken: { kind: 'valid', expiresAt: new Date('2099-01-01T00:00:00Z') } as DevTokenStatus },
+    { localDevAuth: true, devToken: { kind: 'missing' } as DevTokenStatus },
+  ])('does not report success under the local fake-auth client', async (props) => {
+    renderReset(props)
+
+    const banner = await screen.findByRole('alert')
+    expect(banner).toHaveTextContent('local fake-auth client')
+    expect(banner).toHaveTextContent('no email path')
+    expect(banner).toHaveTextContent('make login')
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Email')).not.toBeInTheDocument()
+  })
+
+  it('keeps the reset form and success response on the real Supabase path', async () => {
+    const client = authClient()
+    render(
+      <MemoryRouter initialEntries={['/reset-password']}>
+        <AuthProvider client={client}>
+          <ResetPasswordPage localDevAuth={false} devToken={{ kind: 'missing' }} />
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+
+    fireEvent.change(await screen.findByLabelText('Email'), { target: { value: 'admin@example.test' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send reset link' }))
+
+    expect(await screen.findByRole('status')).toHaveTextContent('If that address is an administrator account')
+    expect((client.auth.resetPasswordForEmail as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
+      'admin@example.test',
+      expect.objectContaining({ redirectTo: expect.stringContaining('/reset-password') }),
+    )
+  })
+})

--- a/frontend/src/features/auth/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/ResetPasswordPage.tsx
@@ -3,12 +3,19 @@ import { Link } from 'react-router-dom'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { devTokenStatus, isLocalDevAuth, type DevTokenStatus } from '@/lib/auth'
 import { useAuth } from '@/lib/hooks/useAuth'
 
 import { AuthErrorMessage, AuthLayout } from './AuthLayout'
+import { LocalDevAuthBanner } from './LocalDevAuthBanner'
 import { errorMessage } from './auth-utils'
 
-export function ResetPasswordPage() {
+type ResetPasswordPageProps = {
+  localDevAuth?: boolean
+  devToken?: DevTokenStatus
+}
+
+export function ResetPasswordPage({ localDevAuth = isLocalDevAuth, devToken = devTokenStatus }: ResetPasswordPageProps = {}) {
   const { authConfigured, resetPassword } = useAuth()
   const [email, setEmail] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -29,6 +36,8 @@ export function ResetPasswordPage() {
     }
   }
 
+  const localDevResetBlocked = localDevAuth && authConfigured
+
   return (
     <AuthLayout>
       <h1 className="text-2xl font-semibold tracking-tight">Reset your password</h1>
@@ -38,13 +47,19 @@ export function ResetPasswordPage() {
         {error && <AuthErrorMessage message={error} />}
         {sent && <p className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800" role="status">If that address is an administrator account, a reset link is on its way.</p>}
       </div>
-      <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
-        <label className="block space-y-2 text-sm font-medium" htmlFor="reset-email">
-          Email
-          <Input id="reset-email" name="email" type="email" autoComplete="email" required value={email} onChange={(event) => setEmail(event.target.value)} />
-        </label>
-        <Button className="w-full" type="submit" disabled={isSubmitting || !authConfigured}>{isSubmitting ? 'Sending…' : 'Send reset link'}</Button>
-      </form>
+      {localDevResetBlocked ? (
+        <div className="mt-6">
+          <LocalDevAuthBanner passwordReset status={devToken} />
+        </div>
+      ) : (
+        <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+          <label className="block space-y-2 text-sm font-medium" htmlFor="reset-email">
+            Email
+            <Input id="reset-email" name="email" type="email" autoComplete="email" required value={email} onChange={(event) => setEmail(event.target.value)} />
+          </label>
+          <Button className="w-full" type="submit" disabled={isSubmitting || !authConfigured}>{isSubmitting ? 'Sending…' : 'Send reset link'}</Button>
+        </form>
+      )}
       <p className="mt-6 text-sm text-muted-foreground"><Link className="font-medium text-primary hover:underline" to="/sign-in">Back to sign in</Link></p>
     </AuthLayout>
   )


### PR DESCRIPTION
## Summary

- Show an explicit local-development password-reset unavailable message when `localdevkey` selects the fake-auth client.
- Tell developers to use `make login` for a local session instead of claiming an email was sent.
- Keep the real Supabase reset form and response unchanged, with parameterized regression coverage for both paths.

## Spec / ADR citation

Implements ADR 0011 (local development orchestration and environment contract); no `SPEC.md` section applies because this is developer tooling behavior.

Fixes #94
