### PR TITLE
fix: surface session expiry instead of silent 401s

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -12,6 +12,31 @@
 - Open items: commit/push, open PR with `Fixes #94` and ADR 0011 citation, inspect CI/reviews, and
   update the Workpad after the required checks pass. Skill draft: no — routine auth-surface reuse.
 
+## Issue #95 mid-session token expiry
+
+- The frontend now re-checks local fake-auth JWT expiry on a timer and on token reads. At `exp`, it
+  emits a session-ended event, signs out the fake client, and redirects the auth shell to the existing
+  local banner naming `make login` and the required Vite restart.
+- The API boundary emits the same event only for HTTP 401 responses with RFC 9457 type
+  `invalid-token`; the auth provider clears the session, calls Supabase `signOut`, and the sign-in page
+  explains that the session expired or is no longer valid. ADR 0009 records this decision.
+- Added API event, provider/surface, and fake-clock boundary coverage. Focused frontend auth/API tests
+  pass (21), and the full frontend test gate passes (83); frontend build and lint also pass.
+- The preserved commit was rebased onto current `origin/main` at `14ea2e0`; the only conflict was this
+  handoff-notes file, with both the #94 and #95 entries retained. Backend race tests, backend lint,
+  backend format/vet, and `git diff --check` pass.
+- Local `make test-backend` is blocked by the pre-existing fixed-name `miniclass-postgres` Docker
+  container conflict; direct `go test -race -v ./... -count=1` passes with DB integration cases skipped.
+  `make generate` is blocked by local sqlc v1.31.1 versus pinned v1.27.0; migration round-trip lacks
+  `MIGRATION_ROUNDTRIP_DATABASE_URL`; `make smoke` lacks the checkout `.env`. CI must verify the
+  required current-head checks after push.
+- PR #114 is open, non-draft, mergeable, references `Fixes #95`, and cites SPEC §9.3 plus ADR 0009.
+  Current head `4280936b` passed all ten required checks in run `33126534875`; no reviews or inline
+  comments remain. CI duration was about 87s; slowest checks were Backend tests (83s), Backend lint
+  (80s), and Generated code drift (76s). Quiet-window wait was 0s; local final merge gate was under
+  1s; latest main CI is successful and no post-merge run is active.
+- Skill draft: no — this is a scoped auth lifecycle fix using existing frontend and ADR patterns.
+
 ## Issue #92 developer tooling CI check
 
 - Added the tenth `Developer tooling` CI check, with `.env.example` sourcing validation, Compose/PostgreSQL role provisioning, `make setup`, unclaimed `make db-seed`, and `make smoke`; no path filters are used. Added it to `detent.yaml` and root `make check`, and updated `WORKFLOW.md`, README, and QUICKSTART documentation.

--- a/docs/adr/0009-administrator-sessions-and-identity-provider.md
+++ b/docs/adr/0009-administrator-sessions-and-identity-provider.md
@@ -54,6 +54,14 @@ to Go; it does not talk to Supabase directly". The corrected statement is: *the 
 Supabase for authentication only; every data path goes through Go.* ADR 0001's actual rationale — one
 tenancy guard, one authorization implementation, one audit log — is untouched.
 
+**3a. An API rejection ends the browser session.** The frontend API boundary treats only a `401`
+response whose RFC 9457 type is `invalid-token` as a terminal session signal. It clears the auth
+shell session, asks Supabase to sign out so a rejected persisted session is not reused after reload,
+and sends the person to the sign-in surface with an explanation. Other `401` problems, including a
+missing bearer, remain ordinary API errors; a request-level response is not enough evidence that a
+renewable Supabase session has ended. The local fake client applies the same session-ended path at
+the JWT `exp` boundary and tells the developer to run `make login` and restart Vite.
+
 **4. Administrators are provisioned by invitation, never just-in-time.** A verified subject with no
 application record gets nothing; otherwise anyone able to sign up to the project becomes a user.
 

--- a/frontend/src/features/auth/SignInPage.test.tsx
+++ b/frontend/src/features/auth/SignInPage.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { AuthClient, DevTokenStatus } from '@/lib/auth'
+import { createLocalDevAuthClient, reportSessionEnded, type AuthClient, type DevTokenStatus } from '@/lib/auth'
 import { AuthProvider } from '@/lib/hooks/AuthProvider'
+import { useAuth } from '@/lib/hooks/useAuth'
 
 import { SignInPage } from './SignInPage'
 
@@ -15,6 +16,7 @@ function sessionlessClient(): AuthClient {
       getSession: vi.fn(async () => ({ data: { session: null }, error: null })),
       onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
       signInWithPassword: vi.fn(async () => ({ data: { session: null, user: null }, error: null })),
+      signOut: vi.fn(async () => ({ error: null })),
     },
   } as unknown as AuthClient
 }
@@ -28,6 +30,23 @@ function renderSignIn(props: { localDevAuth: boolean; devToken: DevTokenStatus }
     </MemoryRouter>,
   )
 }
+
+function base64url(value: unknown): string {
+  return btoa(JSON.stringify(value)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function token(payload: Record<string, unknown>): string {
+  return `${base64url({ alg: 'ES256', kid: 'local', typ: 'JWT' })}.${base64url(payload)}.c2lnbmF0dXJl`
+}
+
+function SessionSurface({ devToken }: { devToken: DevTokenStatus }) {
+  const { session } = useAuth()
+  return session ? <p>Authenticated session</p> : <SignInPage localDevAuth devToken={devToken} />
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 describe('sign-in page under local development auth', () => {
   it('replaces the form with a banner naming make login when no token is set', async () => {
@@ -79,5 +98,53 @@ describe('sign-in page under local development auth', () => {
     expect(await screen.findByLabelText('Password')).toBeInTheDocument()
     expect(screen.getByLabelText('Email')).toBeInTheDocument()
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('changes the visible surface when a local session crosses its expiry boundary', async () => {
+    vi.useFakeTimers()
+    const now = new Date('2026-08-25T12:00:00Z')
+    vi.setSystemTime(now)
+    const expiresAt = new Date(now.getTime() + 1000)
+    const localToken = token({ exp: expiresAt.getTime() / 1000 })
+    const client = createLocalDevAuthClient(localToken, { kind: 'valid', expiresAt }) as AuthClient
+
+    render(
+      <MemoryRouter initialEntries={['/sign-in']}>
+        <AuthProvider client={client}>
+          <SessionSurface devToken={{ kind: 'valid', expiresAt }} />
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+
+    await act(async () => {})
+    expect(screen.getByText('Authenticated session')).toBeInTheDocument()
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    const banner = screen.getByRole('alert')
+    expect(banner).toHaveTextContent(/VITE_DEV_TOKEN expired on .*2026/)
+    expect(banner).toHaveTextContent('make login')
+    expect(screen.queryByText('Authenticated session')).not.toBeInTheDocument()
+  })
+
+  it('explains an API-invalid session and signs out the persisted client', async () => {
+    const client = sessionlessClient()
+    render(
+      <MemoryRouter initialEntries={['/sign-in']}>
+        <AuthProvider client={client}>
+          <SignInPage />
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+
+    await act(async () => {})
+    await act(async () => {
+      reportSessionEnded({ kind: 'api-invalid-token' })
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Your session expired or is no longer valid. Please sign in again.')
+    expect(client.auth.signOut).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/features/auth/SignInPage.tsx
+++ b/frontend/src/features/auth/SignInPage.tsx
@@ -1,9 +1,9 @@
-import { useState, type FormEvent } from 'react'
+import { useEffect, useState, type FormEvent } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { devTokenStatus, isLocalDevAuth, type DevTokenStatus } from '@/lib/auth'
+import { devTokenStatus, getDevTokenStatus, isLocalDevAuth, type DevTokenStatus } from '@/lib/auth'
 import { useAuth } from '@/lib/hooks/useAuth'
 
 import { AuthErrorMessage, AuthLayout } from './AuthLayout'
@@ -21,8 +21,33 @@ type SignInPageProps = {
   devToken?: DevTokenStatus
 }
 
-export function SignInPage({ localDevAuth = isLocalDevAuth, devToken = devTokenStatus }: SignInPageProps = {}) {
-  const { authConfigured, authError, isLoading, signIn } = useAuth()
+function useRuntimeDevTokenStatus(enabled: boolean): DevTokenStatus {
+  const [status, setStatus] = useState(devTokenStatus)
+
+  useEffect(() => {
+    if (!enabled) return
+
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const refresh = () => {
+      const next = getDevTokenStatus()
+      setStatus(next)
+      if (next.kind === 'valid') {
+        timer = setTimeout(refresh, Math.max(0, next.expiresAt.getTime() - Date.now()))
+      }
+    }
+
+    refresh()
+    return () => {
+      if (timer !== undefined) clearTimeout(timer)
+    }
+  }, [enabled])
+
+  return status
+}
+
+export function SignInPage({ localDevAuth = isLocalDevAuth, devToken }: SignInPageProps = {}) {
+  const { authConfigured, authError, isLoading, sessionEndedReason, signIn } = useAuth()
+  const runtimeDevToken = useRuntimeDevTokenStatus(localDevAuth && devToken === undefined)
   const location = useLocation()
   const navigate = useNavigate()
   const [email, setEmail] = useState('')
@@ -47,7 +72,11 @@ export function SignInPage({ localDevAuth = isLocalDevAuth, devToken = devTokenS
 
   // With no auth client at all there is nothing to explain about a dev token:
   // the missing configuration is the accurate message.
-  const devTokenBlocks = localDevAuth && authConfigured && devToken.kind !== 'valid'
+  const configuredDevToken = devToken ?? runtimeDevToken
+  const displayedDevToken = sessionEndedReason?.kind === 'local-dev-token-expired'
+    ? { kind: 'expired' as const, expiresAt: sessionEndedReason.expiresAt }
+    : configuredDevToken
+  const devTokenBlocks = localDevAuth && authConfigured && displayedDevToken.kind !== 'valid'
 
   return (
     <AuthLayout>
@@ -58,6 +87,7 @@ export function SignInPage({ localDevAuth = isLocalDevAuth, devToken = devTokenS
 
       <div className="mt-6 space-y-3">
         {!authConfigured && <AuthErrorMessage message="Authentication is not configured for this site." />}
+        {sessionEndedReason?.kind === 'api-invalid-token' && <AuthErrorMessage message="Your session expired or is no longer valid. Please sign in again." />}
         {authError && <AuthErrorMessage message={authError.message ?? ''} /> }
         {error && <AuthErrorMessage message={error} />}
       </div>
@@ -65,7 +95,7 @@ export function SignInPage({ localDevAuth = isLocalDevAuth, devToken = devTokenS
       {devTokenBlocks ? (
         <>
           <div className="mt-6">
-            <LocalDevAuthBanner status={devToken} />
+            <LocalDevAuthBanner status={displayedDevToken} />
           </div>
 
           {/* /health is the one route that works without a session. */}

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { ApiError, createApiClient, fieldErrorMap, unwrap, unwrapList, unwrapNoContent } from './api'
+import { onSessionEnded } from './auth'
 
 // These tests drive the real request-assembly path: a stub `fetch` receives the
 // Request the client actually built, so the URL, the method, the headers and the
@@ -150,6 +151,23 @@ describe('response handling', () => {
       status: 502,
       message: 'The API request failed with status 502',
     })
+  })
+
+  it('reports an invalid bearer as a terminal session event', async () => {
+    const ended = vi.fn()
+    const unsubscribe = onSessionEnded(ended)
+    try {
+      const { client } = stubClient(() => new Response(JSON.stringify({
+        type: 'invalid-token',
+        title: 'Invalid token',
+        detail: 'the bearer token is invalid',
+      }), { status: 401, headers: { 'Content-Type': 'application/problem+json' } }))
+
+      await expect(unwrap(client.GET('/api/me'))).rejects.toMatchObject({ status: 401, code: 'invalid-token' })
+      expect(ended).toHaveBeenCalledWith({ kind: 'api-invalid-token' })
+    } finally {
+      unsubscribe()
+    }
   })
 })
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,7 @@
 import createClient, { type Client, type Middleware } from 'openapi-fetch'
 
 import type { components, paths } from './api.generated'
-import { getAccessToken as sessionAccessToken } from './auth'
+import { getAccessToken as sessionAccessToken, reportSessionEnded } from './auth'
 
 // This module is the only place in the frontend where a URL, a header and a
 // body meet. Everything else declares calls as typed wrappers over the client
@@ -105,6 +105,9 @@ type ApiResult<D> = {
 function problemError(response: Response, problem: unknown): ApiError {
   const details = (problem ?? undefined) as ProblemDetails | undefined
   const message = details?.detail ?? details?.title ?? `The API request failed with status ${response.status}`
+  if (response.status === 401 && details?.type === 'invalid-token') {
+    reportSessionEnded({ kind: 'api-invalid-token' })
+  }
   return new ApiError('http', message, response.status, details?.type, details?.errors ?? [])
 }
 

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -14,6 +14,24 @@ export type DevTokenStatus =
   | { kind: 'expired'; expiresAt: Date }
   | { kind: 'valid'; expiresAt: Date }
 
+export type SessionEndedReason =
+  | { kind: 'local-dev-token-expired'; expiresAt: Date }
+  | { kind: 'api-invalid-token' }
+
+type SessionEndedListener = (reason: SessionEndedReason) => void
+const sessionEndedListeners = new Set<SessionEndedListener>()
+
+export function onSessionEnded(listener: SessionEndedListener): () => void {
+  sessionEndedListeners.add(listener)
+  return () => sessionEndedListeners.delete(listener)
+}
+
+export function reportSessionEnded(reason: SessionEndedReason): void {
+  for (const listener of sessionEndedListeners) {
+    listener(reason)
+  }
+}
+
 // Reads a JWT payload without verifying the signature, which a browser cannot
 // do and the API does on every request anyway.
 function decodeTokenPayload(token: string): Record<string, unknown> | null {
@@ -45,11 +63,14 @@ export function inspectDevToken(token: string | undefined, now: Date): DevTokenS
     : { kind: 'valid', expiresAt }
 }
 
-// Evaluated once, like every other VITE_* read: the token is inlined when the
-// dev server starts. A token that expires mid-session therefore still produces
-// unexplained 401s until a reload; the banner addresses the common case of
-// starting the dev server without a usable token.
+// This value preserves the startup diagnostic for callers such as the sign-in
+// page. Runtime consumers should use getDevTokenStatus so expiry is
+// re-evaluated after the Vite process has started.
 export const devTokenStatus = inspectDevToken(devToken, new Date())
+
+export function getDevTokenStatus(now = new Date()): DevTokenStatus {
+  return inspectDevToken(devToken, now)
+}
 
 // Export a runtime-initialized client. For local development we support a
 // lightweight fake-auth client when the special dev anon key is used. This
@@ -58,11 +79,10 @@ export let supabase: SupabaseClient | null = null
 
 // Minimal fake client implementing the small supabase auth surface the app
 // uses. It stores a single session derived from a provided JWT (VITE_DEV_TOKEN).
-function makeFakeClient(token: string | undefined, status: DevTokenStatus) {
+export function createLocalDevAuthClient(token: string | undefined, status: DevTokenStatus) {
   // Only a usable token becomes a session. There is no refresh path here, so a
-  // fabricated session for an expired or unreadable token would present as an
-  // authenticated app whose every request fails with 401 invalid-token.
-  const session: Session | null = token && status.kind === 'valid'
+  // local expiry is a terminal session event rather than a silent API failure.
+  let session: Session | null = token && status.kind === 'valid'
     ? {
         access_token: token,
         token_type: 'bearer',
@@ -82,23 +102,67 @@ function makeFakeClient(token: string | undefined, status: DevTokenStatus) {
     }
   }
 
+  const listeners = new Set<(event: AuthChangeEvent, nextSession: Session | null) => void>()
+  let expirationTimer: ReturnType<typeof setTimeout> | undefined
+
+  function notify(event: AuthChangeEvent, nextSession: Session | null) {
+    for (const listener of listeners) {
+      listener(event, nextSession)
+    }
+  }
+
+  function expireIfNeeded() {
+    if (!session || !session.expires_at || Date.now() < session.expires_at * 1000) {
+      return
+    }
+    const expiresAt = new Date(session.expires_at * 1000)
+    session = null
+    if (expirationTimer !== undefined) {
+      clearTimeout(expirationTimer)
+      expirationTimer = undefined
+    }
+    reportSessionEnded({ kind: 'local-dev-token-expired', expiresAt })
+    notify('SIGNED_OUT', null)
+  }
+
+  function scheduleExpiration() {
+    if (!session?.expires_at) return
+    const delay = Math.max(0, session.expires_at * 1000 - Date.now())
+    expirationTimer = setTimeout(() => {
+      expireIfNeeded()
+      if (session) scheduleExpiration()
+    }, delay)
+  }
+
+  scheduleExpiration()
+
   return {
     auth: {
       async getSession() {
+        expireIfNeeded()
         return { data: { session }, error: null }
       },
-      onAuthStateChange() {
-        // Return a noop unsubscribe compatible shape
-        return { data: { subscription: { unsubscribe: () => {} } } }
+      onAuthStateChange(callback: (event: AuthChangeEvent, nextSession: Session | null) => void) {
+        listeners.add(callback)
+        return { data: { subscription: { unsubscribe: () => listeners.delete(callback) } } }
       },
       async signInWithPassword() {
         // In dev mode accept any credentials and return the session derived from VITE_DEV_TOKEN.
+        expireIfNeeded()
+        if (session) notify('SIGNED_IN', session)
         return { data: { session, user: session?.user }, error: null }
       },
       async signUp() {
+        expireIfNeeded()
         return { data: { session, user: session?.user }, error: null }
       },
       async signOut() {
+        session = null
+        if (expirationTimer !== undefined) {
+          clearTimeout(expirationTimer)
+          expirationTimer = undefined
+        }
+        notify('SIGNED_OUT', null)
         return { error: null }
       },
       async resetPasswordForEmail() {
@@ -112,7 +176,7 @@ if (isLocalDevAuth) {
   // Use a fake client in dev when the dev anon key is present. This avoids
   // attempting to reach a Supabase project while letting the UI behave like
   // an authenticated app when a VITE_DEV_TOKEN is provided.
-  supabase = makeFakeClient(devToken, devTokenStatus) as unknown as SupabaseClient
+  supabase = createLocalDevAuthClient(devToken, devTokenStatus) as unknown as SupabaseClient
 } else if (supabaseUrl && supabaseAnonKey) {
   void (async () => {
     const mod = await import('@supabase/supabase-js')

--- a/frontend/src/lib/hooks/AuthProvider.tsx
+++ b/frontend/src/lib/hooks/AuthProvider.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { AuthError, Session } from '@supabase/supabase-js'
 
-import { supabase } from '@/lib/auth'
+import { onSessionEnded, supabase } from '@/lib/auth'
 
 import { AuthContext, type AuthContextValue, type AuthProviderProps } from './auth-context'
 
@@ -9,6 +9,7 @@ export function AuthProvider({ children, client = supabase }: AuthProviderProps)
   const [session, setSession] = useState<Session | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [authError, setAuthError] = useState<AuthError | null>(null)
+  const [sessionEndedReason, setSessionEndedReason] = useState<AuthContextValue['sessionEndedReason']>(null)
 
   useEffect(() => {
     let mounted = true
@@ -20,12 +21,23 @@ export function AuthProvider({ children, client = supabase }: AuthProviderProps)
       }
     }
 
-    const { data } = client.auth.onAuthStateChange((_event, nextSession) => {
+    const { data } = client.auth.onAuthStateChange((event, nextSession) => {
       if (mounted) {
         setSession(nextSession)
+        if (nextSession && event !== 'SIGNED_OUT') {
+          setSessionEndedReason(null)
+        }
         setAuthError(null)
         setIsLoading(false)
       }
+    })
+
+    const unsubscribeSessionEnded = onSessionEnded((reason) => {
+      if (!mounted) return
+      setSession(null)
+      setSessionEndedReason(reason)
+      setIsLoading(false)
+      void client.auth.signOut()
     })
 
     void client.auth.getSession().then(({ data: sessionData, error }) => {
@@ -40,6 +52,7 @@ export function AuthProvider({ children, client = supabase }: AuthProviderProps)
     return () => {
       mounted = false
       data.subscription.unsubscribe()
+      unsubscribeSessionEnded()
     }
   }, [client])
 
@@ -49,6 +62,7 @@ export function AuthProvider({ children, client = supabase }: AuthProviderProps)
       authError,
       isLoading,
       session,
+      sessionEndedReason,
       signIn: async (email, password) => {
         if (!client) {
           throw new Error('Authentication is not configured.')
@@ -90,7 +104,7 @@ export function AuthProvider({ children, client = supabase }: AuthProviderProps)
         }
       },
     }),
-    [authError, client, isLoading, session],
+    [authError, client, isLoading, session, sessionEndedReason],
   )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/frontend/src/lib/hooks/auth-context.ts
+++ b/frontend/src/lib/hooks/auth-context.ts
@@ -1,6 +1,6 @@
 import { createContext, type ReactNode } from 'react'
 
-import type { AuthClient, AuthError, Session } from '@/lib/auth'
+import type { AuthClient, AuthError, Session, SessionEndedReason } from '@/lib/auth'
 
 export type AuthActionResult = {
   session: Session | null
@@ -11,6 +11,7 @@ export type AuthContextValue = {
   authError: AuthError | null
   isLoading: boolean
   session: Session | null
+  sessionEndedReason: SessionEndedReason | null
   signIn: (email: string, password: string) => Promise<AuthActionResult>
   signUp: (email: string, password: string) => Promise<AuthActionResult>
   resetPassword: (email: string) => Promise<void>


### PR DESCRIPTION
## Summary

- end the local fake-auth session at the JWT `exp` boundary and show the existing `make login` / Vite restart guidance
- treat only API `401` responses with RFC 9457 type `invalid-token` as a terminal browser-session event
- clear the auth shell, sign out the persisted Supabase client, and explain that sign-in is required
- add fake-clock, API boundary, and sign-in surface regression coverage

Implements SPEC §9.3 (administrator authentication sessions) and records the API rejection decision in ADR 0009.

Fixes #95

## Validation

- `make test-frontend` — 83 tests passed
- `make build-frontend` — passed
- `make lint-frontend` — passed
- `GOTOOLCHAIN=local go test -race -v ./... -count=1` — passed; DB integration cases skipped because test database URLs are unset
- `make lint-backend` — passed
- `make format` — passed
- `git diff --check` — passed
- `make test-backend` could not start because the existing fixed-name `miniclass-postgres` container conflicts
- `make generate` is unavailable locally because installed sqlc is v1.31.1 while the repository pins v1.27.0
- `make test-migrations` lacks `MIGRATION_ROUNDTRIP_DATABASE_URL`; `make smoke` lacks checkout `.env`
- CI will validate the pinned generated-code, migration, and developer-tooling environments