### PR TITLE
fix: exclude soft-deleted people from link listings (SPEC 21.3)

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -1,5 +1,16 @@
 # Detent handoff notes
 
+## Issue #101 soft-deleted people in relationship and membership listings
+
+- Worktree rebased cleanly onto `origin/main` at `14ea2e0`; no PR existed at start and the issue has no native dependencies or `Depends on:` references.
+- Current live year-wide household membership queries already exclude deleted households and members. The missing predicates are in `ListHouseholdStudents`, `ListHouseholdAdults` (deleted household), and `ListGuardianRelationships` (deleted adult/student); registry queries must remain unfiltered.
+- Workpad comment `5438876572` tracks the change. It cites SPEC §21.3, preserves link rows, and adds integration regression coverage.
+- Restore API is tracked separately in #103. Until it lands the reversibility criterion is proved by clearing `deleted_at` in a migrator transaction that sets `app.organization_id` (RLS is forced on the person tables), which is the stricter check anyway: nothing but the person's own flag changes.
+- Both new assertions were confirmed to fail against the pre-fix generated queries before the fix was reinstated.
+- Regenerated `internal/db/gen` with the pinned sqlc v1.27.0 through the local `sqlc/sqlc:1.27.0` image; the worker's PATH sqlc is v1.31.1 and the Makefile refuses it.
+- Gates run locally: Backend tests, Backend lint, Backend format, Generated code drift, Migration round-trip, Frontend tests, Frontend build, Frontend lint, Repository formatting — all green. Developer tooling (`make smoke`) was not run: it requires ports 8080 and 5173 free, and a developer API process already owns 8080 on this machine. The change touches no tooling; CI covers that gate.
+- Open items: commit/push, open PR with `Fixes #101` and the SPEC citation, inspect CI/reviews, then update the Workpad.
+
 ## Issue #94 local fake-auth password reset
 
 - Added local-dev reset blocking in `frontend/src/features/auth/ResetPasswordPage.tsx`; it reuses
@@ -530,3 +541,17 @@
   Backend tests, Backend lint, and Generated code drift. CI migration round-trip passed despite the
   local wrapper lacking `POSTGRES_ADMIN_DATABASE_URL`. Skill draft: no — this was standard
   frontend/API integration work.
+
+## 2026-08-27T12:14:40Z - Failed run output tail
+
+- final_state: failed
+- error: stream turn: context canceled
+close codex app-server transport: signal: terminated: stderr: [2m2026-08-27T12:09:57.290204Z[0m [31mERROR[0m [2mcodex_core::tools::router[0m[2m:[0m [3merror[0m[2m=[0mexec_command failed for `/bin/zsh -lc 'rg -n "ListGuardianRelationships|ListHouseholdStudents|ListHouseholdAdults|SoftDelete(Student|Adult|Household)|deleted_at" backend/tests backend/internal | head -240'`: CreateProcess { message: "Rejected(\"Failed to create unified exec process: No such file or directory (os error 2)\")" }
+[2m2026-08-27T12:14:39.285451Z[0m [31mERROR[0m [2mcodex_models_manager::manager[0m[2m:[0m failed to refresh available models: timeout waiting for child process to exit
+worker github REST budget monitor failed: Get "https://api.github.com/rate_limit": context deadline exceeded
+
+Output tail:
+
+```text
+I’ll inspect the current issue/PR state and the existing household/guardian listing queries, reproduce the soft-delete leak, then make the smallest scoped fix and run the relevant backend plus repository gates. I’ll keep the Workpad and `.detent/notes.md` current throughout.The issue is open and has no existing PR or Workpad comment. A maintainer note confirms the household membership UI now uses the listing endpoints, and restore behavior is tracked separately in #103; this fix should remain a query-time exclusion that preserves reversible link rows. I’m checking dependency state and the current SQL/test architecture before editing.The dependency check is clear: #101 has no native blockers or `Depends on:` references. The branch is clean but behind the freshly fetched `origin/main`, so I’ll rebase it before source changes. The live household member queries already filter deleted members in two paths; the remaining leak is the guardian query plus household-listing predicates that must also exclude deleted households and preserve registry queries.The rebase onto current `origin/main` completed cleanly. The implementation target is now precise: add `exists` checks for both live person endpoints to `ListGuardianRelationships`, and require an active household in the per-household student/adult listings. The year-wide membership queries already enforce all three live-record predicates; registry queries remain intentionally unfiltered. I’m adding regression coverage that also proves retained link rows are still removable/servable through their explicit historical paths.The pinned sqlc container is available, so generated output was regenerated with the repository-required v1.27.0 rather than the worker’s v1.31.1 binary. The regression test now covers both deleted relationship endpoints, both membership kinds, direct row retention, and the deleted-household query path. Next I’m running focused backend tests; integration cases will use the repository’s two-role database harness if its test URLs are available.The focused compile exposed one test-only API mismatch: membership retention is intentionally available through `internal/data`, not the `people.Service`. I’m correcting the assertions to use the tenant-scoped read transaction, which also keeps the test aligned with the repository’s data-access boundary.The focused backend compilation/tests now pass. The integration package reports success in this checkout, but I’m verifying whether its database-backed cases actually ran or were skipped, then I’ll run the full required gates and address any environment-specific failures without weakening coverage.The first required gate is currently blocked by a pre-existing Docker resource collision: `make test-backend` cannot start its fixed-name `miniclass-postgres` container because another container already owns that name. I won’t remove or overwrite that container; I’m inspecting whether it is a compatible repository database so I can run the equivalent backend checks safely, while recording the exact gate result.
+```

--- a/backend/internal/db/gen/household.sql.go
+++ b/backend/internal/db/gen/household.sql.go
@@ -591,6 +591,22 @@ where organization_id = $1::public.xid20
   and school_year_id = $2::public.xid20
   and ($3::public.xid20 is null or adult_id = $3::public.xid20)
   and ($4::public.xid20 is null or student_id = $4::public.xid20)
+  and exists (
+    select 1
+    from adults
+    where adults.id = guardian_relationships.adult_id
+      and adults.organization_id = guardian_relationships.organization_id
+      and adults.school_year_id = guardian_relationships.school_year_id
+      and adults.deleted_at is null
+  )
+  and exists (
+    select 1
+    from students
+    where students.id = guardian_relationships.student_id
+      and students.organization_id = guardian_relationships.organization_id
+      and students.school_year_id = guardian_relationships.school_year_id
+      and students.deleted_at is null
+  )
 order by adult_id, student_id, id
 `
 
@@ -641,6 +657,14 @@ from household_adults
 where household_adults.organization_id = $1
   and household_adults.school_year_id = $2
   and household_adults.household_id = $3
+  and exists (
+    select 1
+    from households
+    where households.id = household_adults.household_id
+      and households.organization_id = household_adults.organization_id
+      and households.school_year_id = household_adults.school_year_id
+      and households.deleted_at is null
+  )
   and exists (
     select 1
     from adults
@@ -749,6 +773,14 @@ from household_students
 where household_students.organization_id = $1
   and household_students.school_year_id = $2
   and household_students.household_id = $3
+  and exists (
+    select 1
+    from households
+    where households.id = household_students.household_id
+      and households.organization_id = household_students.organization_id
+      and households.school_year_id = household_students.school_year_id
+      and households.deleted_at is null
+  )
   and exists (
     select 1
     from students

--- a/backend/sql/queries/household.sql
+++ b/backend/sql/queries/household.sql
@@ -52,6 +52,14 @@ where household_students.organization_id = $1
   and household_students.household_id = $3
   and exists (
     select 1
+    from households
+    where households.id = household_students.household_id
+      and households.organization_id = household_students.organization_id
+      and households.school_year_id = household_students.school_year_id
+      and households.deleted_at is null
+  )
+  and exists (
+    select 1
     from students
     where students.id = household_students.student_id
       and students.organization_id = household_students.organization_id
@@ -130,6 +138,14 @@ where household_adults.organization_id = $1
   and household_adults.household_id = $3
   and exists (
     select 1
+    from households
+    where households.id = household_adults.household_id
+      and households.organization_id = household_adults.organization_id
+      and households.school_year_id = household_adults.school_year_id
+      and households.deleted_at is null
+  )
+  and exists (
+    select 1
     from adults
     where adults.id = household_adults.adult_id
       and adults.organization_id = household_adults.organization_id
@@ -202,6 +218,22 @@ where organization_id = sqlc.arg('organization_id')::public.xid20
   and school_year_id = sqlc.arg('school_year_id')::public.xid20
   and (sqlc.narg('adult_id')::public.xid20 is null or adult_id = sqlc.narg('adult_id')::public.xid20)
   and (sqlc.narg('student_id')::public.xid20 is null or student_id = sqlc.narg('student_id')::public.xid20)
+  and exists (
+    select 1
+    from adults
+    where adults.id = guardian_relationships.adult_id
+      and adults.organization_id = guardian_relationships.organization_id
+      and adults.school_year_id = guardian_relationships.school_year_id
+      and adults.deleted_at is null
+  )
+  and exists (
+    select 1
+    from students
+    where students.id = guardian_relationships.student_id
+      and students.organization_id = guardian_relationships.organization_id
+      and students.school_year_id = guardian_relationships.school_year_id
+      and students.deleted_at is null
+  )
 order by adult_id, student_id, id;
 
 -- name: GetGuardianRelationshipByID :one

--- a/backend/tests/integration/household_test.go
+++ b/backend/tests/integration/household_test.go
@@ -168,17 +168,47 @@ func TestHouseholdMembershipExcludesSoftDeletedPeopleAndHouseholds(t *testing.T)
 	require.NoError(t, err)
 	require.Empty(t, householdStudents)
 
+	// Soft deletion is reversible (SPEC §21.3), so the hidden row must come back
+	// from restoring the person alone.
+	restoreStudent(t, harness, organizationID, tenant.student.ID)
+	householdStudents, err = service.ListHouseholdStudents(ctx, organizationID, tenant.year.ID, tenant.household.ID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{string(tenant.student.ID)}, studentIDsOf(householdStudents))
+	require.NoError(t, service.DeleteStudent(ctx, organizationID, tenant.year.ID, tenant.student.ID, actor))
+
 	// Removing the retained membership row is still possible: the deletion path
 	// looks the row up directly rather than through the filtered listing.
+	var retainedStudentMembership data.HouseholdStudent
+	err = harness.Database.InTenantRead(ctx, organizationID, func(ctx context.Context, tx *data.Tx) error {
+		var err error
+		retainedStudentMembership, err = tx.GetHouseholdStudent(ctx, tenant.year.ID, tenant.household.ID, tenant.student.ID)
+		return err
+	})
+	require.NoError(t, err)
+	require.Equal(t, tenant.student.ID, retainedStudentMembership.StudentID)
 	require.NoError(t, service.RemoveStudentFromHousehold(ctx, organizationID, tenant.year.ID, tenant.household.ID, tenant.student.ID, actor))
 
 	require.NoError(t, service.Delete(ctx, organizationID, tenant.year.ID, tenant.adult.ID, actor))
+	var retainedAdultMembership data.HouseholdAdult
+	err = harness.Database.InTenantRead(ctx, organizationID, func(ctx context.Context, tx *data.Tx) error {
+		var err error
+		retainedAdultMembership, err = tx.GetHouseholdAdult(ctx, tenant.year.ID, tenant.household.ID, tenant.adult.ID)
+		return err
+	})
+	require.NoError(t, err)
+	require.Equal(t, tenant.adult.ID, retainedAdultMembership.AdultID)
 	membership, err = service.ListHouseholdMembership(ctx, organizationID, tenant.year.ID)
 	require.NoError(t, err)
 	require.Empty(t, adultIDsOf(membership.Adults))
 	householdAdults, err := service.ListHouseholdAdults(ctx, organizationID, tenant.year.ID, tenant.household.ID)
 	require.NoError(t, err)
 	require.Empty(t, householdAdults)
+
+	restoreAdult(t, harness, organizationID, tenant.adult.ID)
+	householdAdults, err = service.ListHouseholdAdults(ctx, organizationID, tenant.year.ID, tenant.household.ID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{string(tenant.adult.ID)}, adultIDsOf(householdAdults))
+	require.NoError(t, service.Delete(ctx, organizationID, tenant.year.ID, tenant.adult.ID, actor))
 
 	// A soft-deleted household is absent from the household listing, so its
 	// membership must be absent from the year's membership too; otherwise the
@@ -197,6 +227,126 @@ func TestHouseholdMembershipExcludesSoftDeletedPeopleAndHouseholds(t *testing.T)
 	households, err := service.ListHouseholds(ctx, organizationID, tenant.year.ID)
 	require.NoError(t, err)
 	require.Empty(t, households)
+
+	// The per-household query itself also excludes a deleted household. The
+	// service normally rejects a deleted household before reaching this query,
+	// so exercise the data listing directly to cover the predicate.
+	var deletedHouseholdStudents []data.HouseholdStudent
+	err = harness.Database.InTenantRead(ctx, organizationID, func(ctx context.Context, tx *data.Tx) error {
+		var err error
+		deletedHouseholdStudents, err = tx.ListHouseholdStudents(ctx, tenant.year.ID, tenant.household.ID)
+		return err
+	})
+	require.NoError(t, err)
+	require.Empty(t, deletedHouseholdStudents)
+}
+
+// SPEC §21.3: relationship rows remain historical records, but a live listing
+// excludes a row if either endpoint has been soft-deleted. Each side gets a
+// separate fixture relationship so both filtered directions are exercised.
+func TestGuardianRelationshipListingExcludesSoftDeletedPeople(t *testing.T) {
+	harness := testharness.Open(t)
+	ctx := harness.Context
+	service := people.New(harness.Database)
+	actor := audit.Actor{Type: audit.ActorTypeSystem, Label: "guardian relationship soft delete test"}
+	tenant := newMembershipFixture(t, harness, service, actor, "GuardianSoftDelete")
+	organizationID := string(tenant.organizationID)
+
+	studentB, err := service.CreateStudent(ctx, organizationID, tenant.year.ID, actor, people.StudentCreateInput{
+		LegalGivenName: "Synthetic", LegalFamilyName: "Guardian Student B", GradeLevelID: tenant.gradeID, HomeroomID: tenant.homeroomID,
+	})
+	require.NoError(t, err)
+	adultB, err := service.Create(ctx, organizationID, tenant.year.ID, actor, people.AdultCreateInput{
+		LegalGivenName: "Synthetic", LegalFamilyName: "Guardian Adult B", ParticipationIntent: data.AdultParticipationHelp,
+	})
+	require.NoError(t, err)
+
+	adultDeletedRelationship, err := service.CreateGuardianRelationship(ctx, organizationID, tenant.year.ID, actor, people.GuardianRelationshipCreateInput{
+		AdultID: adultB.ID, StudentID: tenant.student.ID, RelationshipType: data.GuardianRelationshipParent,
+	})
+	require.NoError(t, err)
+	studentDeletedRelationship, err := service.CreateGuardianRelationship(ctx, organizationID, tenant.year.ID, actor, people.GuardianRelationshipCreateInput{
+		AdultID: tenant.adult.ID, StudentID: studentB.ID, RelationshipType: data.GuardianRelationshipGuardian,
+	})
+	require.NoError(t, err)
+
+	relationshipIDs := func(rows []data.GuardianRelationship) []string {
+		result := make([]string, 0, len(rows))
+		for _, row := range rows {
+			result = append(result, string(row.ID))
+		}
+		return result
+	}
+
+	byStudent, err := service.ListGuardianRelationships(ctx, organizationID, tenant.year.ID, data.GuardianRelationshipFilter{StudentID: tenant.student.ID})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{string(adultDeletedRelationship.ID)}, relationshipIDs(byStudent))
+	byAdult, err := service.ListGuardianRelationships(ctx, organizationID, tenant.year.ID, data.GuardianRelationshipFilter{AdultID: tenant.adult.ID})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{string(studentDeletedRelationship.ID)}, relationshipIDs(byAdult))
+
+	require.NoError(t, service.Delete(ctx, organizationID, tenant.year.ID, adultB.ID, actor))
+	byStudent, err = service.ListGuardianRelationships(ctx, organizationID, tenant.year.ID, data.GuardianRelationshipFilter{StudentID: tenant.student.ID})
+	require.NoError(t, err)
+	require.Empty(t, byStudent)
+	retainedAdultDeleted, err := service.GetGuardianRelationship(ctx, organizationID, tenant.year.ID, adultDeletedRelationship.ID)
+	require.NoError(t, err)
+	require.Equal(t, adultDeletedRelationship.ID, retainedAdultDeleted.ID)
+
+	require.NoError(t, service.DeleteStudent(ctx, organizationID, tenant.year.ID, studentB.ID, actor))
+	byAdult, err = service.ListGuardianRelationships(ctx, organizationID, tenant.year.ID, data.GuardianRelationshipFilter{AdultID: tenant.adult.ID})
+	require.NoError(t, err)
+	require.Empty(t, byAdult)
+	retainedStudentDeleted, err := service.GetGuardianRelationship(ctx, organizationID, tenant.year.ID, studentDeletedRelationship.ID)
+	require.NoError(t, err)
+	require.Equal(t, studentDeletedRelationship.ID, retainedStudentDeleted.ID)
+
+	unfiltered, err := service.ListGuardianRelationships(ctx, organizationID, tenant.year.ID, data.GuardianRelationshipFilter{})
+	require.NoError(t, err)
+	require.Empty(t, unfiltered)
+
+	// Restoring both people restores both rows, with no mutation of the link
+	// rows themselves: the exclusion is a read-time predicate (SPEC §21.3).
+	restoreAdult(t, harness, organizationID, adultB.ID)
+	restoreStudent(t, harness, organizationID, studentB.ID)
+	restored, err := service.ListGuardianRelationships(ctx, organizationID, tenant.year.ID, data.GuardianRelationshipFilter{})
+	require.NoError(t, err)
+	require.ElementsMatch(t,
+		[]string{string(adultDeletedRelationship.ID), string(studentDeletedRelationship.ID)},
+		relationshipIDs(restored))
+}
+
+// SPEC §21.3 requires soft deletion to be reversible, but the restore endpoint
+// is tracked separately in #103. Until it lands, clearing deleted_at directly
+// is the closest available stand-in, and it is the stricter check for this
+// issue: nothing but the person's own flag changes, so a row that reappears in
+// a listing proves the exclusion is a read-time predicate and not a mutation.
+func restoreStudent(t *testing.T, harness *testharness.Harness, organizationID string, studentID ids.XID) {
+	t.Helper()
+	restorePerson(t, harness, organizationID, studentID,
+		`update students set deleted_at = null where id = $1 and organization_id = $2`)
+}
+
+func restoreAdult(t *testing.T, harness *testharness.Harness, organizationID string, adultID ids.XID) {
+	t.Helper()
+	restorePerson(t, harness, organizationID, adultID,
+		`update adults set deleted_at = null where id = $1 and organization_id = $2`)
+}
+
+func restorePerson(t *testing.T, harness *testharness.Harness, organizationID string, personID ids.XID, statement string) {
+	t.Helper()
+	ctx := harness.Context
+	tx, err := harness.Migrator.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+	// Row-level security is forced on the person tables (SPEC §9.2), so this
+	// transaction sets the same tenant setting an application transaction sets.
+	_, err = tx.Exec(ctx, `select set_config('app.organization_id', $1, true)`, organizationID)
+	require.NoError(t, err)
+	tag, err := tx.Exec(ctx, statement, string(personID), organizationID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), tag.RowsAffected())
+	require.NoError(t, tx.Commit(ctx))
 }
 
 type membershipFixture struct {


### PR DESCRIPTION
Fixes #101.

## Spec citation

SPEC §21.3 (Deletion): a soft-deleted person "is excluded from views, solves, reports and published artifacts, while referential integrity with historical records is preserved." Supporting: SPEC §8.2 (guardian relationship), SPEC §8.7 (names are never keys), ADR 0010 (link rows are hard deleted only by an explicit removal).

## What was wrong

The second half of §21.3 held and the first did not. Soft-deleting a person left every link row naming them in place — correct — but the link listings returned those rows unconditionally, so the person stayed visible through the link.

The visible symptom was on the person detail page: `GuardianRelationships.tsx` resolves each row's label from the roster listing for the opposite kind, which does exclude soft-deleted people, so the row rendered as a bare xid whose link 404s.

## What changed

The exclusion is a read-time predicate on the listings, in `internal/data` where the queries live, not a nicer fallback label in one React component:

- `ListGuardianRelationships` now requires a live adult **and** a live student.
- `ListHouseholdStudents` and `ListHouseholdAdults` already required a live person; they now also require a live household, which is what the year-scoped membership listings beside them already do.

No link row is hard-deleted: `people.Service.Delete` and `DeleteStudent` still only soft-delete the person (ADR 0010). The registry listings are untouched, so the entity registry still enumerates every row.

## Organiser signal

None. §21.3 says excluded, and a §5.2 warning attaches to an object the organiser can act on, which a hidden row is not. Absent a spec citation permitting the warning, the exclusion is silent — stated here deliberately, per the issue's design sketch.

## Reversibility

Because the exclusion is query-time, restoring a person restores every hidden row with no further mutation. The restore endpoint is tracked separately in #103, so the tests clear `deleted_at` directly in a transaction that sets `app.organization_id` (row-level security is forced on the person tables). That is the stricter proof for this change: nothing but the person's own flag moves, and the rows come back.

Out of scope, as the issue notes: §21.3's hard-delete obligations are Phase 10.

## Tests

`backend/tests/integration/household_test.go`, every assertion scoped to the organisation the test mints:

- `TestGuardianRelationshipListingExcludesSoftDeletedPeople` — both directions (deleted adult, deleted student), the retained rows still readable by id, and both rows reappearing after restore.
- `TestHouseholdMembershipExcludesSoftDeletedPeopleAndHouseholds` — extended to prove the retained membership rows are still readable, that each kind reappears on restore, and that the per-household listing excludes a deleted household.

Both new assertions were confirmed to fail against the pre-fix generated queries.

## Validation

Run locally from the repository root: Backend tests, Backend lint, Backend format, Generated code drift (`internal/db/gen` regenerated with the pinned sqlc v1.27.0), Migration round-trip, Frontend tests, Frontend build, Frontend lint, Repository formatting — all green.

Developer tooling (`make smoke`) was not run locally: it requires ports 8080 and 5173 to be free and a developer API process already owns 8080 on this machine. This change touches no tooling; CI runs that gate.
