### PR TITLE
Fix query cache isolation across signed-in identities

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -1,5 +1,14 @@
 # Detent handoff notes
 
+## Issue #110 query cache identity boundary
+
+- Current worktree is cleanly based on `origin/main` at `494cfb2`; the stale prior entry for #101 was already merged and is unrelated.
+- `AuthProvider` now tracks the last signed-in Supabase user ID across sign-out events and clears the shared React Query cache only when a different non-null identity arrives. Same-user `TOKEN_REFRESHED` events and `SIGNED_OUT` leave the cache intact, preventing anonymous refetches while the shell unmounts.
+- Added `AuthProvider.test.tsx` covering the exact sign-out → different sign-in transition for `['account']` and a school-year key, plus same-user refresh preservation. Bare `AuthProvider` tests now render under `QueryClientProvider`.
+- Focused Vitest/build could not start because this checkout has no installed frontend dependencies (`openapi-typescript`, Vitest, TypeScript, and ESLint binaries absent); frontend lint also fails before ESLint because Bun cannot write its tempdir. Migration round-trip cannot start without `MIGRATION_ROUNDTRIP_DATABASE_URL`, and smoke cannot start without `.env`.
+- Backend lint/format, direct `go test -race -v ./... -count=1` (database cases skipped without test URLs), pinned generated-code drift, and `git diff --check` pass. `make test-backend` stops at the pre-existing fixed-name `miniclass-postgres` collision.
+- Open items: commit and push, open PR with `Fixes #110` and SPEC §§9.3/11.1, inspect current-head CI/reviews, then complete the Workpad.
+
 ## Issue #101 soft-deleted people in relationship and membership listings
 
 - Worktree rebased cleanly onto `origin/main` at `14ea2e0`; no PR existed at start and the issue has no native dependencies or `Depends on:` references.

--- a/frontend/src/features/auth/ResetPasswordPage.test.tsx
+++ b/frontend/src/features/auth/ResetPasswordPage.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -18,12 +19,15 @@ function authClient(): AuthClient {
 }
 
 function renderReset(props: { localDevAuth: boolean; devToken: DevTokenStatus }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <MemoryRouter initialEntries={['/reset-password']}>
-      <AuthProvider client={authClient()}>
-        <ResetPasswordPage {...props} />
-      </AuthProvider>
-    </MemoryRouter>,
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/reset-password']}>
+        <AuthProvider client={authClient()}>
+          <ResetPasswordPage {...props} />
+        </AuthProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
   )
 }
 
@@ -45,11 +49,13 @@ describe('reset-password page authentication paths', () => {
   it('keeps the reset form and success response on the real Supabase path', async () => {
     const client = authClient()
     render(
-      <MemoryRouter initialEntries={['/reset-password']}>
-        <AuthProvider client={client}>
-          <ResetPasswordPage localDevAuth={false} devToken={{ kind: 'missing' }} />
-        </AuthProvider>
-      </MemoryRouter>,
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter initialEntries={['/reset-password']}>
+          <AuthProvider client={client}>
+            <ResetPasswordPage localDevAuth={false} devToken={{ kind: 'missing' }} />
+          </AuthProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
     )
 
     fireEvent.change(await screen.findByLabelText('Email'), { target: { value: 'admin@example.test' } })

--- a/frontend/src/features/auth/SignInPage.test.tsx
+++ b/frontend/src/features/auth/SignInPage.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -22,12 +23,15 @@ function sessionlessClient(): AuthClient {
 }
 
 function renderSignIn(props: { localDevAuth: boolean; devToken: DevTokenStatus }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <MemoryRouter initialEntries={['/sign-in']}>
-      <AuthProvider client={sessionlessClient()}>
-        <SignInPage {...props} />
-      </AuthProvider>
-    </MemoryRouter>,
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/sign-in']}>
+        <AuthProvider client={sessionlessClient()}>
+          <SignInPage {...props} />
+        </AuthProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
   )
 }
 
@@ -109,11 +113,13 @@ describe('sign-in page under local development auth', () => {
     const client = createLocalDevAuthClient(localToken, { kind: 'valid', expiresAt }) as AuthClient
 
     render(
-      <MemoryRouter initialEntries={['/sign-in']}>
-        <AuthProvider client={client}>
-          <SessionSurface devToken={{ kind: 'valid', expiresAt }} />
-        </AuthProvider>
-      </MemoryRouter>,
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter initialEntries={['/sign-in']}>
+          <AuthProvider client={client}>
+            <SessionSurface devToken={{ kind: 'valid', expiresAt }} />
+          </AuthProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
     )
 
     await act(async () => {})
@@ -132,11 +138,13 @@ describe('sign-in page under local development auth', () => {
   it('explains an API-invalid session and signs out the persisted client', async () => {
     const client = sessionlessClient()
     render(
-      <MemoryRouter initialEntries={['/sign-in']}>
-        <AuthProvider client={client}>
-          <SignInPage />
-        </AuthProvider>
-      </MemoryRouter>,
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter initialEntries={['/sign-in']}>
+          <AuthProvider client={client}>
+            <SignInPage />
+          </AuthProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
     )
 
     await act(async () => {})

--- a/frontend/src/lib/hooks/AuthProvider.test.tsx
+++ b/frontend/src/lib/hooks/AuthProvider.test.tsx
@@ -1,0 +1,97 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AuthChangeEvent, AuthClient, Session } from '@/lib/auth'
+
+import { AuthProvider } from './AuthProvider'
+import { useAuth } from './useAuth'
+
+type AuthStateListener = (event: AuthChangeEvent, session: Session | null) => void
+
+function session(userId: string, accessToken = `${userId}-token`): Session {
+  return {
+    access_token: accessToken,
+    expires_at: 4102444800,
+    expires_in: 3600,
+    refresh_token: `${userId}-refresh-token`,
+    token_type: 'bearer',
+    user: { id: userId, email: `${userId}@example.test` },
+  } as Session
+}
+
+function authClient(initialSession: Session) {
+  let listener: AuthStateListener | undefined
+  const client = {
+    auth: {
+      getSession: vi.fn(async () => ({ data: { session: initialSession }, error: null })),
+      onAuthStateChange: vi.fn((nextListener: AuthStateListener) => {
+        listener = nextListener
+        return { data: { subscription: { unsubscribe: vi.fn() } } }
+      }),
+      signOut: vi.fn(async () => ({ error: null })),
+    },
+  } as unknown as AuthClient
+
+  return {
+    client,
+    emit: (event: AuthChangeEvent, nextSession: Session | null) => listener?.(event, nextSession),
+  }
+}
+
+function SessionProbe() {
+  const { session: currentSession } = useAuth()
+  return <span data-testid="session-user">{currentSession?.user.id ?? 'signed-out'}</span>
+}
+
+function renderProvider(client: AuthClient, queryClient: QueryClient) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider client={client}>
+        <SessionProbe />
+      </AuthProvider>
+    </QueryClientProvider>,
+  )
+}
+
+async function waitForInitialSession() {
+  await waitFor(() => expect(screen.getByTestId('session-user')).toHaveTextContent('user-a'))
+}
+
+describe('AuthProvider query cache boundary', () => {
+  it('clears resource caches when a different signed-in identity arrives', async () => {
+    const harness = authClient(session('user-a'))
+    const queryClient = new QueryClient()
+    renderProvider(harness.client, queryClient)
+    await waitForInitialSession()
+
+    queryClient.setQueryData(['account'], { organization: { name: 'A organisation' } })
+    queryClient.setQueryData(['school-years', 'year-a'], [{ id: 'year-a', label: 'A year' }])
+
+    act(() => harness.emit('SIGNED_OUT', null))
+    expect(queryClient.getQueryData(['account'])).toEqual({ organization: { name: 'A organisation' } })
+
+    act(() => harness.emit('SIGNED_IN', session('user-b')))
+
+    expect(queryClient.getQueryData(['account'])).toBeUndefined()
+    expect(queryClient.getQueryData(['school-years', 'year-a'])).toBeUndefined()
+    expect(screen.getByTestId('session-user')).toHaveTextContent('user-b')
+  })
+
+  it('keeps resource caches intact when the same identity refreshes its token', async () => {
+    const harness = authClient(session('user-a'))
+    const queryClient = new QueryClient()
+    renderProvider(harness.client, queryClient)
+    await waitForInitialSession()
+
+    const account = { organization: { name: 'A organisation' } }
+    const schoolYears = [{ id: 'year-a', label: 'A year' }]
+    queryClient.setQueryData(['account'], account)
+    queryClient.setQueryData(['school-years', 'year-a'], schoolYears)
+
+    act(() => harness.emit('TOKEN_REFRESHED', session('user-a', 'refreshed-token')))
+
+    expect(queryClient.getQueryData(['account'])).toBe(account)
+    expect(queryClient.getQueryData(['school-years', 'year-a'])).toBe(schoolYears)
+  })
+})

--- a/frontend/src/lib/hooks/AuthProvider.tsx
+++ b/frontend/src/lib/hooks/AuthProvider.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import type { AuthError, Session } from '@supabase/supabase-js'
 
 import { onSessionEnded, supabase } from '@/lib/auth'
@@ -6,10 +7,12 @@ import { onSessionEnded, supabase } from '@/lib/auth'
 import { AuthContext, type AuthContextValue, type AuthProviderProps } from './auth-context'
 
 export function AuthProvider({ children, client = supabase }: AuthProviderProps) {
+  const queryClient = useQueryClient()
   const [session, setSession] = useState<Session | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [authError, setAuthError] = useState<AuthError | null>(null)
   const [sessionEndedReason, setSessionEndedReason] = useState<AuthContextValue['sessionEndedReason']>(null)
+  const lastSignedInUserId = useRef<string | null>(null)
 
   useEffect(() => {
     let mounted = true
@@ -22,6 +25,14 @@ export function AuthProvider({ children, client = supabase }: AuthProviderProps)
     }
 
     const { data } = client.auth.onAuthStateChange((event, nextSession) => {
+      const nextUserId = nextSession?.user.id ?? null
+      if (nextUserId && lastSignedInUserId.current && nextUserId !== lastSignedInUserId.current) {
+        queryClient.clear()
+      }
+      if (nextUserId) {
+        lastSignedInUserId.current = nextUserId
+      }
+
       if (mounted) {
         setSession(nextSession)
         if (nextSession && event !== 'SIGNED_OUT') {
@@ -45,6 +56,9 @@ export function AuthProvider({ children, client = supabase }: AuthProviderProps)
         return
       }
       setSession(sessionData.session)
+      if (sessionData.session) {
+        lastSignedInUserId.current = sessionData.session.user.id
+      }
       setAuthError(error)
       setIsLoading(false)
     })
@@ -54,7 +68,7 @@ export function AuthProvider({ children, client = supabase }: AuthProviderProps)
       data.subscription.unsubscribe()
       unsubscribeSessionEnded()
     }
-  }, [client])
+  }, [client, queryClient])
 
   const value = useMemo<AuthContextValue>(
     () => ({


### PR DESCRIPTION
Fixes #110

## Summary

- Clear the shared React Query cache in `AuthProvider` when auth state reports a different signed-in user ID.
- Preserve cached resource data for same-user token refreshes and across sign-out until the next identity is established, avoiding anonymous refetches while the protected shell unmounts.
- Add provider-level regression coverage for account and school-year cache entries, plus QueryClient wrappers for existing bare provider tests.

## Spec

Implements SPEC §9.3 (authentication identity boundary) and protects the owner-only lifecycle control described in SPEC §11.1 from stale account data.

## Validation

- Passed: backend lint, backend format, direct race-enabled backend tests (database cases skipped without test URLs), generated artifact drift, and `git diff --check`.
- Local frontend tests/build could not start because dependencies are not installed; frontend lint is blocked by Bun tempdir permissions. Migration round-trip lacks `MIGRATION_ROUNDTRIP_DATABASE_URL`; smoke lacks `.env`. Required CI checks will provide dependency-backed verification.