### PR TITLE
P2-6: implement grades_csv whole-name matching

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -3,6 +3,6 @@
 - Scope: P2-6 `grades_csv`: header-name parsing, whole-cell normalized legal/preferred-name matching, update-only grade vocabulary resolution, preview/commit/idempotency, and audit summary. Governing contract: SPEC §§10.1–10.2, 11.3, 11.5–11.7, 20.1, Appendix A.5; ADR 0014.
 - Key files: `backend/internal/ingest/grades.go`, `backend/internal/ingest/envelope.go`, `backend/internal/ingest/commit.go`, `backend/internal/ingest/preview_test.go`; existing parser: `backend/internal/ingest/roster/grades.go`.
 - Implementation: exact duplicate assignments remain independently reviewable and deduplicated at write time; contradictory normalized-name assignments are `Conflict`; unmatched names are `Conflict` and never create students; unknown grades are `Error`.
-- Validation so far: `go test ./...` passes; focused ingest tests pass; `git diff --check` passes. Required make gates and PR handoff remain.
-- Open items: run all ten project gate commands as available, commit/push, open PR with `Fixes #125`, inspect CI/review, and update Workpad status only after the PR gate is ready.
+- Validation: focused ingest tests, `go test ./...`, `go test -race -v ./... -count=1`, `make lint-backend`, `make format`, `make generate` plus generated-path drift, and `git diff --check` pass. All ten required PR CI checks pass on PR #134 head `ae05578`; local test-backend, migration, frontend, and smoke commands are environment-limited as recorded in the Workpad.
+- Handoff: PR #134 is open, non-draft, references #125 with `Fixes #125`, and has no review or inline comments. Detent should advance the issue through its configured review lane.
 - Skill draft: no — implementation uses existing import/data patterns and has not exposed a broadly reusable non-routine method.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -1,45 +1,8 @@
-## Current handoff — issue #123
+## Current handoff — issue #125
 
-- Scope: the read-only `internal/ingest` envelope, roster matching/classification, and `POST /api/imports/{kind}/preview`; no domain writes or audit entries.
-- Governing contract: SPEC §§5.2, 9.4, 10.1–10.2, 11.1, 11.3–11.7, 20.1, 21.3; ADRs 0007, 0008, 0014.
-- Base: `origin/main` at `ebb145b`; P2-2/#121 and P2-3/#122 are terminal/merged dependencies. Issue #123 is In Progress; no PR yet.
-- Existing implementation: `internal/ingest/roster` parses the synthetic `roster_json` and `grades_csv` corpus; `internal/ingest` now registers both kinds, previews `roster_json` as a source-row tree, matches only by year-scoped external ID, reports field changes, soft-delete conflicts, vocabulary errors, exclusions, warnings, and guardian removals, and hashes exact bytes. `POST /api/imports/{kind}/preview` is registered with `manage_roster`; `grades_csv` remains registered but unsupported until P2-6 owns whole-name matching and grade resolution.
-- Validation: focused ingest/API/integration tests pass; `go test -race -v ./... -count=1`, backend lint/depguard, format/vet, generated OpenAPI determinism, and `git diff --check` pass. New integration coverage exercises tenant isolation, closed years, read-only audit counts, the full synthetic corpus, repeated previews, and one hand edit. Local `make test-backend` and `make smoke` stop at the pre-existing `/miniclass-postgres` Docker name collision / missing `.env`; `make test-migrations` has no `MIGRATION_ROUNDTRIP_DATABASE_URL`; frontend test/build/lint cannot run because dependencies are not installed (`openapi-typescript` missing, `bunx eslint` temp install denied).
-- Handoff: commits `1f04952`, `7c54e0e`, and `565d95a` are pushed in PR #132 (`Fixes #123`), which is open and non-draft. Current head `565d95a` passed all ten required CI checks; no review or inline comments are actionable. Detent should advance the issue through its configured review lane.
-- Skill draft: no — this change used the repository's existing service/test patterns and exposed no broadly reusable non-routine method.
-
-## 2026-08-30T07:19:09Z - Failed run output tail
-
-- final_state: failed
-- error: stream turn: context canceled
-close codex app-server transport: signal: terminated: stderr: [2m2026-08-30T05:47:37.547587Z[0m [31mERROR[0m [2mcodex_core::tools::router[0m[2m:[0m [3merror[0m[2m=[0mapply_patch verification failed: invalid patch: multiple operations target /Users/chrismott/dev/personal/miniclass-worktrees/miniclass-christophergm_miniclass_122-2feb50729d32/.detent/notes.md
-[2m2026-08-30T05:52:38.655340Z[0m [31mERROR[0m [2mcodex_core::tools::router[0m[2m:[0m [3merror[0m[2m=[0mapply_patch verification failed: Failed to find expected lines in /Users/chrismott/dev/personal/miniclass-worktrees/miniclass-christophergm_miniclass_122-2feb50729d32/backend/internal/ingest/roster/cmd/generate/main.go:
-	directory := filepath.Join("..", "testdata")
-worker github REST budget monitor failed: Get "https://api.github.com/rate_limit": dial tcp: lookup api.github.com: no such host
-
-Output tail:
-
-```text
-I’m continuing issue #122 from the Detent worktree. I’ll first verify the preserved repository/tracker state and read the backend-development guidance, then complete the parser/filter/corpus implementation, run the required gates, and finish the PR handoff with the Workpad updated.The branch already contains a prior commit (`7f89d69`) and has no uncommitted changes, so I’m treating it as preserved implementation rather than starting over. The required skill confirms the Go/service conventions; next I’m checking the issue/PR state and auditing the committed diff against the repository instructions and acceptance scope.Issue #122 is still open/in progress, with no PR or existing Workpad comment. The repository has no ingest package yet; the current committed change is only a frontend fixture correction from the prior attempt. I found the governing contract in SPEC §§11.3–11.7 and ADR 0014, including the exact observed counts and the decision that classroom bands remain display-only. I’m now defining the package around those contracts and will include compatibility-friendly exported types/functions plus golden synthetic fixtures.I’m recording the required persistent Workpad now with the issue’s acceptance criteria, the SPEC/ADR citations, and an explicit `in_progress` status. I’ll also replace the stale handoff notes so the next stage sees issue #122’s actual scope and validation state.The first Workpad/notes write hit a tooling constraint because the patch tried to delete and recreate the same file in one operation; no repository change was accepted. I’m splitting that into separate safe edits and will then post the Workpad comment.The implementation shape is now clear: a stateless parser will decode only named fields into a canonical result, track child identity independently of source order, apply enrollment/adult filters after collecting all occurrences, and return warnings/exclusions as data. I’m adding the parser, a deterministic 324-adult/247-child synthetic source generator, golden files, and tests that exercise the edge cases explicitly required by the issue.The parser and generator compile. The first generation run revealed a path mistake in the generator: `../testdata` placed files beside the package instead of under `internal/ingest/roster/testdata`. I’m correcting that now, removing only those disposable misplaced outputs, and then I’ll add the behavioral tests before generating the committed goldens again.The first focused test pass caught three concrete issues in the initial implementation: only children referenced by relationships are visible (so the synthetic generator needed to reference all 62 unenrolled children), retained adults must not emit relationships to excluded children, and the contradiction error assertion should check the two quoted name variants as the parser reports them. I’m fixing those semantics now; these are exactly the kinds of filter-boundary checks the acceptance criteria require.The focused suite now passes for parser behavior and synthetic aggregate counts: 185 enrolled students, 226 retained adults, 303 edges, 62 child exclusions, and the three adult exclusion buckets. I’m doing a second semantic review before broad validation—especially repeated-child classroom data, golden-file verification, and dead/ambiguous helper code—so the committed fixtures prove the generator output rather than merely existing beside it.
-```
-
-## 2026-08-30T19:21:37Z - Failed run output tail
-
-- final_state: failed
-- error: stream turn: context canceled
-close codex app-server transport: signal: terminated: stderr: [2m2026-08-30T19:20:36.174186Z[0m [31mERROR[0m [2mcodex_core::tools::router[0m[2m:[0m [3merror[0m[2m=[0mapply_patch verification failed: Failed to find expected lines in /Users/chrismott/dev/personal/miniclass-worktrees/miniclass-christophergm_miniclass_124-13f201f62fd7/backend/cmd/api/main.go:
-		WithGuardianRelationships(people.New(database)),
-		WithImportPreview(ingest.NewPreviewService(database)),
-worker github REST budget monitor failed: Get "https://api.github.com/rate_limit": context deadline exceeded
-
-Output tail:
-
-```text
-I’m continuing issue #124 from its preserved Detent worktree. I’ll use the backend-development guidance, verify the current implementation and tracker/Workpad state, then complete the commit-phase behavior, run focused and full gates, and finish the PR handoff.The preserved worktree is clean at `origin/main` and issue #124 has no PR or Workpad comment yet; the checked-in `.detent/notes.md` is stale from #123. I’m treating the issue’s acceptance criteria as authoritative and auditing the existing ingest/data/API patterns plus SPEC §11/§20 and ADR 0014 before coding.The design is now pinned down: the service will recompute the preview inside one tenant transaction, reject hash drift or any `Error` before mutation, apply roster people and relationship changes through `internal/data`, hard-delete only the represented adult’s omitted edges, and append per-removal plus one aggregate `import_commit` audit record. The API will carry the hash as `content_hash` alongside the exact raw document and reuse `manage_roster`.
-```
-## Current handoff — issue #124
-
-- Scope: atomic `roster_json` import commit with content-hash binding, conflict/error policy, literal adult guardian-edge authority and hard-delete audits; API commit route is wired with `manage_roster`. Governing contract: SPEC §§11.2, 11.4–11.7, 20.1; ADRs 0007 and 0014.
-- Key files: `backend/internal/ingest/commit.go`, `envelope.go`, `preview.go`; `backend/internal/api/handlers/import.go`, `routes.go`, `server.go`; `backend/openapi.json`.
-- Validation: focused ingest/API tests, `go test ./...`, backend lint/depguard, format/vet, OpenAPI generation/drift and `git diff --check` pass. PR CI passed all ten required gates; local `make check` stopped at `db-up` because `/miniclass-postgres` is already occupied.
-- Handoff complete: PR #133 is open, non-draft, clean, references #124, and has no actionable review comments. No skill draft: this used existing service/data patterns without exposing a reusable non-routine method.
+- Scope: P2-6 `grades_csv`: header-name parsing, whole-cell normalized legal/preferred-name matching, update-only grade vocabulary resolution, preview/commit/idempotency, and audit summary. Governing contract: SPEC §§10.1–10.2, 11.3, 11.5–11.7, 20.1, Appendix A.5; ADR 0014.
+- Key files: `backend/internal/ingest/grades.go`, `backend/internal/ingest/envelope.go`, `backend/internal/ingest/commit.go`, `backend/internal/ingest/preview_test.go`; existing parser: `backend/internal/ingest/roster/grades.go`.
+- Implementation: exact duplicate assignments remain independently reviewable and deduplicated at write time; contradictory normalized-name assignments are `Conflict`; unmatched names are `Conflict` and never create students; unknown grades are `Error`.
+- Validation so far: `go test ./...` passes; focused ingest tests pass; `git diff --check` passes. Required make gates and PR handoff remain.
+- Open items: run all ten project gate commands as available, commit/push, open PR with `Fixes #125`, inspect CI/review, and update Workpad status only after the PR gate is ready.
+- Skill draft: no — implementation uses existing import/data patterns and has not exposed a broadly reusable non-routine method.

--- a/backend/internal/ingest/commit.go
+++ b/backend/internal/ingest/commit.go
@@ -256,6 +256,46 @@ func commitRoster(ctx context.Context, request CommitRequest) error {
 	return nil
 }
 
+func commitGrades(ctx context.Context, request CommitRequest) error {
+	rows, ok := request.Parsed.([]roster.GradeRecord)
+	if !ok {
+		return errors.New("commit grades: unexpected parsed document")
+	}
+	if request.Tx == nil {
+		return errors.New("commit grades: transaction is nil")
+	}
+
+	updated := make(map[ids.XID]struct{})
+	for index, source := range rows {
+		if index >= len(request.Preview.Rows) || len(request.Preview.Rows[index].Records) != 1 {
+			return fmt.Errorf("commit grades: row %d is absent from the preview", index+2)
+		}
+		record := request.Preview.Rows[index].Records[0]
+		if record.Outcome != OutcomeUpdate {
+			continue
+		}
+		candidates := matchingGradeStudents(source.StudentName, request.State.Students)
+		if len(candidates) != 1 {
+			return fmt.Errorf("commit grades: row %d no longer has a unique student match", index+2)
+		}
+		student := candidates[0]
+		if _, exists := updated[student.ID]; exists {
+			continue
+		}
+		level, detail := resolveGradeLevel(source.Grade, request.State.GradeLevels)
+		if detail != "" {
+			return fmt.Errorf("commit grades: row %d: %s", index+2, detail)
+		}
+		if _, err := request.Tx.UpdateStudent(ctx, ids.XID(request.SchoolYearID), student.ID,
+			student.LegalGivenName, student.LegalFamilyName, student.PreferredGivenName, &level.ID,
+			student.HomeroomID, student.ExternalIdentifier, student.PriorYearStudentID); err != nil {
+			return fmt.Errorf("update grade for %q: %w", source.StudentName, err)
+		}
+		updated[student.ID] = struct{}{}
+	}
+	return nil
+}
+
 func previewRecordIndex(preview Preview) map[string]RecordPreview {
 	result := make(map[string]RecordPreview)
 	for _, row := range preview.Rows {

--- a/backend/internal/ingest/envelope.go
+++ b/backend/internal/ingest/envelope.go
@@ -66,8 +66,8 @@ type Registry struct {
 }
 
 // NewRegistry returns the Phase 2 registry containing both declared source
-// kinds. grades_csv is registered now so adding its kind does not require a
-// new envelope; its matching and writing behavior arrives in P2-6.
+// kinds. Each kind owns parsing, matching, and writing behind the same
+// content-hash-guarded envelope.
 func NewRegistry() *Registry {
 	registry := &Registry{kinds: make(map[string]Kind)}
 	registry.MustRegister(Kind{
@@ -79,8 +79,8 @@ func NewRegistry() *Registry {
 	registry.MustRegister(Kind{
 		Name:    KindGradesCSV,
 		Parser:  func(document []byte) (any, error) { return roster.ParseGradesCSV(bytes.NewReader(document)) },
-		Matcher: unsupportedMatcher,
-		Writer:  unavailableWriter,
+		Matcher: matchGrades,
+		Writer:  commitGrades,
 	})
 	return registry
 }

--- a/backend/internal/ingest/grades.go
+++ b/backend/internal/ingest/grades.go
@@ -1,0 +1,163 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/chrismott/miniclass/internal/data"
+	"github.com/chrismott/miniclass/internal/ids"
+	"github.com/chrismott/miniclass/internal/ingest/roster"
+)
+
+// matchGrades implements the update-only grades_csv source. The CSV has no
+// opaque identifier, so its complete name cell is matched against the two
+// names the student may use in this application.
+func matchGrades(_ context.Context, parsed any, state CurrentState) (Preview, error) {
+	rows, ok := parsed.([]roster.GradeRecord)
+	if !ok {
+		return Preview{}, errors.New("grades_csv matcher received an unexpected parsed document")
+	}
+
+	preview := Preview{
+		Rows:                         make([]SourceRowPreview, 0, len(rows)),
+		GuardianRelationshipRemovals: []GuardianRelationshipRemoval{},
+		Exclusions:                   []ExclusionPreview{},
+		Warnings:                     []PreviewNotice{},
+	}
+	duplicateGrades := make(map[string]string, len(rows))
+	contradictoryDuplicates := make(map[string]struct{})
+	for _, source := range rows {
+		nameKey := normalizeImportName(source.StudentName)
+		gradeKey := normalizeImportText(source.Grade)
+		if previous, exists := duplicateGrades[nameKey]; exists && previous != gradeKey {
+			// A source that assigns two grades to the same normalized name cannot
+			// be made safe by choosing one. Both rows remain visible conflicts.
+			contradictoryDuplicates[nameKey] = struct{}{}
+			continue
+		}
+		duplicateGrades[nameKey] = gradeKey
+	}
+
+	for index, source := range rows {
+		record := classifyGrade(source, state.Students, state.GradeLevels)
+		nameKey := normalizeImportName(source.StudentName)
+		if _, exists := contradictoryDuplicates[nameKey]; exists {
+			record.Outcome = OutcomeConflict
+			record.Changes = nil
+			record.Detail = fmt.Sprintf("normalized student name is assigned more than one grade in the source (including %q)", source.Grade)
+		}
+		preview.Rows = append(preview.Rows, SourceRowPreview{
+			Number:                   index + 2,
+			SourceExternalIdentifier: source.StudentName,
+			Outcome:                  record.Outcome,
+			Records:                  []RecordPreview{record},
+		})
+		addCount(&preview.Counts, record.Outcome)
+	}
+	return preview, nil
+}
+
+func classifyGrade(source roster.GradeRecord, students []data.Student, levels []data.GradeLevel) RecordPreview {
+	record := RecordPreview{RecordType: "student", SourceExternalIdentifier: source.StudentName}
+	if normalizeImportName(source.StudentName) == "" {
+		record.Outcome, record.Detail = OutcomeError, "grade row has no student name"
+		return record
+	}
+
+	candidates := matchingGradeStudents(source.StudentName, students)
+	if len(candidates) == 0 {
+		// This kind is deliberately update-only. An unmatched row is reviewable
+		// but never becomes a new student with a missing required homeroom.
+		record.Outcome, record.Detail = OutcomeConflict, "no existing student matches this normalized whole name; the row will be skipped"
+		return record
+	}
+	if len(candidates) > 1 {
+		record.Outcome, record.Detail = OutcomeConflict, "normalized whole name matches more than one student; the importer will not choose"
+		return record
+	}
+	student := candidates[0]
+	record.ExistingID = string(student.ID)
+	if student.DeletedAt != nil {
+		record.Outcome, record.Detail = OutcomeConflict, fmt.Sprintf("student matches a soft-deleted record; restore it before importing (deleted at %s)", student.DeletedAt.UTC().Format("2006-01-02T15:04:05Z07:00"))
+		record.DeletedAt = student.DeletedAt
+		return record
+	}
+
+	level, detail := resolveGradeLevel(source.Grade, levels)
+	if detail != "" {
+		record.Outcome, record.Detail = OutcomeError, detail
+		return record
+	}
+	if student.GradeLevelID != nil && *student.GradeLevelID == level.ID {
+		record.Outcome = OutcomeUnchanged
+		return record
+	}
+
+	var before any
+	if student.GradeLevelID != nil {
+		before = string(*student.GradeLevelID)
+	}
+	record.Outcome = OutcomeUpdate
+	record.Changes = []FieldChange{{Field: "grade_level_id", Before: before, After: string(level.ID)}}
+	record.Detail = fmt.Sprintf("grade resolves to %q (%s)", level.Label, level.Code)
+	return record
+}
+
+func matchingGradeStudents(sourceName string, students []data.Student) []data.Student {
+	key := normalizeImportName(sourceName)
+	result := make([]data.Student, 0)
+	seen := make(map[ids.XID]struct{})
+	for _, student := range students {
+		legal := normalizeImportName(student.LegalGivenName + " " + student.LegalFamilyName)
+		preferred := ""
+		if student.PreferredGivenName != nil {
+			preferred = normalizeImportName(*student.PreferredGivenName + " " + student.LegalFamilyName)
+		}
+		if key != legal && (preferred == "" || key != preferred) {
+			continue
+		}
+		if _, exists := seen[student.ID]; exists {
+			continue
+		}
+		seen[student.ID] = struct{}{}
+		result = append(result, student)
+	}
+	return result
+}
+
+func resolveGradeLevel(source string, levels []data.GradeLevel) (data.GradeLevel, string) {
+	key := normalizeImportText(source)
+	if key == "" {
+		return data.GradeLevel{}, "grade label is empty or unrecognized"
+	}
+	var matches []data.GradeLevel
+	seen := make(map[ids.XID]struct{})
+	for _, level := range levels {
+		if key != normalizeImportText(level.Code) && key != normalizeImportText(level.Label) {
+			continue
+		}
+		if _, exists := seen[level.ID]; exists {
+			continue
+		}
+		seen[level.ID] = struct{}{}
+		matches = append(matches, level)
+	}
+	if len(matches) == 0 {
+		return data.GradeLevel{}, fmt.Sprintf("grade label %q is not recognized by the grade-level vocabulary", source)
+	}
+	if len(matches) > 1 {
+		return data.GradeLevel{}, fmt.Sprintf("grade label %q matches more than one grade-level vocabulary entry", source)
+	}
+	return matches[0], ""
+}
+
+// normalizeImportName intentionally receives the whole name cell. Do not
+// split it into tokens: Appendix A.5 includes two-word surnames as a defect
+// case, and only the canonical given/family combinations may be compared.
+func normalizeImportName(value string) string { return normalizeImportText(value) }
+
+func normalizeImportText(value string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(value)), " "))
+}

--- a/backend/internal/ingest/preview_test.go
+++ b/backend/internal/ingest/preview_test.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
@@ -27,6 +28,63 @@ func TestRegistryHasPhaseTwoKindsAndRequiredHooks(t *testing.T) {
 	}
 	require.Error(t, registry.Register(Kind{Name: KindRosterJSON, Parser: func([]byte) (any, error) { return nil, nil }, Matcher: unsupportedMatcher, Writer: unavailableWriter}))
 	require.Error(t, NewEmptyRegistry().Register(Kind{Name: "incomplete"}))
+}
+
+func TestGradesPreviewMatchesWholeNamesAndRemainsUpdateOnly(t *testing.T) {
+	preferred := "Katie"
+	gradeID := ids.XID("grade-four")
+	state := CurrentState{
+		SchoolYear: data.SchoolYear{ID: "year-grades", State: data.SchoolYearSetup},
+		Students: []data.Student{
+			{ID: "student-katie", LegalGivenName: "Katherine", LegalFamilyName: "Smith", PreferredGivenName: &preferred},
+			{ID: "student-del-a", LegalGivenName: "Riley", LegalFamilyName: "De La Sample"},
+			{ID: "student-alice", LegalGivenName: "Alice", LegalFamilyName: "Jones"},
+			{ID: "student-jordan", LegalGivenName: "Jordan", LegalFamilyName: "Unknown"},
+			{ID: "student-ambiguous-a", LegalGivenName: "Taylor", LegalFamilyName: "Same"},
+			{ID: "student-ambiguous-b", LegalGivenName: "Taylor", LegalFamilyName: "Same"},
+		},
+		GradeLevels: []data.GradeLevel{{ID: gradeID, Code: "4", Label: "Fourth Grade"}},
+	}
+	rows := []roster.GradeRecord{
+		{StudentName: "Katie Smith", Grade: "4"},
+		{StudentName: "  Riley   De La Sample ", Grade: "Fourth   Grade"},
+		{StudentName: " alice   JONES ", Grade: "4"},
+		{StudentName: "Taylor Same", Grade: "4"},
+		{StudentName: "Missing Student", Grade: "4"},
+		{StudentName: "Jordan Unknown", Grade: "not-a-grade"},
+		{StudentName: "Katie Smith", Grade: "4"},
+	}
+
+	preview, err := matchGrades(context.TODO(), rows, state)
+	require.NoError(t, err)
+	require.Equal(t, OutcomeCounts{Update: 4, Conflict: 2, Error: 1}, preview.Counts)
+	require.Len(t, preview.Rows, len(rows))
+	require.Equal(t, OutcomeUpdate, preview.Rows[0].Outcome, "preferred-name-only match")
+	require.Equal(t, "student-katie", preview.Rows[0].Records[0].ExistingID)
+	require.Equal(t, "grade_level_id", preview.Rows[0].Records[0].Changes[0].Field)
+	require.Nil(t, preview.Rows[0].Records[0].Changes[0].Before)
+	require.Equal(t, string(gradeID), preview.Rows[0].Records[0].Changes[0].After)
+	require.Equal(t, OutcomeUpdate, preview.Rows[1].Outcome, "two-word surname remains part of the whole name")
+	require.Equal(t, OutcomeUpdate, preview.Rows[2].Outcome, "case and internal whitespace are normalized")
+	require.Equal(t, OutcomeConflict, preview.Rows[3].Outcome, "ambiguous names are never chosen")
+	require.Equal(t, OutcomeConflict, preview.Rows[4].Outcome, "unmatched names are not created")
+	require.Equal(t, OutcomeError, preview.Rows[5].Outcome, "unknown vocabulary is an error")
+	require.Equal(t, OutcomeUpdate, preview.Rows[6].Outcome, "an identical duplicate remains reviewable")
+}
+
+func TestGradesPreviewConflictsContradictoryDuplicateAssignments(t *testing.T) {
+	state := CurrentState{
+		Students:    []data.Student{{ID: "student-1", LegalGivenName: "Casey", LegalFamilyName: "One"}},
+		GradeLevels: []data.GradeLevel{{ID: "grade-three", Code: "3", Label: "Third Grade"}, {ID: "grade-four", Code: "4", Label: "Fourth Grade"}},
+	}
+	preview, err := matchGrades(context.TODO(), []roster.GradeRecord{
+		{StudentName: "Casey One", Grade: "3"},
+		{StudentName: " casey   one ", Grade: "Fourth Grade"},
+	}, state)
+	require.NoError(t, err)
+	require.Equal(t, OutcomeCounts{Conflict: 2}, preview.Counts)
+	require.Equal(t, OutcomeConflict, preview.Rows[0].Outcome)
+	require.Equal(t, OutcomeConflict, preview.Rows[1].Outcome)
 }
 
 func TestContentHashCoversExactSubmittedBytes(t *testing.T) {

--- a/backend/tests/integration/import_preview_test.go
+++ b/backend/tests/integration/import_preview_test.go
@@ -195,6 +195,61 @@ func TestImportPreviewRejectsClosedSchoolYear(t *testing.T) {
 	require.True(t, errors.Is(err, ingest.ErrSchoolYearClosed), "closed year = %v", err)
 }
 
+// TestGradesImportUpdatesExistingStudentsOnly verifies the name-based,
+// update-only source through the tenant transaction and commit audit boundary.
+func TestGradesImportUpdatesExistingStudentsOnly(t *testing.T) {
+	harness := testharness.Open(t)
+	ctx := harness.Context
+	organizationID := harness.MintOrganization(t)
+	actor := audit.Actor{Type: audit.ActorTypeSystem, Label: "grades import integration test"}
+	year, err := schoolyear.New(harness.Database).Create(ctx, string(organizationID), actor, "2026–2027")
+	require.NoError(t, err)
+	homeroom, err := vocabulary.New(harness.Database).CreateHomeroom(ctx, string(organizationID), actor, "Grades Room", nil)
+	require.NoError(t, err)
+	grade, err := vocabulary.New(harness.Database).CreateGrade(ctx, string(organizationID), actor, "4", "Fourth Grade")
+	require.NoError(t, err)
+	preferred := "Katie"
+	peopleService := people.New(harness.Database)
+	_, err = peopleService.CreateStudent(ctx, string(organizationID), year.ID, actor, people.StudentCreateInput{
+		LegalGivenName: "Katherine", LegalFamilyName: "Smith", PreferredGivenName: &preferred, HomeroomID: homeroom.ID,
+	})
+	require.NoError(t, err)
+	_, err = peopleService.CreateStudent(ctx, string(organizationID), year.ID, actor, people.StudentCreateInput{
+		LegalGivenName: "Riley", LegalFamilyName: "De La Sample", HomeroomID: homeroom.ID,
+	})
+	require.NoError(t, err)
+
+	document := []byte("grade,student_name\n4,Katie Smith\nFourth Grade, Riley   De La Sample\n")
+	service := ingest.NewPreviewService(harness.Database)
+	preview, err := service.Preview(ctx, string(organizationID), year.ID, ingest.KindGradesCSV, document)
+	require.NoError(t, err)
+	require.Equal(t, ingest.OutcomeCounts{Update: 2}, preview.Counts)
+	require.Equal(t, "grade_level_id", preview.Rows[0].Records[0].Changes[0].Field)
+	require.Nil(t, preview.Rows[0].Records[0].Changes[0].Before)
+	require.Equal(t, string(grade.ID), preview.Rows[0].Records[0].Changes[0].After)
+
+	auditBefore := countAuditEntries(t, harness.Database, ctx, organizationID)
+	committed, err := service.Commit(ctx, string(organizationID), year.ID, ingest.KindGradesCSV, document, preview.ContentHash, actor)
+	require.NoError(t, err)
+	require.Equal(t, preview, committed)
+	require.Equal(t, auditBefore+1, countAuditEntries(t, harness.Database, ctx, organizationID), "one import_commit audit entry per commit")
+
+	students, err := peopleService.ListStudents(ctx, string(organizationID), year.ID, false)
+	require.NoError(t, err)
+	require.Len(t, students, 2, "grades import is update-only")
+	for _, student := range students {
+		require.NotNil(t, student.GradeLevelID)
+		require.Equal(t, grade.ID, *student.GradeLevelID)
+	}
+
+	repeated, err := service.Preview(ctx, string(organizationID), year.ID, ingest.KindGradesCSV, document)
+	require.NoError(t, err)
+	require.Equal(t, ingest.OutcomeCounts{Unchanged: 2}, repeated.Counts, "re-import is idempotent")
+	_, err = service.Commit(ctx, string(organizationID), year.ID, ingest.KindGradesCSV, document, repeated.ContentHash, actor)
+	require.NoError(t, err)
+	require.Equal(t, auditBefore+2, countAuditEntries(t, harness.Database, ctx, organizationID), "the repeated commit adds one aggregate audit entry")
+}
+
 func countAuditEntries(t *testing.T, database *data.DB, ctx context.Context, organizationID ids.XID) int64 {
 	t.Helper()
 	var count int64


### PR DESCRIPTION
Fixes #125

## Summary

- Registers `grades_csv` with the existing import envelope and parses named CSV headers.
- Matches the complete normalized student name against legal and preferred given names plus the full family name; no fuzzy matching or token splitting.
- Keeps grades import update-only, reports unmatched/ambiguous rows as conflicts, resolves active grade vocabulary by normalized code or label, and rejects unknown labels as errors.
- Shows field-level grade changes, preserves unrelated student fields, handles duplicate rows safely, and records the existing aggregate import audit entry.

## Contract

Implements SPEC §§10.1–10.2, 11.3, 11.5–11.7, 20.1, and Appendix A.5, with source-authority decisions from ADR 0014.

## Validation

- `go test -race -v ./... -count=1`
- `make lint-backend`
- `make format`
- `make generate` plus generated-path drift check
- `git diff --check`
- Focused matcher tests and added grades commit integration coverage

The database-backed integration test is present but skipped locally without `TEST_DATABASE_URL` and `TEST_APP_DATABASE_URL`. The root `make test-backend`/migration/frontend/smoke gates are environment-limited as documented in the issue Workpad.