### PR TITLE
D11-1: enforce year-scoped composite schema keys

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -1,9 +1,8 @@
-## Current handoff — issue #127
+## Current handoff — issue #138
 
-- Scope: Gate annual program membership on a known student grade; governing contract SPEC §§5.2, 8.3, 10.1, 12.1, 14.2 and ADR 0014.
-- Key files: `backend/migrations/20260830200000_programmes.sql`, `backend/internal/data/program.go`, `backend/internal/program/service.go`, `backend/internal/api/handlers/program.go`, `frontend/src/features/programs/ProgramPages.tsx`.
-- Implementation: year-scoped `programs` and `program_memberships` tables with composite FKs, forced RLS and closed-year triggers; audited program/membership services; known-grade refusal names the student; later grade clearing retains and flags membership; missing-grade count links to the roster; generated sqlc/OpenAPI and frontend client/page are included.
-- Isolation: Layer 2 registry entries and integration coverage exercise both new tables, cross-tenant invisibility/mutation/foreign-parent rejection, and the grade gate/flag behavior with organization-scoped fixtures.
-- Validation: direct `go test -race -v ./...`, `make lint-backend`, `make format`, `make generate`, and `git diff --check` pass. `make test-backend` is blocked before tests by the existing `/miniclass-postgres` container-name conflict. Frontend test/build cannot start because `openapi-typescript` is not installed; frontend lint cannot write Bun temp files. Migration round-trip lacks `MIGRATION_ROUNDTRIP_DATABASE_URL`. Smoke requires `.env`.
-- Open items: stage, run cached whitespace/generated checks, commit/push, open/update PR with `Fixes #127` and SPEC/ADR citations, then verify CI/review state.
-- Skill draft: no — the reusable tenant-entity and backend procedures already exist and this change did not expose a new broadly reusable method.
+- Scope: Make the Layer 1 schema meta-test require year-scoped composite uniqueness and composite foreign keys; governed by SPEC §9.2 and ADR 0007 §5 (with ADR 0015 context).
+- Key file: `backend/tests/integration/isolation_test.go`.
+- Implementation: live `school_year_id` detection now gates `unique(id, organization_id, school_year_id)`; FK inspection checks both source and target year columns when the target has a live year column. Named exceptions are `audit_log` and `students.students_prior_year_fk`.
+- Validation: focused integration invocation, `go test -race -v ./...`, `make lint-backend`, `make format`, `make generate && git diff --exit-code`, and `git diff --check` pass. Local database-backed gates are limited by the existing `/miniclass-postgres` name conflict and missing environment prerequisites. PR #141 current head passed all ten required CI checks.
+- Open items: verify final PR/review state and leave the issue for Detent's completion-lane transition.
+- Skill draft: no — the reusable tenant-isolation harness guidance already covers this method; no new broadly reusable procedure was discovered.

--- a/backend/tests/integration/isolation_test.go
+++ b/backend/tests/integration/isolation_test.go
@@ -111,6 +111,15 @@ func verifySchemaContract(t *testing.T, harness *testharness.Harness) {
 	for _, table := range nonTenantTables {
 		allowlist[table] = struct{}{}
 	}
+	// These literals are the deliberate exceptions to the year-scoped schema
+	// contract. Adding a name here must be a visible, spec-cited change.
+	yearScopedUniqueKeyExceptions := map[string]struct{}{
+		"audit_log": {},
+	}
+	yearScopedForeignKeyExceptions := map[string]struct{}{
+		"audit_log":                      {},
+		"students.prior_year_student_id": {},
+	}
 
 	rows, err := harness.Migrator.Query(harness.Context, `
 		select c.relname
@@ -134,7 +143,7 @@ func verifySchemaContract(t *testing.T, harness *testharness.Harness) {
 		}
 		tenantTables[table] = struct{}{}
 
-		var hasOrganizationID, rlsEnabled, rlsForced, hasPolicy, hasUnique bool
+		var hasOrganizationID, hasSchoolYearID, rlsEnabled, rlsForced, hasPolicy, hasUnique, hasYearScopedUnique bool
 		err := harness.Migrator.QueryRow(harness.Context, `
 			select
 				exists (
@@ -147,6 +156,13 @@ func verifySchemaContract(t *testing.T, harness *testharness.Harness) {
 					  and typ.typnamespace = 'public'::regnamespace
 					  and typ.typname = 'xid20'
 				),
+				exists (
+					select 1
+					from pg_attribute year_attr
+					where year_attr.attrelid = c.oid
+					  and year_attr.attname = 'school_year_id'
+					  and not year_attr.attisdropped
+				),
 				c.relrowsecurity,
 				c.relforcerowsecurity,
 				exists (
@@ -155,32 +171,36 @@ func verifySchemaContract(t *testing.T, harness *testharness.Harness) {
 					  and p.tablename = c.relname
 					  and (coalesce(p.qual, '') || coalesce(p.with_check, '')) like '%app.organization_id%'
 				),
+					exists (
+						select 1
+						from pg_constraint con
+						where con.conrelid = c.oid
+						  and con.contype = 'u'
+						  and (
+							  (select array_agg(att.attname order by cols.ordinality)
+							   from unnest(con.conkey) with ordinality cols(attnum, ordinality)
+							   join pg_attribute att on att.attrelid = con.conrelid and att.attnum = cols.attnum)
+							      = array['id', 'organization_id']::name[]
+							  or (select array_agg(att.attname order by cols.ordinality)
+							      from unnest(con.conkey) with ordinality cols(attnum, ordinality)
+							      join pg_attribute att on att.attrelid = con.conrelid and att.attnum = cols.attnum)
+							      = array['id', 'organization_id', 'school_year_id']::name[]
+						  )
+				),
 				exists (
 					select 1
 					from pg_constraint con
 					where con.conrelid = c.oid
 					  and con.contype = 'u'
-					  and (
-						  (select array_agg(att.attname order by cols.ordinality)
-						   from unnest(con.conkey) with ordinality cols(attnum, ordinality)
-						   join pg_attribute att on att.attrelid = con.conrelid and att.attnum = cols.attnum)
-						      = array['id', 'organization_id']::name[]
-						  or (exists (
-							  select 1
-							  from pg_attribute year_attr
-							  where year_attr.attrelid = c.oid
-							    and year_attr.attname = 'school_year_id'
-							    and not year_attr.attisdropped
-						  ) and (select array_agg(att.attname order by cols.ordinality)
-						      from unnest(con.conkey) with ordinality cols(attnum, ordinality)
-						      join pg_attribute att on att.attrelid = con.conrelid and att.attnum = cols.attnum)
-						      = array['id', 'organization_id', 'school_year_id']::name[])
-					  )
+					  and (select array_agg(att.attname order by cols.ordinality)
+					       from unnest(con.conkey) with ordinality cols(attnum, ordinality)
+					       join pg_attribute att on att.attrelid = con.conrelid and att.attnum = cols.attnum)
+					      = array['id', 'organization_id', 'school_year_id']::name[]
 				)
 			from pg_class c
 			join pg_namespace n on n.oid = c.relnamespace
 			where n.nspname = current_schema() and c.relname = $1`, table).Scan(
-			&hasOrganizationID, &rlsEnabled, &rlsForced, &hasPolicy, &hasUnique,
+			&hasOrganizationID, &hasSchoolYearID, &rlsEnabled, &rlsForced, &hasPolicy, &hasUnique, &hasYearScopedUnique,
 		)
 		require.NoError(t, err)
 		require.True(t, hasOrganizationID, table+" lacks organization_id")
@@ -188,6 +208,10 @@ func verifySchemaContract(t *testing.T, harness *testharness.Harness) {
 		require.True(t, rlsForced, table+" does not force RLS")
 		require.True(t, hasPolicy, table+" lacks an app.organization_id policy")
 		require.True(t, hasUnique, table+" lacks unique(id, organization_id)")
+		if _, exempt := yearScopedUniqueKeyExceptions[table]; !exempt && hasSchoolYearID {
+			require.True(t, hasYearScopedUnique,
+				table+" lacks unique constraint (id, organization_id, school_year_id); missing column: school_year_id")
+		}
 
 		var queryCount int64
 		err = harness.App.QueryRow(harness.Context, `select count(*) from `+quoteIdentifier(harness.Schema)+`.`+quoteIdentifier(table)).Scan(&queryCount)
@@ -232,6 +256,7 @@ func verifySchemaContract(t *testing.T, harness *testharness.Harness) {
 	foreignKeys, err := harness.Migrator.Query(harness.Context, `
 		select con.conrelid::regclass::text,
 		       con.confrelid::regclass::text,
+		       con.conname,
 		       array(select a.attname
 		             from unnest(con.conkey) with ordinality cols(attnum, ordinality)
 		             join pg_attribute a on a.attrelid = con.conrelid and a.attnum = cols.attnum
@@ -239,16 +264,24 @@ func verifySchemaContract(t *testing.T, harness *testharness.Harness) {
 		       array(select a.attname
 		             from unnest(con.confkey) with ordinality cols(attnum, ordinality)
 		             join pg_attribute a on a.attrelid = con.confrelid and a.attnum = cols.attnum
-		             order by cols.ordinality)
+		             order by cols.ordinality),
+		       exists (
+			       select 1
+			       from pg_attribute target_year_attr
+			       where target_year_attr.attrelid = con.confrelid
+			         and target_year_attr.attname = 'school_year_id'
+			         and not target_year_attr.attisdropped
+		       )
 		from pg_constraint con
 		join pg_namespace src on src.oid = con.connamespace
 		where con.contype = 'f' and src.nspname = current_schema()`)
 	require.NoError(t, err)
 	defer foreignKeys.Close()
 	for foreignKeys.Next() {
-		var source, target string
+		var source, target, constraint string
 		var sourceColumns, targetColumns []string
-		require.NoError(t, foreignKeys.Scan(&source, &target, &sourceColumns, &targetColumns))
+		var targetYearScoped bool
+		require.NoError(t, foreignKeys.Scan(&source, &target, &constraint, &sourceColumns, &targetColumns, &targetYearScoped))
 		if _, sourceTenant := tenantTables[strings.TrimPrefix(source, harness.Schema+".")]; !sourceTenant {
 			continue
 		}
@@ -257,6 +290,27 @@ func verifySchemaContract(t *testing.T, harness *testharness.Harness) {
 		}
 		require.Contains(t, sourceColumns, "organization_id", source+" FK lacks organization_id")
 		require.Contains(t, targetColumns, "organization_id", target+" FK target lacks organization_id")
+		if !targetYearScoped {
+			continue
+		}
+		sourceTable := strings.TrimPrefix(source, harness.Schema+".")
+		if _, exempt := yearScopedForeignKeyExceptions[sourceTable]; exempt {
+			continue
+		}
+		foreignKeyExcepted := false
+		for _, sourceColumn := range sourceColumns {
+			if _, exempt := yearScopedForeignKeyExceptions[sourceTable+"."+sourceColumn]; exempt {
+				foreignKeyExcepted = true
+				break
+			}
+		}
+		if foreignKeyExcepted {
+			continue
+		}
+		require.Contains(t, sourceColumns, "school_year_id",
+			fmt.Sprintf("%s constraint %s FK to %s lacks source column school_year_id", source, constraint, target))
+		require.Contains(t, targetColumns, "school_year_id",
+			fmt.Sprintf("%s constraint %s FK to %s lacks target column school_year_id", source, constraint, target))
 	}
 	require.NoError(t, foreignKeys.Err())
 }


### PR DESCRIPTION
## Summary

- Require `unique(id, organization_id, school_year_id)` for every live year-bearing tenant table.
- Require `school_year_id` on both sides of foreign keys targeting year-bearing tenant tables.
- Keep explicit exceptions for `audit_log` and `students.prior_year_student_id`.

## Contract

Implements SPEC §9.2 and ADR 0007 §5, with year-scope context from ADR 0015.

## Validation

- `go test -race -v ./...`
- `go test ./tests/integration -run TestLayerOneIsolationAndAudit -count=1`
- `make lint-backend`
- `make format`
- `make generate && git diff --exit-code`
- `git diff --check`

The Docker-backed `make test-backend` gate is unavailable locally because `/miniclass-postgres` already exists; migration round-trip, frontend, and smoke gates are blocked by the documented local environment prerequisites.

Fixes #138