### PR TITLE
feat(frontend): route single-program years directly

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -179,3 +179,11 @@
 - Validation: local `make format`, `make lint-backend`, `make generate` with generated-artifact drift check, and `git diff --check` pass. Local `make check` stops at Docker address-pool exhaustion; local frontend tests/build/lint are unavailable because dependencies are absent and Bun cannot write its temp cache. PR #178 head `aa9a494` passes all ten required CI checks, is open/non-draft/merge-clean, and has no actionable reviews or comments.
 - Open items: none; Detent owns the completion-lane transition. CI duration was approximately 1m46s; slow checks were Backend tests and Generated code drift at approximately 105s each. No post-merge main CI applies while the PR is open.
 - Skill draft: no — this is a focused frontend routing/presentation change with no broadly reusable procedure discovered.
+## Current work — issue #175
+
+- Scope: route `/y/:schoolYearId` to the sole program detail/home when exactly one program exists, otherwise to `/y/:schoolYearId/programs`; do not infer activity from session lifecycle state.
+- Key files: `frontend/src/App.tsx`, `frontend/src/features/programs/ProgramPages.tsx`, and `frontend/src/features/programs/ProgramPages.test.tsx`.
+- Implementation in progress: `ProgramYearEntryPage` loads the year-scoped program list and uses an explicit count-based `Navigate`; the complete Programs list remains a direct route.
+- Validation: pending focused frontend tests and repository gates.
+- Open items: run validation, commit/push, open PR with `Fixes #175`, verify current-head CI/reviews, then update Workpad completion status.
+- Skill draft: no — this is a focused frontend routing change with no broadly reusable procedure discovered.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -185,6 +185,6 @@
 - Key files: `frontend/src/App.tsx`, `frontend/src/features/programs/ProgramPages.tsx`, and `frontend/src/features/programs/ProgramPages.test.tsx`.
 - Implementation: `ProgramYearEntryPage` loads the year-scoped program list and uses an explicit count-based `Navigate`; the complete Programs list remains a direct route. No program activity or session lifecycle state is consulted.
 - Validation: local backend lint/format, generation drift, and `git diff --check` pass. Local backend tests, migration round-trip, frontend tests/build/lint, and smoke are environment-limited as recorded in the PR. PR #179 head `f6fd5b3` passes all ten required checks; slow checks were Backend tests (104s), Generated code drift (88s), and Backend lint (80s). PR CI duration was 108s; quiet-window wait was 0s; local merge-gate duration was not applicable beyond the clean `git diff --check`; no post-merge main CI applies while the PR is open.
-- Repository state: commit `f6fd5b3` is pushed to PR #179, which references `Fixes #175`, is open, non-draft, clean, and has no actionable reviews or comments.
+- Repository state: commits `f6fd5b3` and `092c830` are pushed to PR #179, which references `Fixes #175`, is open, non-draft, clean, and has no actionable reviews or comments. The final head is `092c830`.
 - Open items: none; Detent owns the completion-lane transition.
 - Skill draft: no — this is a focused frontend routing change with no broadly reusable procedure discovered.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -179,11 +179,12 @@
 - Validation: local `make format`, `make lint-backend`, `make generate` with generated-artifact drift check, and `git diff --check` pass. Local `make check` stops at Docker address-pool exhaustion; local frontend tests/build/lint are unavailable because dependencies are absent and Bun cannot write its temp cache. PR #178 head `aa9a494` passes all ten required CI checks, is open/non-draft/merge-clean, and has no actionable reviews or comments.
 - Open items: none; Detent owns the completion-lane transition. CI duration was approximately 1m46s; slow checks were Backend tests and Generated code drift at approximately 105s each. No post-merge main CI applies while the PR is open.
 - Skill draft: no — this is a focused frontend routing/presentation change with no broadly reusable procedure discovered.
-## Current work — issue #175
+## Current handoff — issue #175
 
 - Scope: route `/y/:schoolYearId` to the sole program detail/home when exactly one program exists, otherwise to `/y/:schoolYearId/programs`; do not infer activity from session lifecycle state.
 - Key files: `frontend/src/App.tsx`, `frontend/src/features/programs/ProgramPages.tsx`, and `frontend/src/features/programs/ProgramPages.test.tsx`.
-- Implementation in progress: `ProgramYearEntryPage` loads the year-scoped program list and uses an explicit count-based `Navigate`; the complete Programs list remains a direct route.
-- Validation: pending focused frontend tests and repository gates.
-- Open items: run validation, commit/push, open PR with `Fixes #175`, verify current-head CI/reviews, then update Workpad completion status.
+- Implementation: `ProgramYearEntryPage` loads the year-scoped program list and uses an explicit count-based `Navigate`; the complete Programs list remains a direct route. No program activity or session lifecycle state is consulted.
+- Validation: local backend lint/format, generation drift, and `git diff --check` pass. Local backend tests, migration round-trip, frontend tests/build/lint, and smoke are environment-limited as recorded in the PR. PR #179 head `f6fd5b3` passes all ten required checks; slow checks were Backend tests (104s), Generated code drift (88s), and Backend lint (80s). PR CI duration was 108s; quiet-window wait was 0s; local merge-gate duration was not applicable beyond the clean `git diff --check`; no post-merge main CI applies while the PR is open.
+- Repository state: commit `f6fd5b3` is pushed to PR #179, which references `Fixes #175`, is open, non-draft, clean, and has no actionable reviews or comments.
+- Open items: none; Detent owns the completion-lane transition.
 - Skill draft: no — this is a focused frontend routing change with no broadly reusable procedure discovered.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,7 @@ import { AdultDetailPage, AdultListPage, StudentDetailPage, StudentListPage } fr
 import { AuditLog } from '@/features/audit/AuditLog'
 import { ImportPage } from '@/features/imports/ImportPage'
 import { OfferingPage } from '@/features/programs/OfferingPages'
-import { ProgramDetailPage, ProgramInterestAreasPage, ProgramListPage, ProgramMembershipPage, ProgramObjectiveWeightsPage, ProgramSettingsPage, SessionObjectiveWeightsPage, SessionPage } from '@/features/programs/ProgramPages'
+import { ProgramDetailPage, ProgramInterestAreasPage, ProgramListPage, ProgramMembershipPage, ProgramObjectiveWeightsPage, ProgramSettingsPage, ProgramYearEntryPage, SessionObjectiveWeightsPage, SessionPage } from '@/features/programs/ProgramPages'
 
 function App() {
   return (
@@ -50,7 +50,7 @@ function AppRoutes() {
 
           <Route path="/y/:schoolYearId" element={<SchoolYearGuard />}>
             <Route element={<SchoolYearLayout />}>
-              <Route index element={<Navigate replace to="settings" />} />
+              <Route index element={<ProgramYearEntryPage />} />
               <Route path="settings" element={<SchoolYearSettingsPage />} />
               <Route path="vocabulary" element={<VocabularyPage />} />
               <Route path="programs" element={<ProgramListPage />} />

--- a/frontend/src/features/programs/ProgramPages.test.tsx
+++ b/frontend/src/features/programs/ProgramPages.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SchoolYear } from '@/lib/apiResources'
 import { renderWithQueryClient } from '@/test/queryClient'
 
-import { ProgramDetailPage, ProgramInterestAreasPage, ProgramListPage, ProgramMembershipPage, ProgramObjectiveWeightsPage, ProgramSettingsPage, SessionObjectiveWeightsPage, SessionPage } from './ProgramPages'
+import { ProgramDetailPage, ProgramInterestAreasPage, ProgramListPage, ProgramMembershipPage, ProgramObjectiveWeightsPage, ProgramSettingsPage, ProgramYearEntryPage, SessionObjectiveWeightsPage, SessionPage } from './ProgramPages'
 import { OfferingPage } from './OfferingPages'
 
 const mocks = vi.hoisted(() => ({
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   programUpdate: vi.fn(),
   sessionUpdate: vi.fn(),
   reorderAreas: vi.fn(),
+  programs: [{ id: 'program-1', organization_id: 'org-1', school_year_id: 'year-1', name: 'Enrichment', created_at: '', updated_at: '' }],
 }))
 
 vi.mock('./usePrograms', () => {
@@ -26,7 +27,7 @@ vi.mock('./usePrograms', () => {
   return {
     useSession: vi.fn(() => ({ data: { id: 'session-1', organization_id: 'org-1', school_year_id: 'year-1', program_id: 'program-1', name: 'Autumn session', state: mocks.sessionState, draft_assignments_stale: false, meeting_dates: ['2026-10-02'], feasibility_warnings: [], created_at: '', updated_at: '' }, isLoading: false, isError: false, error: null })),
     useOffering: vi.fn(() => ({ data: mocks.offering, isLoading: false, isError: false, error: null })),
-    usePrograms: query([{ id: 'program-1', organization_id: 'org-1', school_year_id: 'year-1', name: 'Enrichment', created_at: '', updated_at: '' }]),
+    usePrograms: vi.fn(() => ({ data: mocks.programs, isLoading: false, isError: false, error: null })),
     useSessions: query([{ id: 'session-1', organization_id: 'org-1', school_year_id: 'year-1', program_id: 'program-1', name: 'Autumn session', ordinal: 1, state: 'planning', draft_assignments_stale: false, meeting_dates: ['2026-10-02'], feasibility_warnings: [], created_at: '', updated_at: '' }]),
     useMeetingDates: query([{ id: 'date-1', school_year_id: 'year-1', organization_id: 'org-1', program_id: 'program-1', session_id: 'session-1', meeting_date: '2026-10-02', created_at: '', updated_at: '' }]),
     useOfferings: query([{ id: 'offering-1', school_year_id: 'year-1', organization_id: 'org-1', program_id: 'program-1', session_id: 'session-1', name: 'Making', description: 'Build a project', capacity: 10, minimum_viable_enrollment: 2, min_grade_level_id: 'grade-1', max_grade_level_id: 'grade-1', location: 'Studio', meeting_point: 'Front desk', meeting_instructions: 'Ask for the key', interest_area_id: null, created_at: '', updated_at: '' }]),
@@ -51,6 +52,10 @@ vi.mock('@/lib/hooks/useVocabulary', () => ({ useVocabulary: vi.fn(() => ({ data
 vi.mock('@/features/people/roster-queries', () => ({ usePeople: vi.fn(() => ({ data: [], isLoading: false, isError: false, error: null })) }))
 
 const year = (state: SchoolYear['state']): SchoolYear => ({ id: 'year-1', organization_id: 'org-1', label: '2026–27', state, created_at: '', updated_at: '' })
+
+beforeEach(() => {
+  mocks.programs = [{ id: 'program-1', organization_id: 'org-1', school_year_id: 'year-1', name: 'Enrichment', created_at: '', updated_at: '' }]
+})
 
 function renderSession(currentYear = year('active')) {
   function ContextRoute() { return <Outlet context={currentYear} /> }
@@ -87,6 +92,10 @@ function renderProgramList(currentYear = year('active')) {
   return renderWithQueryClient(<MemoryRouter initialEntries={['/y/year-1/programs']}><Routes><Route element={<ContextRoute />} path="/y/:schoolYearId"><Route element={<ProgramListPage />} path="programs" /></Route></Routes></MemoryRouter>)
 }
 
+function renderProgramYearEntry() {
+  return renderWithQueryClient(<MemoryRouter initialEntries={['/y/year-1']}><Routes><Route path="/y/:schoolYearId"><Route element={<ProgramYearEntryPage />} index /><Route element={<p>Programs list</p>} path="programs" /><Route element={<p>Program detail</p>} path="programs/:programId" /></Route></Routes></MemoryRouter>)
+}
+
 function renderProgramObjectives(currentYear = year('active')) {
   function ContextRoute() { return <Outlet context={currentYear} /> }
   return renderWithQueryClient(<MemoryRouter initialEntries={['/y/year-1/programs/program-1/settings/assignment-planner']}><Routes><Route element={<ContextRoute />} path="/y/:schoolYearId"><Route element={<ProgramObjectiveWeightsPage />} path="programs/:programId/settings/assignment-planner" /></Route></Routes></MemoryRouter>)
@@ -111,6 +120,37 @@ describe('ProgramListPage', () => {
     renderProgramList(year('closed'))
 
     expect(screen.getByRole('button', { name: 'Create program' })).toBeDisabled()
+  })
+})
+
+describe('program year entry', () => {
+  it('routes a year with no programs to the complete Programs list', () => {
+    mocks.programs = []
+    renderProgramYearEntry()
+
+    expect(screen.getByText('Programs list')).toBeInTheDocument()
+  })
+
+  it('routes a year with one program to that program home', () => {
+    renderProgramYearEntry()
+
+    expect(screen.getByText('Program detail')).toBeInTheDocument()
+  })
+
+  it('routes a year with multiple programs to the complete Programs list', () => {
+    mocks.programs = [
+      ...mocks.programs,
+      { id: 'program-2', organization_id: 'org-1', school_year_id: 'year-1', name: 'Arts', created_at: '', updated_at: '' },
+    ]
+    renderProgramYearEntry()
+
+    expect(screen.getByText('Programs list')).toBeInTheDocument()
+  })
+
+  it('keeps the complete Programs list directly reachable', () => {
+    renderWithQueryClient(<MemoryRouter initialEntries={['/y/year-1/programs']}><Routes><Route path="/y/:schoolYearId/programs" element={<p>Programs list</p>} /></Routes></MemoryRouter>)
+
+    expect(screen.getByText('Programs list')).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/features/programs/ProgramPages.tsx
+++ b/frontend/src/features/programs/ProgramPages.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type FormEvent, type ReactNode } from 'react'
-import { Link, useOutletContext, useParams } from 'react-router-dom'
+import { Link, Navigate, useOutletContext, useParams } from 'react-router-dom'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -48,6 +48,18 @@ function MeetingDateDraftList({ dates, onChange }: { dates: string[]; onChange: 
 
 function SessionForm({ value, onChange, onSubmit, pending, error, submitLabel }: { value: SessionDraft; onChange: (value: SessionDraft) => void; onSubmit: (event: FormEvent<HTMLFormElement>) => void; pending: boolean; error: unknown; submitLabel: string }) {
   return <form className="space-y-4" onSubmit={onSubmit}><label className="block text-sm font-medium">Session name<Input aria-label="Session name" className="mt-2" onChange={(event) => onChange({ ...value, name: event.target.value })} required value={value.name} /></label><div><p className="text-sm font-medium">Meeting dates</p><p className="mt-1 text-sm text-muted-foreground">Every offering meets on every date listed here.</p><div className="mt-2"><MeetingDateDraftList dates={value.meetingDates} onChange={(meetingDates) => onChange({ ...value, meetingDates })} /></div></div><Button disabled={pending || !value.name.trim() || value.meetingDates.length === 0 || value.meetingDates.some((date) => !date)} type="submit">{pending ? 'Saving…' : submitLabel}</Button>{error != null ? <Problem error={error} fallback="Unable to save the session." /> : null}</form>
+}
+
+export function ProgramYearEntryPage() {
+  const { schoolYearId } = useParams<{ schoolYearId: string }>()
+  const programs = usePrograms(schoolYearId)
+
+  if (!schoolYearId) return <PageFrame><p>School year is required.</p></PageFrame>
+  if (programs.isLoading) return <PageFrame><p className="text-sm text-muted-foreground" role="status">Loading programs…</p></PageFrame>
+  if (programs.isError) return <PageFrame><Problem error={programs.error} fallback="Unable to load programs." /></PageFrame>
+
+  const program = programs.data?.length === 1 ? programs.data[0] : undefined
+  return <Navigate replace to={program ? `/y/${schoolYearId}/programs/${program.id}` : `/y/${schoolYearId}/programs`} />
 }
 
 export function ProgramListPage() {


### PR DESCRIPTION
## Summary

- Route a year root to its only program home when exactly one program exists.
- Route zero- and multiple-program years to the complete Programs list.
- Keep the year Programs list directly reachable.
- Add routing coverage for zero, one, and multiple programs.

## Testing

- make lint-backend
- make format
- make generate && git diff --exit-code
- git diff --check
- make test-frontend: blocked locally because openapi-typescript is not installed
- make test-backend: blocked locally because Docker address pools are exhausted
- make test-migrations: blocked locally because MIGRATION_ROUNDTRIP_DATABASE_URL is unset
- make build-frontend: blocked locally because openapi-typescript is not installed
- make lint-frontend: blocked locally because Bun cannot write its temp cache
- make smoke: blocked locally because .env is absent

Fixes #175