### PR TITLE
docs(access): define Phase 4 security contract (#183)

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -200,9 +200,12 @@
   Removed stale household wording from ADR 0002 and fixed the malformed guardian sentence in SPEC.
 - Key files: `SPEC.md`, `docs/adr/0002-authentication-and-access-mechanisms.md`, and
   `docs/adr/0013-guardian-and-volunteer-access.md`.
-- Validation: `git diff --check` passes; full repository checks and PR CI remain to be run after commit
-  and push. No dependency blocker or human action declared.
-- Open items: inspect final diff, run applicable gates, commit/push, open PR with `Fixes #183`, verify
-  current-head CI/review state, and update the Workpad completion status.
+- Validation: local `make format`, `make lint-backend`, `make generate`, and `git diff --check` pass;
+  generated artifacts are unchanged. Root `make check` stops before gates because Docker reports all
+  predefined address pools exhausted. PR #192 head `d6344e4` passes all ten required checks; PR CI took
+  111s, with Backend tests 108s, Generated code drift/Developer tooling 91s, and Backend lint 86s.
+- Open items: none; PR #192 is open, non-draft, merge-clean, references `Fixes #183`, and has no
+  actionable review comments. Quiet-window wait 0s; local merge-gate duration under 1s; no post-merge
+  main CI applies while the PR is open. Detent owns the completion-lane transition.
 - Skill draft: no — this is a one-off contract clarification using existing ADR/spec conventions; no
   broadly reusable procedure was discovered.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -188,3 +188,21 @@
 - Repository state: commits `f6fd5b3` and `092c830` are pushed to PR #179, which references `Fixes #175`, is open, non-draft, clean, and has no actionable reviews or comments. The final head is `092c830`.
 - Open items: none; Detent owns the completion-lane transition.
 - Skill draft: no — this is a focused frontend routing change with no broadly reusable procedure discovered.
+
+## Current work — issue #183
+
+- Scope: define the Phase 4 principal, capability, session, authentication, recovery, attribution, and
+  authorization contract per SPEC §§6.2, 6.5–6.6, 9.3–9.4, 13.8 and ADRs 0002/0008/0013.
+- Implementation: clarified administrative-account versus scoped non-account principals; explicit
+  guardian/student-code boundaries; current relationship-derived scope; OTP/session bounds and
+  revocation; MFA recovery/reset invalidation; mode reauthentication; duplicate/no-email behavior;
+  administrator-on-behalf attribution; tenant/audit transaction obligations; and security-test coverage.
+  Removed stale household wording from ADR 0002 and fixed the malformed guardian sentence in SPEC.
+- Key files: `SPEC.md`, `docs/adr/0002-authentication-and-access-mechanisms.md`, and
+  `docs/adr/0013-guardian-and-volunteer-access.md`.
+- Validation: `git diff --check` passes; full repository checks and PR CI remain to be run after commit
+  and push. No dependency blocker or human action declared.
+- Open items: inspect final diff, run applicable gates, commit/push, open PR with `Fixes #183`, verify
+  current-head CI/review state, and update the Workpad completion status.
+- Skill draft: no — this is a one-off contract clarification using existing ADR/spec conventions; no
+  broadly reusable procedure was discovered.

--- a/SPEC.md
+++ b/SPEC.md
@@ -523,7 +523,8 @@ diverge.
 
 ## 6. Personas and Roles
 
-Five human roles interact with the system. Only one of them has an account.
+Five persona categories interact with the system. Administrative users have accounts; the other
+personas use narrow, scoped access proofs rather than accounts.
 
 ### 6.1 Program organizer / administrator
 
@@ -538,12 +539,12 @@ multiple administrators per organization, and SHOULD support distinguishing thei
 
 ### 6.2 Guardian
 
-An adult with a recorded relationship to one or more students (§8.2). Submits preference information
-and views their students' placements. Authenticating by email OTP provides guardian access; an adult
-who also has administrative capabilities may step up to administration (§9.3).
+An adult with a recorded relationship to one or more students (§8.2). Guardian is a scoped capability,
+not a separate account: email OTP provides guardian access, while an adult who also has an explicitly
+linked administrative account may step up to administration (§9.3).
 
 The authenticated guardian view shows **that adult's own information only** — the students they are a
-their students' preferences and placements.
+guardian of, those students' preferences and placements.
 It MUST NOT show class rosters, another adult's students, or any program-wide view.
 
 Scope is derived from the guardian relationships in force at the moment of the request, not from any
@@ -579,9 +580,9 @@ goes where. Six people in the reference program, using it weekly for two minutes
 ### 6.5 Student
 
 The subject of every placement and the author of the preferences that drive it, but not an account
-user in v1. A student may use a survey-scoped invite code to submit their own interest profile or ranked
-choices; the code grants no broader system access (§13.8). Preference records identify the student they
-describe and separately record who or what submitted them.
+user in v1. A student may use a survey-scoped access code as a non-account principal to submit their
+own interest profile or ranked choices; the code grants no broader system access (§13.8). Preference
+records identify the student they describe and separately record who or what submitted them.
 
 ### 6.6 Role and permission model
 
@@ -612,6 +613,16 @@ Minimum capability separation:
 `Coordinator` exists for the common real case: a second organizer who does substantive work on one
 program but should not be the person who publishes it or removes a family's data. Finer-grained
 permissions, including per-program scoping of administrators, are `Implementation-defined`.
+
+Capabilities are evaluated on the resolved principal, not inferred from a name, email address, or
+browser mode. Guardian, student-code, class-leader, homeroom-teacher, and public-reader principals
+never inherit account capabilities. In particular:
+
+- A guardian session may read and submit for only the adult's current guardian-scoped students.
+- A student-code principal may read and submit only for its one student and one bound instrument.
+- Administrator-on-behalf entry is an administrative capability, and the acting administrator and
+  target student remain distinct in the resulting record (§13.8).
+- A mode switch changes the surface presented; it never broadens the principal's server-side grants.
 
 ## 7. System Overview
 
@@ -942,18 +953,35 @@ remembering to filter.
 
 ### 9.3 Authentication
 
-Four mechanisms, deliberately unequal, with one adult identity able to hold both guardian and administrator capabilities.
+Five mechanisms, deliberately unequal, with one adult identity able to hold both guardian and
+administrator capabilities. The proof, resulting session, and grants are distinct:
 
-| Principal | Mechanism | Lifetime |
+| Principal | Authentication proof | Session and minimum grant |
 |---|---|---|
-| Owner, Administrator, Coordinator | Account with credential and mandatory MFA | Session-based, renewable; step-up required for administration |
-| Guardian | Email OTP followed by a session token | Bounded, renewable session; guardian scope derived per request |
-| Class leader, Homeroom teacher | Tokenized link | Scoped to a session |
-| Public reader | Unauthenticated share link | Scoped to a session, expiring (§9.5) |
+| Owner, Administrator, Coordinator | Account credential plus mandatory MFA for administration | Renewable account session; account capabilities at organization scope |
+| Guardian | Short-lived, single-use email OTP | Bounded, revocable guardian session; current guardian scope derived per request |
+| Student | High-entropy survey/session access code | Instrument-bound principal for one student; no account or broader access |
+| Class leader, Homeroom teacher | Tokenized link | Link-scoped principal for named objects |
+| Public reader | Unauthenticated share link | Expiring, artifact-scoped access (§9.5) |
 
 Only administrators have administrative accounts. Guardian access does not create an account and uses
 email OTP: the code is short-lived and single-use, and the resulting session is bounded and revocable.
 Email OTP alone MUST NOT grant administrative access to PII; administration requires step-up MFA.
+
+Authentication and session requirements:
+
+- OTP challenges MUST be short-lived, single-use, rate-limited, and stored only as a verifier. A
+  successful challenge creates a revocable session; it does not create an account or permanently copy
+  the adult's student scope into the session.
+- Sessions MUST have an absolute bound and an idle bound, and MUST be invalidatable server-side.
+  Renewal MUST NOT restore a revoked session or an authorization that the current relationships no
+  longer grant.
+- Administrative MFA recovery uses single-use recovery codes or an explicit Owner-assisted reset.
+  Email OTP MUST NOT be an administrative MFA fallback. A reset invalidates all active administrative
+  sessions and prior recovery codes; the reset and its actor, target, time, and reason are audited.
+- Guardian mode, survey mode, and administration mode are separate server-authorized surfaces. Leaving
+  administration or returning to it from survey mode requires reauthentication with the required MFA;
+  a client-side mode flag is never an authorization decision.
 
 A guardian session MUST be scoped to the adult's current guardian relationships. It MUST NOT grant
 access to any other adult's data or reach a student that adult is not a guardian of. An adult who has
@@ -970,9 +998,19 @@ to administration. Survey mode MUST NOT expose administrative or program-wide da
   `Implementation-defined`.
 - Account-to-adult links MUST be explicit and identifier-based. Email matching may suggest a link but
   MUST NOT create one silently.
+- Authorization for a guardian request MUST resolve the adult's current relationships before loading
+  a student or response. A guardian request for a student outside that scope MUST fail the same way as
+  a missing student, including when the student is in the same organization.
 - Link-based principals are authorized for exactly the objects their link names — a class leader's
   token grants their offerings and nothing else, including no visibility of other offerings in the
   same session.
+- Every tenant-scoped write MUST use the tenant unit-of-work path and record an audit entry in the
+  same transaction, or declare an explicit `NoAuditRequired` reason. Reads MUST use the read-only
+  tenant path (§20.1; ADRs 0007 and 0008).
+- The security test suite MUST cover cross-tenant not-found behavior, cross-student guardian and
+  student-code denial, account-link scope, OTP single-use and expiry, MFA assurance and reset
+  invalidation, code regeneration/revocation, and audit attribution. These tests are required for a
+  new access path, not optional end-to-end coverage.
 
 ### 9.5 Share-link security model
 
@@ -1659,13 +1697,15 @@ Preference access is deliberately split by principal while using one underlying 
   session. The session shows only the adult's current guardian-scoped students and their open forms.
 - **Student access** uses a high-entropy code bound to one student and one survey or session. Codes are
   stored hashed, are regenerable and revocable, and are valid only while the bound instrument is open.
-  They grant access only to that student's response.
+  They grant access only to that student's response. The code is a student-code principal, not an
+  account or an adult identity.
 - **Administrator access** begins from the adult's linked administrative identity and requires step-up
-  MFA. An administrator can open a form for a selected student and submit on that student's behalf.
+  MFA. An administrator can open a form for a selected student and submit on that student's behalf;
+  the response records the acting administrator, target student, channel, and submission time.
 - An adult without an email is unreachable for self-service, but the student remains eligible and an
   administrator can submit on the student's behalf.
 - Distinct adult records MUST NOT share an email for OTP access. Duplicate emails are a warning that
-  requires resolution; the system MUST NOT silently merge their scopes.
+  requires resolution before OTP access is issued; the system MUST NOT silently merge their scopes.
 
 Interest-profile surveys and ranked choices have separate access grants. A survey may be configured
 with any practical response-window duration; ranked-choice access closes automatically at its session

--- a/docs/adr/0002-authentication-and-access-mechanisms.md
+++ b/docs/adr/0002-authentication-and-access-mechanisms.md
@@ -13,16 +13,19 @@
 
 ## Context
 
-SPEC §9.3 requires **four deliberately unequal** authentication mechanisms:
+SPEC §9.3 requires deliberately unequal authentication mechanisms. The original household terminology in
+this record was superseded when ADR 0012 removed the household entity; ADR 0013 resolves the remaining
+Phase 4 adult and student access questions:
 
 | Principal | Mechanism | Scope |
 |---|---|---|
 | Owner, Administrator, Coordinator | Account with credential, renewable session | Organisation |
-| Household | Emailed magic link | Household, submission window |
+| Guardian | Application-owned email OTP followed by a bounded session | Current guardian relationships |
+| Student | Application-owned high-entropy survey/session code | One student and one instrument |
 | Class leader, Homeroom teacher | Tokenised link | Named objects, session |
 | Public reader | Unauthenticated share link | One artifact, one session, expiring |
 
-Only administrators have passwords. The specification is explicit that this inequality is
+Only administrative users have accounts. The specification is explicit that this inequality is
 intentional: "obscurity is the only access control here" for share links, and the design accepts that
 in exchange for a workflow that parents and volunteers will actually complete.
 
@@ -44,32 +47,35 @@ which maps three unequal mechanisms onto one and understates the problem.
    subject onto an application user carrying an organisation and one of `Owner`, `Administrator`,
    `Coordinator`. Supabase is an identity provider only; it is not consulted for authorization.
 
-2. **The three link mechanisms are owned by this application**, in PostgreSQL, as a single
-   `access_token` concept with a discriminated purpose:
+2. **Non-administrative scoped access is owned by this application**, in PostgreSQL, as application
+   verifiers and a single `access_token` concept with discriminated purposes:
 
    - opaque high-entropy random token, stored hashed, never derived from any identifier;
-   - a purpose (`household_submission`, `class_leader`, `homeroom_teacher`, `published_artifact`);
+   - a purpose (`guardian_submission`, `student_code`, `class_leader`, `homeroom_teacher`,
+     `published_artifact`);
    - the exact object set the token authorizes;
    - an expiry, a revoked-at, and a generation counter so regeneration invalidates the prior URL;
-   - single-purpose and non-reusable outside its window, per §9.3.
+   - single-purpose and non-reusable outside its window, per §9.3. OTP verifiers follow the same
+     single-use and expiry requirements but are not an identity or a bearer grant to administration.
 
 3. **Authorization is always the application's own**, evaluated server-side on every request, after
    the tenancy guard has run. No principal — including an administrator — reaches data through a
    path that bypasses the guard.
 
-4. **Persona separation is enforced**, per §6.3: the household view and the class-leader view never
-   merge, even when the same person holds both. A household link yields the household view and
-   nothing else.
+4. **Persona separation is enforced**, per §6.3 and ADR 0013: the guardian, student, class-leader,
+   homeroom-teacher, and public-reader views never merge, even when the same adult holds more than one
+   access path. A guardian session yields guardian data only, and a student code yields one student's
+   instrument only.
 
 ## Alternatives considered
 
-**Supabase Auth for everything, including households.** Rejected. Supabase magic links authenticate
-an *email address into an account*; SPEC requires a link scoped to a *household's submission window*
-for a *specific session*, single-purpose, non-reusable afterwards, and independently revocable. It
-would also create accounts for ~90 households that the specification deliberately avoids, and it
-cannot express the class-leader or public-share cases at all.
+**Supabase Auth for everything, including guardians.** Rejected. Supabase magic links authenticate
+an *email address into an account*; SPEC requires guardian OTP access scoped to an adult's current
+relationships, a bounded session, and no account creation. It would also make email possession enough
+to enter a surface containing child data, and it cannot express the student-code, class-leader or
+public-share cases with their independent scopes.
 
-**Drop Supabase Auth and own all four mechanisms.** Genuinely attractive: there are three
+**Drop Supabase Auth and own all administrator authentication.** Genuinely attractive: there are three
 administrator accounts, the token machinery is being built regardless, and §5.7 prefers the direct
 approach. Rejected for now on the operator's judgement that other Supabase capabilities may be
 adopted later. Should be revisited at R3 if Supabase is still doing nothing but authenticating three
@@ -89,5 +95,5 @@ into the token, which §9.5 forbids.
 - Tokens are stored hashed, so a database disclosure does not yield working links.
 - Supabase is a hard external dependency of the administrative surface. Published artifacts must not
   inherit that dependency; see [ADR 0005](./0005-published-artifact-availability.md).
-- Whether a household link addresses a *household* or an *individual adult* is not settled by this
-  record. See [ADR 0006](./0006-household-and-volunteer-access.md).
+- Guardian scope is addressed to an individual adult and derived from guardian relationships, not a
+  household entity; see [ADR 0012](./0012-remove-the-household-entity.md) and [ADR 0013](./0013-guardian-and-volunteer-access.md).

--- a/docs/adr/0013-guardian-and-volunteer-access.md
+++ b/docs/adr/0013-guardian-and-volunteer-access.md
@@ -29,6 +29,19 @@ account. The account-to-adult link is explicit and uses opaque identifiers. Matc
 suggest a link but must never create one silently. Distinct adult records must not share an email for
 OTP access; duplicates require resolution. Changing an email does not change the identity link.
 
+The resolved principal is a security value, not a UI persona label. The implementation must preserve
+these distinctions:
+
+| Principal | Proof | Maximum preference scope |
+|---|---|---|
+| Guardian session | Single-use email OTP | The adult's current guardian relationships |
+| Student-code principal | Hashed, instrument-bound code | One student and one survey or session |
+| Administrative account | Linked account identity plus MFA | Organization capabilities, including selected administrator-on-behalf targets |
+
+Guardian, student-code, and link principals never inherit account capabilities. An account-to-adult
+link is an explicit opaque-ID relationship; a matching email may suggest a link for an organizer to
+review, but cannot create or widen one.
+
 The application presents separate modes:
 
 - **Guardian mode** shows only the adult's current guardian-scoped students and their open preference
@@ -50,11 +63,22 @@ Administrative access uses the existing account identity provider and requires m
 uses single-use recovery codes or an explicit, audited Owner-assisted reset; email OTP alone is not an
 administrative MFA fallback. Administrative sessions are invalidated after an MFA reset.
 
+OTP challenges are short-lived, single-use, rate-limited, and stored only as verifiers. Successful
+guardian authentication creates a bounded, revocable session with an absolute and idle expiry. The
+session is renewable only while valid and never stores a permanent student list: current guardian
+relationships are resolved on every request. An MFA reset or Owner-assisted reset invalidates all
+active administrative sessions and prior recovery codes, and records the actor, target, time, and
+reason in the audit log.
+
 Transactional email for OTP delivery is in scope. Bulk and workflow notifications remain out of scope,
 including emailing student codes, survey invitations, reminders, or follow-ups.
 
 An adult without an email is unreachable for self-service preference submission. The student remains
 eligible and appears in response tracking; an administrator can submit on the student's behalf.
+
+Duplicate email addresses are an unresolved ambiguity, not a shared guardian scope. OTP access is not
+issued for an ambiguous email until an organizer resolves the adult records. A missing email is
+represented as unreachable, not as an invitation to infer an identity from names or other attributes.
 
 ### Student survey access
 
@@ -63,6 +87,8 @@ and revise their own response:
 
 - one code is bound to one student and one interest-profile survey or ranked-choice session;
 - the code is stored hashed, regenerable, revocable, and valid only while its instrument is open;
+- the code is a non-account student-code principal and grants no access to another student, instrument,
+  placement, guardian record, or administration surface;
 - codes are generated when the instrument opens from its frozen audience;
 - an organizer-only list presents codes grouped by homeroom in a print-friendly view;
 - code-list view/print is not audited, but generation and regeneration are audited;
@@ -71,6 +97,13 @@ and revise their own response:
 Interest-profile surveys and ranked-choice responses use the same narrow respondent pattern but remain
 separate domain concepts. Interest surveys have administrator-configured windows. Ranked-choice access
 follows the session voting window and stops at its configured deadline before assignment.
+
+Every submission retains the target student, acting principal, access channel, and timestamp. An
+administrator-on-behalf submission additionally records the acting administrator and selected target
+student as separate identifiers. Authorization tests must demonstrate that another tenant, another
+student, and another instrument are each denied even when the caller knows a valid opaque ID. All
+tenant-scoped reads and writes follow ADRs 0007 and 0008: reads use the tenant read path, writes use
+the audited tenant unit of work, and no unaudited write commits.
 
 ### Volunteer and artifact access
 


### PR DESCRIPTION
## Summary
- Defines the Phase 4 principal and capability contract in SPEC §§6.2, 6.5–6.6, 9.3–9.4, and 13.8.
- Specifies guardian OTP sessions, account-to-adult links, administrative MFA recovery/reset invalidation, mode boundaries, duplicate/no-email handling, student-code scope, and administrator-on-behalf attribution.
- Reconciles ADR 0002 with the household removal and records the shared access/security obligations in ADR 0013.

## Validation
- `git diff --check`
- `make format`
- `make lint-backend`
- `make generate` (no generated artifact changes)
- `make check` could not start its gates because Docker reported that all predefined address pools are exhausted.

Fixes #183