### PR TITLE
test: complete Phase 4 validation coverage (#191)

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -3,9 +3,10 @@
 - Scope: complete Phase 4 integration, accessibility, security validation, generated-client wiring, and documentation consistency per SPEC §§5.2, 9.2–9.4, 13, 14.3, 19.5, 22.4–22.5 and ADR 0013.
 - Dependency: #190 and #199 are closed and their pull requests are merged; the native `blocked_by` relation is terminal. Branch is rebased onto current `origin/main`.
 - Implementation: added explicit duplicate-email neutrality, OTP expiry, idle/absolute guardian-session expiry, live guardian-scope removal, and session revocation regressions; added ranked-choice mobile E2E coverage, a mobile accessibility baseline, response-tracking UI coverage, and generated-resource path coverage; documented the Phase 4 validation record in `PLAN.md`.
-- Validation: race-enabled full backend tests, `make format`, `make lint-backend`, `make generate`, generated-code drift, and `git diff --check` pass. Root `make check` stops at Docker address-pool exhaustion; migration round-trip lacks its configured URL; frontend gates lack installed dependencies; smoke lacks `.env`.
+- Validation: race-enabled full backend tests, `make format`, `make lint-backend`, `make generate`, generated-code drift, and `git diff --check` pass locally. Root `make check` stops at Docker address-pool exhaustion; migration round-trip lacks its configured URL; frontend gates lack installed dependencies; smoke lacks `.env`. PR #203 has passed all ten required CI checks on the latest source head.
 - Out-of-scope: populated adult-auth migration rollback enum mismatch filed as Backlog issue #202 with `detent-agent` effort `medium`.
-- Open items: commit/push, open PR referencing `Fixes #191`, verify all current-head CI checks and review comments, then refresh this note and the persistent Workpad.
+- Repository/PR: PR #203 is open, non-draft, merge-clean, references `Fixes #191`, and has no actionable reviews or inline comments. Detent owns the completion-lane transition.
+- Open items: none.
 - Skill draft: no — this pass used existing project test and validation conventions without discovering a broadly reusable procedure.
 
 ## Current work — issue #185

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -290,3 +290,11 @@
 - Open items: add final Workpad evidence, commit/push, open PR with `Fixes #199`, verify current-head CI/reviews, and hand off through Detent’s review lane.
 - Blockers: none.
 - Skill draft: no — this is a focused frontend authoring flow using existing API/hooks and modal/access-code patterns; no broadly reusable procedure was discovered.
+## Current work — issue #191
+
+- Scope: complete Phase 4 integration, accessibility, security validation, generated-client wiring, and documentation consistency per SPEC §§5.2, 9.2–9.4, 13, 14.3, 19.5, 22.4–22.5 and ADR 0013.
+- Dependency: #190 and #199 are closed and their pull requests are merged; the native `blocked_by` relation is terminal.
+- Repository state: rebased onto `origin/main` after the Phase 4 dependencies landed; implementation and validation are in progress.
+- Open items: inspect the integrated Phase 4 surfaces, implement scoped fixes and regressions, run all ten validation stages, then push a PR referencing #191 and verify current-head CI/review state.
+- Validation: pending implementation; `git diff --check` will run before handoff.
+- Skill draft: no — implementation has not yet exposed a broadly reusable procedure beyond the existing project guidance.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -1,3 +1,13 @@
+## Current work — issue #191
+
+- Scope: complete Phase 4 integration, accessibility, security validation, generated-client wiring, and documentation consistency per SPEC §§5.2, 9.2–9.4, 13, 14.3, 19.5, 22.4–22.5 and ADR 0013.
+- Dependency: #190 and #199 are closed and their pull requests are merged; the native `blocked_by` relation is terminal. Branch is rebased onto current `origin/main`.
+- Implementation: added explicit duplicate-email neutrality, OTP expiry, idle/absolute guardian-session expiry, live guardian-scope removal, and session revocation regressions; added ranked-choice mobile E2E coverage, a mobile accessibility baseline, response-tracking UI coverage, and generated-resource path coverage; documented the Phase 4 validation record in `PLAN.md`.
+- Validation: race-enabled full backend tests, `make format`, `make lint-backend`, `make generate`, generated-code drift, and `git diff --check` pass. Root `make check` stops at Docker address-pool exhaustion; migration round-trip lacks its configured URL; frontend gates lack installed dependencies; smoke lacks `.env`.
+- Out-of-scope: populated adult-auth migration rollback enum mismatch filed as Backlog issue #202 with `detent-agent` effort `medium`.
+- Open items: commit/push, open PR referencing `Fixes #191`, verify all current-head CI checks and review comments, then refresh this note and the persistent Workpad.
+- Skill draft: no — this pass used existing project test and validation conventions without discovering a broadly reusable procedure.
+
 ## Current work — issue #185
 
 - Scope: admin-managed interest-profile surveys and lifecycle per SPEC §§13.5–13.6; dependency #184 is closed and merged on origin/main.

--- a/PLAN.md
+++ b/PLAN.md
@@ -474,6 +474,11 @@ history import is intentionally out of scope; all preference data is collected n
 - No preference import is implemented; a program with no placement history starts normally and reports
   fairness/variety history as unavailable until native completed sessions accumulate.
 
+**Phase 4 validation record:** The backend integration suite covers tenant isolation, authorization,
+OTP/MFA and access-code lifecycle boundaries, lifecycle windows, attribution, and student-centric
+tracking. The frontend test suite covers the generated API wrappers, mobile guardian/student
+submission flows, and the accessibility baseline at `frontend/e2e/accessibility.spec.ts`.
+
 ---
 
 ### Phase 5 — Engine v0

--- a/backend/tests/integration/adult_auth_test.go
+++ b/backend/tests/integration/adult_auth_test.go
@@ -58,12 +58,11 @@ func TestAdultOTPGuardianScopeAndMFAStepUp(t *testing.T) {
 		values ($1, $2, 'owner')`, organizationID, userID)
 	require.NoError(t, err)
 
-	var deliveredCode string
+	deliveredCodes := map[string]string{}
 	deliveryCount := 0
 	store := identity.NewStoreWithOTPDelivery(harness.Database, []byte("integration-auth-key"), func(_ context.Context, deliveredEmail, code string) error {
 		deliveryCount++
-		require.Equal(t, email, deliveredEmail)
-		deliveredCode = code
+		deliveredCodes[deliveredEmail] = code
 		return nil
 	})
 
@@ -75,6 +74,7 @@ func TestAdultOTPGuardianScopeAndMFAStepUp(t *testing.T) {
 	require.True(t, requested.Accepted)
 	require.NotEmpty(t, requested.ChallengeID)
 	require.Equal(t, 1, deliveryCount)
+	deliveredCode := deliveredCodes[email]
 	require.Len(t, deliveredCode, 6)
 	require.NotEqual(t, deliveredCode, requested.ChallengeID)
 
@@ -96,6 +96,41 @@ func TestAdultOTPGuardianScopeAndMFAStepUp(t *testing.T) {
 	require.False(t, guardian.HasCapability(auth.CapabilityManageRoster))
 	_, err = store.VerifyAdultOTP(ctx, auth.OTPVerification{ChallengeID: requested.ChallengeID, Code: deliveredCode, Now: now})
 	require.ErrorIs(t, err, auth.ErrOTPInvalid)
+
+	duplicate, err := factory.CreateAdult(ctx, year.ID, people.AdultCreateInput{
+		LegalGivenName: "Synthetic", LegalFamilyName: "Duplicate Guardian", Email: &email,
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, adult.ID, duplicate.ID)
+	duplicateRequest, err := store.RequestAdultOTP(ctx, auth.OTPRequest{
+		OrganizationID: organizationID, SchoolYearID: year.ID, Email: email, Now: now,
+	})
+	require.NoError(t, err)
+	require.True(t, duplicateRequest.Accepted)
+	require.NotEmpty(t, duplicateRequest.ChallengeID)
+	require.Equal(t, 1, deliveryCount, "duplicate email must not trigger delivery")
+	_, err = store.VerifyAdultOTP(ctx, auth.OTPVerification{ChallengeID: duplicateRequest.ChallengeID, Code: deliveredCode, Now: now})
+	require.ErrorIs(t, err, auth.ErrOTPInvalid, "duplicate email must not create a usable challenge")
+
+	expiredEmail := "expired-guardian@example.test"
+	expiredAdult, err := factory.CreateAdult(ctx, year.ID, people.AdultCreateInput{
+		LegalGivenName: "Synthetic", LegalFamilyName: "Expired Guardian", Email: &expiredEmail,
+	})
+	require.NoError(t, err)
+	_, err = factory.CreateGuardianRelationship(ctx, year.ID, people.GuardianRelationshipCreateInput{
+		AdultID: expiredAdult.ID, StudentID: student.ID, RelationshipType: data.GuardianRelationshipParent,
+	})
+	require.NoError(t, err)
+	expiredRequest, err := store.RequestAdultOTP(ctx, auth.OTPRequest{
+		OrganizationID: organizationID, SchoolYearID: year.ID, Email: expiredEmail, Now: now,
+	})
+	require.NoError(t, err)
+	require.True(t, expiredRequest.Accepted)
+	require.Equal(t, 2, deliveryCount)
+	_, err = store.VerifyAdultOTP(ctx, auth.OTPVerification{
+		ChallengeID: expiredRequest.ChallengeID, Code: deliveredCodes[expiredEmail], Now: now.Add(11 * time.Minute),
+	})
+	require.ErrorIs(t, err, auth.ErrOTPInvalid, "expired OTP must not be usable")
 
 	unknown, err := store.RequestAdultOTP(ctx, auth.OTPRequest{
 		OrganizationID: organizationID, SchoolYearID: year.ID, Email: "unknown@example.test", Now: now,
@@ -132,6 +167,40 @@ func TestAdultOTPGuardianScopeAndMFAStepUp(t *testing.T) {
 	stepUp, err := store.VerifyMFAForGuardian(ctx, guardian, code, "", now)
 	require.NoError(t, err)
 	require.Equal(t, ids.XID(userID), stepUp.UserID)
+
+	idleExpiredSession, err := store.CreateGuardianSessionForAccount(ctx, ids.XID(userID), organizationID, year.ID, now)
+	require.NoError(t, err)
+	_, err = harness.Migrator.Exec(ctx, `
+		update access_tokens
+		set idle_expires_at = $1
+		where id = $2`, now.Add(-time.Minute), idleExpiredSession.SessionID)
+	require.NoError(t, err)
+	_, err = store.ResolveSession(ctx, idleExpiredSession.Bearer)
+	require.ErrorIs(t, err, auth.ErrSessionInvalid, "idle-expired guardian session must be rejected")
+
+	absoluteExpiredSession, err := store.CreateGuardianSessionForAccount(ctx, ids.XID(userID), organizationID, year.ID, now)
+	require.NoError(t, err)
+	_, err = harness.Migrator.Exec(ctx, `
+		update access_tokens
+		set expires_at = $1
+		where id = $2`, now.Add(-time.Minute), absoluteExpiredSession.SessionID)
+	require.NoError(t, err)
+	_, err = store.ResolveSession(ctx, absoluteExpiredSession.Bearer)
+	require.ErrorIs(t, err, auth.ErrSessionInvalid, "absolutely expired guardian session must be rejected")
+
+	peopleService := people.New(harness.Database)
+	relationships, err := peopleService.ListGuardianRelationships(ctx, string(organizationID), year.ID, data.GuardianRelationshipFilter{AdultID: adult.ID})
+	require.NoError(t, err)
+	require.Len(t, relationships, 1)
+	require.NoError(t, peopleService.DeleteGuardianRelationship(ctx, string(organizationID), year.ID, relationships[0].ID, actor))
+	resolvedAfterRemoval, err := store.ResolveSession(ctx, session.Bearer)
+	require.NoError(t, err)
+	guardianAfterRemoval, ok := resolvedAfterRemoval.(auth.GuardianPrincipal)
+	require.True(t, ok)
+	require.Empty(t, guardianAfterRemoval.StudentIDs, "guardian session scope must be resolved from current relationships")
+	require.NoError(t, store.RevokeSession(ctx, guardianSession.Bearer))
+	_, err = store.ResolveSession(ctx, guardianSession.Bearer)
+	require.ErrorIs(t, err, auth.ErrSessionInvalid, "revoked guardian session must be rejected")
 
 	recoverySession, err := store.VerifyMFA(ctx, auth.MFAVerification{
 		UserID: ids.XID(userID), OrganizationID: organizationID, RecoveryCode: enrollment.RecoveryCodes[0], Now: now,

--- a/backend/tests/integration/adult_auth_test.go
+++ b/backend/tests/integration/adult_auth_test.go
@@ -138,7 +138,7 @@ func TestAdultOTPGuardianScopeAndMFAStepUp(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, unknown.Accepted)
 	require.NotEmpty(t, unknown.ChallengeID)
-	require.Equal(t, 1, deliveryCount)
+	require.Equal(t, 2, deliveryCount)
 
 	link, err := store.CreateAdultAccountLink(ctx, auth.AdultAccountLinkInput{
 		OrganizationID: organizationID, SchoolYearID: year.ID, AdultID: adult.ID, UserID: ids.XID(userID), Actor: actor,

--- a/frontend/e2e/accessibility.spec.ts
+++ b/frontend/e2e/accessibility.spec.ts
@@ -42,16 +42,18 @@ test("student preference form keeps an accessible mobile baseline", async ({ pag
   );
   expect(unnamedControls).toEqual([]);
 
-  const unnamedButtons = await page.locator("button").evaluateAll((buttons) =>
-    buttons
-      .filter(
-        (button) =>
-          !button.getAttribute("aria-label")?.trim() &&
-          !button.getAttribute("aria-labelledby")?.trim() &&
-          !button.textContent?.trim(),
-      )
-      .map((button) => button.outerHTML),
-  );
+	const unnamedButtons = await page
+		.locator("button")
+		.evaluateAll((buttons) =>
+			buttons
+				.filter(
+					(button) =>
+						!button.getAttribute("aria-label")?.trim() &&
+						!button.getAttribute("aria-labelledby")?.trim() &&
+						!button.textContent?.trim(),
+				)
+				.map((button) => button.outerHTML),
+		);
   expect(unnamedButtons).toEqual([]);
 
   expect(

--- a/frontend/e2e/accessibility.spec.ts
+++ b/frontend/e2e/accessibility.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+
+const form = {
+  type: "interest_profile",
+  id: "survey-student-1",
+  school_year_id: "year-1",
+  program_id: "program-1",
+  program_name: "Clubs",
+  name: "Interest profile",
+  student_id: "student-1",
+  questions: [{ interest_area_id: "area-1", label: "Making things", ordinal: 1 }],
+  scale_options: [{ value: "interested", label: "Interested", ordinal: 1 }],
+  interest_answers: [],
+};
+
+test("student preference form keeps an accessible mobile baseline", async ({ page }) => {
+  await page.route("**/api/respondent/interest-profile-surveys/**", async (route) => {
+    if (new URL(route.request().url()).pathname.endsWith("/form")) {
+      await route.fulfill({ json: form });
+      return;
+    }
+    await route.fulfill({ json: form });
+  });
+
+  await page.goto(
+    "/respond/interest-profile-surveys/year-1/program-1/survey-student-1?organization_id=org-1&code=secret",
+  );
+  await expect(page.getByRole("heading", { name: form.name })).toBeVisible();
+  await expect(page.getByRole("group", { name: "Making things" })).toBeVisible();
+
+  const unnamedControls = await page.locator("input, select, textarea").evaluateAll((elements) =>
+    elements
+      .filter((element) => {
+        const control = element as HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+        return (
+          !control.getAttribute("aria-label")?.trim() &&
+          !control.getAttribute("aria-labelledby")?.trim() &&
+          !control.labels?.length
+        );
+      })
+      .map((element) => element.outerHTML),
+  );
+  expect(unnamedControls).toEqual([]);
+
+  const unnamedButtons = await page.locator("button").evaluateAll((buttons) =>
+    buttons
+      .filter(
+        (button) =>
+          !button.getAttribute("aria-label")?.trim() &&
+          !button.getAttribute("aria-labelledby")?.trim() &&
+          !button.textContent?.trim(),
+      )
+      .map((button) => button.outerHTML),
+  );
+  expect(unnamedButtons).toEqual([]);
+
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    ),
+  ).toBe(true);
+});

--- a/frontend/e2e/accessibility.spec.ts
+++ b/frontend/e2e/accessibility.spec.ts
@@ -42,18 +42,18 @@ test("student preference form keeps an accessible mobile baseline", async ({ pag
   );
   expect(unnamedControls).toEqual([]);
 
-	const unnamedButtons = await page
-		.locator("button")
-		.evaluateAll((buttons) =>
-			buttons
-				.filter(
-					(button) =>
-						!button.getAttribute("aria-label")?.trim() &&
-						!button.getAttribute("aria-labelledby")?.trim() &&
-						!button.textContent?.trim(),
-				)
-				.map((button) => button.outerHTML),
-		);
+  const unnamedButtons = await page
+    .locator("button")
+    .evaluateAll((buttons) =>
+      buttons
+        .filter(
+          (button) =>
+            !button.getAttribute("aria-label")?.trim() &&
+            !button.getAttribute("aria-labelledby")?.trim() &&
+            !button.textContent?.trim(),
+        )
+        .map((button) => button.outerHTML),
+    );
   expect(unnamedButtons).toEqual([]);
 
   expect(

--- a/frontend/e2e/preferences.spec.ts
+++ b/frontend/e2e/preferences.spec.ts
@@ -119,7 +119,7 @@ test("a student can submit ranked choices on a phone", async ({ page }) => {
     await route.fulfill({ json: form });
   });
 
-	await page.goto("/respond/sessions/year-1/program-1/session-1?organization_id=org-1&code=secret");
+  await page.goto("/respond/sessions/year-1/program-1/session-1?organization_id=org-1&code=secret");
   await expect(page.getByRole("heading", { name: form.name })).toBeVisible();
   await page.locator("#answer-offering-1").selectOption("ranked");
   await page.locator("#rank-offering-1").fill("1");

--- a/frontend/e2e/preferences.spec.ts
+++ b/frontend/e2e/preferences.spec.ts
@@ -119,9 +119,7 @@ test("a student can submit ranked choices on a phone", async ({ page }) => {
     await route.fulfill({ json: form });
   });
 
-  await page.goto(
-    "/respond/sessions/year-1/program-1/session-1?organization_id=org-1&code=secret",
-  );
+	await page.goto("/respond/sessions/year-1/program-1/session-1?organization_id=org-1&code=secret");
   await expect(page.getByRole("heading", { name: form.name })).toBeVisible();
   await page.locator("#answer-offering-1").selectOption("ranked");
   await page.locator("#rank-offering-1").fill("1");

--- a/frontend/e2e/preferences.spec.ts
+++ b/frontend/e2e/preferences.spec.ts
@@ -82,3 +82,56 @@ test("a guardian can submit for each scoped student on a phone", async ({ page }
       "/api/guardian/interest-profile-surveys/year-1/program-1/survey-student-1/students/student-1",
     );
 });
+
+test("a student can submit ranked choices on a phone", async ({ page }) => {
+  const form = {
+    type: "ranked_choice",
+    id: "session-1",
+    school_year_id: "year-1",
+    program_id: "program-1",
+    program_name: "Clubs",
+    session_name: "Autumn clubs",
+    name: "Autumn club choices",
+    student_id: "student-1",
+    rank_depth: 1,
+    offerings: [
+      {
+        id: "offering-1",
+        name: "Making things",
+        description: "Build something useful.",
+        min_grade_level_id: "grade-1",
+        max_grade_level_id: "grade-1",
+        location: "Room 1",
+        meeting_point: "Main hall",
+        meeting_instructions: "Meet by the door.",
+        meeting_dates: ["2026-10-16"],
+      },
+    ],
+    ranked_answers: [],
+  };
+  let submittedBody: unknown;
+  await page.route("**/api/respondent/sessions/**", async (route) => {
+    if (new URL(route.request().url()).pathname.endsWith("/form")) {
+      await route.fulfill({ json: form });
+      return;
+    }
+    submittedBody = route.request().postDataJSON();
+    await route.fulfill({ json: form });
+  });
+
+  await page.goto(
+    "/respond/sessions/year-1/program-1/session-1?organization_id=org-1&code=secret",
+  );
+  await expect(page.getByRole("heading", { name: form.name })).toBeVisible();
+  await page.locator("#answer-offering-1").selectOption("ranked");
+  await page.locator("#rank-offering-1").fill("1");
+  await page.getByRole("button", { name: "Save ranked choices" }).click();
+
+  await expect
+    .poll(() => submittedBody)
+    .toEqual({
+      organization_id: "org-1",
+      code: "secret",
+      responses: [{ offering_id: "offering-1", answer: "ranked", rank: 1 }],
+    });
+});

--- a/frontend/src/features/programs/ResponseTrackingPages.test.tsx
+++ b/frontend/src/features/programs/ResponseTrackingPages.test.tsx
@@ -96,12 +96,14 @@ describe("response tracking pages", () => {
     expect(screen.getByText("Eligible students")).toBeInTheDocument();
     expect(screen.getByText("50%", { selector: "p" })).toBeInTheDocument();
     expect(screen.getByRole("table", { name: "Response tracking by grade" })).toBeInTheDocument();
-    expect(screen.getByRole("table", { name: "Response tracking by homeroom" })).toBeInTheDocument();
+	expect(
+		screen.getByRole("table", { name: "Response tracking by homeroom" }),
+	).toBeInTheDocument();
     expect(screen.getByRole("table", { name: "Named non-responders" })).toBeInTheDocument();
     expect(screen.getByRole("table", { name: "Guardian follow-up" })).toBeInTheDocument();
     expect(screen.getByText("Synthetic Guardian One")).toBeInTheDocument();
     expect(screen.getByText("Synthetic Guardian Two")).toBeInTheDocument();
-    expect(screen.getByText("No email")).toBeInTheDocument();
+	expect(screen.getAllByText("No email")).toHaveLength(2);
     expect(screen.getByText("Not responded")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/programs/ResponseTrackingPages.test.tsx
+++ b/frontend/src/features/programs/ResponseTrackingPages.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { InterestProfileResponseTrackingPage } from "./ResponseTrackingPages";
+
+vi.mock("./useProgramName", () => ({
+  useProgramName: vi.fn(() => "Clubs"),
+}));
+
+vi.mock("./usePrograms", () => ({
+  useInterestProfileResponseTracking: vi.fn(() => ({
+    data: {
+      instrument_type: "interest_profile_survey",
+      instrument_id: "survey-1",
+      instrument_name: "Autumn interests",
+      school_year_id: "year-1",
+      program_id: "program-1",
+      total_students: 2,
+      responded_students: 1,
+      completion_percentage: 50,
+      grade_breakdown: [
+        {
+          id: "grade-1",
+          label: "Grade 1",
+          total_students: 2,
+          responded_students: 1,
+          completion_percentage: 50,
+        },
+      ],
+      homeroom_breakdown: [
+        {
+          id: "room-1",
+          label: "Room 1",
+          total_students: 2,
+          responded_students: 1,
+          completion_percentage: 50,
+        },
+      ],
+      non_responders: [
+        {
+          student_id: "student-2",
+          display_name: "Synthetic Student",
+          grade_level_id: "grade-1",
+          grade_label: "Grade 1",
+          homeroom_id: "room-1",
+          homeroom_name: "Room 1",
+          contact_status: "guardian_follow_up",
+        },
+      ],
+      guardian_follow_up: [
+        {
+          adult_id: "adult-1",
+          adult_name: "Synthetic Guardian One",
+          email: "guardian@example.test",
+          student_id: "student-2",
+          student_name: "Synthetic Student",
+          contact_status: "not_responded",
+        },
+        {
+          adult_id: "adult-2",
+          adult_name: "Synthetic Guardian Two",
+          email: null,
+          student_id: "student-2",
+          student_name: "Synthetic Student",
+          contact_status: "no_email",
+        },
+      ],
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+  })),
+  useRankedChoiceResponseTracking: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isError: false,
+    error: null,
+  })),
+}));
+
+describe("response tracking pages", () => {
+  it("renders student totals and separate follow-up rows for multiple guardians", () => {
+    render(
+      <MemoryRouter initialEntries={["/tracking/year-1/program-1/survey-1"]}>
+        <Routes>
+          <Route
+            element={<InterestProfileResponseTrackingPage />}
+            path="/tracking/:schoolYearId/:programId/:surveyId"
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Autumn interests" })).toBeInTheDocument();
+    expect(screen.getByText("Eligible students")).toBeInTheDocument();
+    expect(screen.getByText("50%", { selector: "p" })).toBeInTheDocument();
+    expect(screen.getByRole("table", { name: "Response tracking by grade" })).toBeInTheDocument();
+    expect(screen.getByRole("table", { name: "Response tracking by homeroom" })).toBeInTheDocument();
+    expect(screen.getByRole("table", { name: "Named non-responders" })).toBeInTheDocument();
+    expect(screen.getByRole("table", { name: "Guardian follow-up" })).toBeInTheDocument();
+    expect(screen.getByText("Synthetic Guardian One")).toBeInTheDocument();
+    expect(screen.getByText("Synthetic Guardian Two")).toBeInTheDocument();
+    expect(screen.getByText("No email")).toBeInTheDocument();
+    expect(screen.getByText("Not responded")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/programs/ResponseTrackingPages.test.tsx
+++ b/frontend/src/features/programs/ResponseTrackingPages.test.tsx
@@ -96,14 +96,14 @@ describe("response tracking pages", () => {
     expect(screen.getByText("Eligible students")).toBeInTheDocument();
     expect(screen.getByText("50%", { selector: "p" })).toBeInTheDocument();
     expect(screen.getByRole("table", { name: "Response tracking by grade" })).toBeInTheDocument();
-	expect(
-		screen.getByRole("table", { name: "Response tracking by homeroom" }),
-	).toBeInTheDocument();
+    expect(
+      screen.getByRole("table", { name: "Response tracking by homeroom" }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("table", { name: "Named non-responders" })).toBeInTheDocument();
     expect(screen.getByRole("table", { name: "Guardian follow-up" })).toBeInTheDocument();
     expect(screen.getByText("Synthetic Guardian One")).toBeInTheDocument();
     expect(screen.getByText("Synthetic Guardian Two")).toBeInTheDocument();
-	expect(screen.getAllByText("No email")).toHaveLength(2);
+    expect(screen.getAllByText("No email")).toHaveLength(2);
     expect(screen.getByText("Not responded")).toBeInTheDocument();
   });
 });

--- a/frontend/src/lib/apiResources.test.ts
+++ b/frontend/src/lib/apiResources.test.ts
@@ -159,3 +159,45 @@ describe("catalog feasibility", () => {
     );
   });
 });
+
+describe("phase 4 generated resources", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("routes respondent and tracking calls through the generated API contract", async () => {
+    const requests: Request[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        requests.push(request);
+        return new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    await resourceApi.getStudentCodeRankedChoiceForm(
+      "year-1",
+      "program-1",
+      "session-1",
+      "org-1",
+      "code-1",
+    );
+    await resourceApi.getInterestProfileResponseTracking("year-1", "program-1", "survey-1");
+    await resourceApi.getRankedChoiceResponseTracking("year-1", "program-1", "session-1");
+
+    expect(requests.map((request) => request.method)).toEqual(["POST", "GET", "GET"]);
+    expect(requests[0].url).toContain(
+      "/api/respondent/sessions/year-1/program-1/session-1/form",
+    );
+    expect(requests[1].url).toContain(
+      "/api/school-years/year-1/programs/program-1/interest-profile-surveys/survey-1/response-tracking",
+    );
+    expect(requests[2].url).toContain(
+      "/api/school-years/year-1/programs/program-1/sessions/session-1/response-tracking",
+    );
+  });
+});

--- a/frontend/src/lib/apiResources.test.ts
+++ b/frontend/src/lib/apiResources.test.ts
@@ -190,7 +190,7 @@ describe("phase 4 generated resources", () => {
     await resourceApi.getRankedChoiceResponseTracking("year-1", "program-1", "session-1");
 
     expect(requests.map((request) => request.method)).toEqual(["POST", "GET", "GET"]);
-		expect(requests[0].url).toContain("/api/respondent/sessions/year-1/program-1/session-1/form");
+    expect(requests[0].url).toContain("/api/respondent/sessions/year-1/program-1/session-1/form");
     expect(requests[1].url).toContain(
       "/api/school-years/year-1/programs/program-1/interest-profile-surveys/survey-1/response-tracking",
     );

--- a/frontend/src/lib/apiResources.test.ts
+++ b/frontend/src/lib/apiResources.test.ts
@@ -190,9 +190,7 @@ describe("phase 4 generated resources", () => {
     await resourceApi.getRankedChoiceResponseTracking("year-1", "program-1", "session-1");
 
     expect(requests.map((request) => request.method)).toEqual(["POST", "GET", "GET"]);
-    expect(requests[0].url).toContain(
-      "/api/respondent/sessions/year-1/program-1/session-1/form",
-    );
+		expect(requests[0].url).toContain("/api/respondent/sessions/year-1/program-1/session-1/form");
     expect(requests[1].url).toContain(
       "/api/school-years/year-1/programs/program-1/interest-profile-surveys/survey-1/response-tracking",
     );


### PR DESCRIPTION
## Summary

- Add explicit OTP/MFA, duplicate-email, bounded-session, live guardian-scope, and revocation regression coverage.
- Add ranked-choice mobile Playwright coverage and a mobile accessibility baseline in the existing Frontend tests stage.
- Add response-tracking UI assertions, generated-client resource path assertions, and the Phase 4 validation record in PLAN.md.

## Contract

Implements PLAN.md P4-8 and the Phase 4 exit criteria under SPEC §§5.2, 9.2–9.4, 13, 14.3, 19.5, and 22.4, with authentication behavior aligned to ADR 0013.

## Validation

- `GOTOOLCHAIN=local go test -race ./... -count=1`
- `make format`
- `make lint-backend`
- `make generate && git diff --exit-code`
- `make -C backend generated-code-drift`
- `git diff --check`
- Frontend and migration gates are wired for CI; this checkout lacks frontend dependencies and `MIGRATION_ROUNDTRIP_DATABASE_URL`. Root `make check` is additionally limited by Docker address-pool exhaustion.

Follow-up issue #202 tracks the unrelated populated adult-auth migration rollback defect discovered during the audit.

Fixes #191