### PR TITLE
fix: restore guardian token enum on rollback (#202)

### DIFF
--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -312,7 +312,7 @@
 ## Issue #202
 
 - Scope: fix adult-authentication rollback enum restoration without editing the merged migration.
-- Key files: `backend/migrations/20260904115900_fix_adult_auth_down_enum.sql` and `backend/scripts/migration-round-trip.sh`.
-- Implementation: added an ordered compatibility migration whose Down renames the adult-auth rollback's restored `household_submission` value back to `guardian_submission`; round-trip now inserts a synthetic guardian access token before rollback.
+- Key files: `backend/migrations/20260904130000_fix_adult_auth_down_enum.sql` and `backend/scripts/migration-round-trip.sh`.
+- Implementation: added a higher-numbered compatibility migration whose Down performs the corrected adult-auth rollback with `guardian_submission`, then removes the merged migration's Goose version row so older Downs continue; round-trip now inserts a synthetic guardian access token before rollback.
 - Validation: `bash -n backend/scripts/migration-round-trip.sh`, `make -C backend format`, and `git diff --check` pass. Database round-trip requires unavailable configured PostgreSQL URLs and must run in CI.
-- Open items: commit/push, open PR referencing `Fixes #202`, verify all ten current-head checks and review state, then update the Workpad.
+- Open items: verify all ten current-head checks and review state, then update the Workpad.

--- a/.detent/notes.md
+++ b/.detent/notes.md
@@ -309,3 +309,10 @@
 - Open items: inspect the integrated Phase 4 surfaces, implement scoped fixes and regressions, run all ten validation stages, then push a PR referencing #191 and verify current-head CI/review state.
 - Validation: pending implementation; `git diff --check` will run before handoff.
 - Skill draft: no — implementation has not yet exposed a broadly reusable procedure beyond the existing project guidance.
+## Issue #202
+
+- Scope: fix adult-authentication rollback enum restoration without editing the merged migration.
+- Key files: `backend/migrations/20260904115900_fix_adult_auth_down_enum.sql` and `backend/scripts/migration-round-trip.sh`.
+- Implementation: added an ordered compatibility migration whose Down renames the adult-auth rollback's restored `household_submission` value back to `guardian_submission`; round-trip now inserts a synthetic guardian access token before rollback.
+- Validation: `bash -n backend/scripts/migration-round-trip.sh`, `make -C backend format`, and `git diff --check` pass. Database round-trip requires unavailable configured PostgreSQL URLs and must run in CI.
+- Open items: commit/push, open PR referencing `Fixes #202`, verify all ten current-head checks and review state, then update the Workpad.

--- a/backend/migrations/20260904130000_fix_adult_auth_down_enum.sql
+++ b/backend/migrations/20260904130000_fix_adult_auth_down_enum.sql
@@ -1,0 +1,67 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+
+-- The adult-authentication migration is already merged and its Down path
+-- cannot be edited. This compatibility migration owns the corrected rollback
+-- for that migration when a database has reached this version.
+
+-- +goose Down
+
+revoke all privileges on mfa_recovery_codes from miniclass_app;
+alter table users drop constraint if exists users_mfa_generation_check;
+alter table users drop column if exists mfa_generation;
+alter table users drop column if exists mfa_enrolled_at;
+alter table users drop column if exists mfa_secret_ciphertext;
+drop index if exists mfa_recovery_codes_active_idx;
+drop index if exists mfa_recovery_codes_user_hash_idx;
+drop table mfa_recovery_codes;
+
+revoke all privileges on adult_account_links from miniclass_app;
+drop trigger if exists adult_account_links_closed_year_guard on adult_account_links;
+drop trigger if exists adult_account_links_set_updated_at on adult_account_links;
+drop policy if exists adult_account_links_tenant_isolation on adult_account_links;
+drop table adult_account_links;
+
+drop index if exists access_tokens_session_user_idx;
+drop index if exists access_tokens_adult_otp_rate_idx;
+alter table access_tokens
+    drop constraint if exists access_tokens_year_scope_fk,
+    drop constraint if exists access_tokens_adult_scope_fk,
+    drop constraint if exists access_tokens_user_fk,
+    drop constraint if exists access_tokens_mfa_generation_check,
+    drop constraint if exists access_tokens_requested_email_hash_check,
+    drop constraint if exists access_tokens_verifier_hash_check,
+    drop constraint if exists access_tokens_attempts_check,
+    drop column if exists mfa_generation,
+    drop column if exists last_seen_at,
+    drop column if exists idle_expires_at,
+    drop column if exists attempts,
+    drop column if exists requested_email_hash,
+    drop column if exists verifier_hash,
+    drop column if exists user_id,
+    drop column if exists adult_id,
+    drop column if exists school_year_id,
+    drop column if exists organization_id;
+
+alter table access_tokens rename to access_tokens_adult_auth_down;
+create type access_token_purpose_original as enum (
+    'admin_invitation',
+    'guardian_submission',
+    'class_leader',
+    'homeroom_teacher',
+    'published_artifact'
+);
+alter table access_tokens_adult_auth_down
+    alter column purpose type access_token_purpose_original using purpose::text::access_token_purpose_original;
+alter type access_token_purpose rename to access_token_purpose_adult_auth_down;
+alter type access_token_purpose_original rename to access_token_purpose;
+alter type access_token_purpose owner to miniclass_migrator;
+alter table access_tokens_adult_auth_down rename to access_tokens;
+drop type access_token_purpose_adult_auth_down;
+
+-- Goose must not attempt the merged migration's defective Down after this
+-- compatibility rollback has completed.
+delete from goose_db_version
+where version_id = 20260904120000
+  and is_applied;

--- a/backend/scripts/migration-round-trip.sh
+++ b/backend/scripts/migration-round-trip.sh
@@ -18,6 +18,9 @@ psql "$POSTGRES_ADMIN_DATABASE_URL" -v ON_ERROR_STOP=1 \
 
 echo "Applying migrations"
 DATABASE_URL="$MIGRATION_ROUNDTRIP_DATABASE_URL" go run ./cmd/migrate up
+echo "Seeding a pre-existing guardian token"
+psql "$MIGRATION_ROUNDTRIP_ADMIN_DATABASE_URL" -v ON_ERROR_STOP=1 \
+    -c "insert into access_tokens (token_hash, purpose, expires_at) values (decode(repeat('aa', 32), 'hex'), 'guardian_submission', now() + interval '1 hour')"
 echo "Rolling migrations back"
 DATABASE_URL="$MIGRATION_ROUNDTRIP_ADMIN_DATABASE_URL" go run ./cmd/migrate down
 echo "Reapplying migrations"


### PR DESCRIPTION
## Summary

- add an ordered compatibility migration so adult-auth rollback restores `guardian_submission`
- exercise rollback with a populated synthetic guardian access token

Implements the migration compatibility convention in ADR 0010.

Fixes #202
