### PR TITLE
feat(frontend): kid-friendly survey response forms

### DIFF
--- a/backend/internal/api/handlers/preference.go
+++ b/backend/internal/api/handlers/preference.go
@@ -67,7 +67,7 @@ type PreferenceFormResponse struct {
 	Name            string                                 `json:"name"`
 	Introduction    string                                 `json:"introduction,omitempty"`
 	StudentID       string                                 `json:"student_id" doc:"Opaque student identifier bound to this form."`
-	StudentName     string                                 `json:"student_name,omitempty" doc:"Shown only to guardians and administrators."`
+	StudentName     string                                 `json:"student_name,omitempty" doc:"Shown to the student identified by a ranked-choice code, guardians and administrators."`
 	ClosesAt        *time.Time                             `json:"closes_at,omitempty" format:"date-time"`
 	RankDepth       int                                    `json:"rank_depth,omitempty"`
 	Questions       []PreferenceFormQuestionResponse       `json:"questions,omitempty"`
@@ -332,7 +332,7 @@ func (h *PreferenceHandler) StudentCodeRankedForm(ctx context.Context, input *Ra
 	if err != nil {
 		return nil, preferenceProblem(err)
 	}
-	return &PreferenceFormOutput{Body: preferenceFormResponse(form, false)}, nil
+	return &PreferenceFormOutput{Body: preferenceFormResponse(form, true)}, nil
 }
 
 func (h *PreferenceHandler) StudentCodeRankedSubmit(ctx context.Context, input *RankedChoiceStudentCodeSubmitInput) (*PreferenceFormOutput, error) {
@@ -348,7 +348,7 @@ func (h *PreferenceHandler) StudentCodeRankedSubmit(ctx context.Context, input *
 	if err != nil {
 		return nil, preferenceProblem(err)
 	}
-	return &PreferenceFormOutput{Body: preferenceFormResponse(form, false)}, nil
+	return &PreferenceFormOutput{Body: preferenceFormResponse(form, true)}, nil
 }
 
 func (h *PreferenceHandler) GuardianInterestSubmit(ctx context.Context, input *InterestProfileGuardianSubmitInput) (*PreferenceFormOutput, error) {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3167,7 +3167,7 @@
             "type": "string"
           },
           "student_name": {
-            "description": "Shown only to guardians and administrators.",
+            "description": "Shown to the student identified by a ranked-choice code, guardians and administrators.",
             "type": "string"
           },
           "submitted_at": {

--- a/docs/adr/0000-record-architecture-decisions.md
+++ b/docs/adr/0000-record-architecture-decisions.md
@@ -82,3 +82,4 @@ and not readable as a set.
 | [0013](./0013-guardian-and-volunteer-access.md) | Guardian and volunteer access mechanics | Open |
 | [0014](./0014-roster-ingest-scope-and-source-authority.md) | Roster ingest scope and source authority | Accepted |
 | [0015](./0015-year-scoped-attribute-vocabularies.md) | Grade and homeroom vocabularies are scoped to the school year | Accepted |
+| [0016](./0016-ranked-choice-response-model.md) | Ranked choices distinguish order, acceptability, objection and absence | Accepted |

--- a/docs/adr/0016-ranked-choice-response-model.md
+++ b/docs/adr/0016-ranked-choice-response-model.md
@@ -1,0 +1,186 @@
+# 16. Ranked choices distinguish order, acceptability, objection and absence
+
+- **Status:** Accepted
+- **Date:** 2026-09-02
+- **Relates to:** SPEC §5.2, §13.1, §13.3–§13.5, §13.8, §17.4, §17.5
+- **Related:** [0003](./0003-assignment-solver-technology.md)
+
+## Context
+
+A ranked-choice survey must do two different jobs at once. It must be simple enough for students to
+complete accurately, and it must give the assignment engine enough information to distinguish a
+highly desired placement from an acceptable fallback and from a placement the student actively does
+not want.
+
+Three simpler response models were considered:
+
+1. require every eligible offering to be ranked in a complete order;
+2. let students rank some offerings and mark the rest `Not interested`;
+3. rate every offering `Very interested`, `Interested` or `Not interested` without ordering any of
+   them.
+
+Each removes apparent complexity, but each also collapses information that matters during allocation.
+A complete order asks students to make distinctions they may not hold, especially near the bottom of
+a long catalog. A partial order with only `Not interested` outside it cannot express "acceptable, but
+not a favorite." Three rating buckets express acceptability well but cannot distinguish a first
+choice among several highly desired offerings.
+
+The central fairness concern is strategic withholding. A student might identify only one acceptable
+offering in the belief that appearing to have no alternatives will increase the chance of receiving
+it, while a student who honestly identifies several good alternatives appears easier to move. If the
+solver gives priority to the student with fewer stated alternatives, it rewards strategic
+inflexibility and penalizes useful, truthful preference information.
+
+This concern is separate from the shape of the response. The survey records **preference**; it does
+not confer **priority**. Priority comes from the objective and fairness history in SPEC §17.4 and
+§17.5, together with constraints and explicit organizer judgement. It must not arise accidentally
+from how many responses a student supplies.
+
+## Decision
+
+### Algorithm
+
+The ranked-choice domain model remains the model in SPEC §13.3. For every offering in a session, a
+student's response is exactly one of:
+
+- a unique rank from `1..N`, where `N` is configurable per session;
+- `Interested`, meaning acceptable but outside the ranked choices;
+- `Not interested`, meaning explicitly unwanted;
+- no response, meaning no opinion was expressed.
+
+These states remain distinct throughout storage, solving and reporting. In particular:
+
+**1. Ranking is deliberately partial.** Students identify the choices for which order carries useful
+information. They are not required to manufacture a complete ordering over the catalog. The session
+may limit the number of ranks so that the amount of ordering requested remains proportionate.
+
+**2. Unranked acceptability is explicit.** `Interested` preserves the distinction between an
+acceptable fallback and an objection. A flexible student can disclose additional acceptable choices
+without pretending they are tied with the student's favorites or placing them in an arbitrary tail
+order.
+
+**3. Objection is explicit but is not absence.** `Not interested` means the student expressed that a
+placement is unwanted. No response remains `Neutral`, not `Unwanted`, under SPEC §13.5 and §17.4.1.
+Missing information is neither consent nor an objection.
+
+**4. The number of alternatives does not create priority.** A first choice has the same preference
+quality whether the student ranked one offering or several. Supplying fewer acceptable alternatives
+must not be used as a tie-breaker in that student's favor. A narrower response gives the solver fewer
+ways to produce a known-good placement; that loss of information is its consequence, not increased
+claim on the one class named.
+
+**5. Bad outcomes are protected before top-choice totals are improved.** Allocation follows the
+worst-outcome-first objective in SPEC §17.4.2: first minimize `Unwanted`, then `Neutral`, then
+`Acceptable`, then `High`. The solver does not maximize first choices by repeatedly trading one
+student's bad placement for marginal improvements to several others. Cross-session fairness deficit
+under §17.5 may legitimately distinguish otherwise equivalent students because it records how poorly
+they have previously been served.
+
+**6. `Not interested` remains a preference quality, not a hard eligibility constraint.** The solver
+strongly avoids an unwanted placement and the system surfaces one when constraints make it
+unavoidable. Treating every objection as a prohibition could make a solvable session infeasible and
+would conflict with the warn-not-block principle of SPEC §5.2. Genuine prohibitions belong in the
+constraint model, not in preference responses.
+
+### User Interface
+
+**1. The student interaction uses four buckets.** Offerings begin in `Not answered`, which maps to no
+response rather than `Not interested`. Students move offerings into `Very interested`, `Interested`
+or `Not interested`. `Very interested` is ordered from top to bottom and displays the resulting
+ordinal rank prominently. Its capacity is the session's configured `N`; adding an offering to a full
+bucket returns the lowest-ranked offering to `Not answered`. The other buckets are unordered and
+shown alphabetically so their presentation does not imply a rank.
+
+Students may submit with unanswered offerings or with no ranked favorites. The interface explains
+that unanswered means no opinion and asks for confirmation when either condition applies, but it does
+not block submission. This follows SPEC §5.2 and preserves the four states in §13.3. Changes remain
+local until the student submits; partially arranged drafts are not server submissions and kiosk
+drafts are not retained in browser storage.
+
+**2. Dragging is an enhancement, not the only control.** On wide displays the unanswered catalog is a
+column beside the three destination buckets. On narrow displays the same state is presented as four
+selectable bucket views rather than shrinking the columns. Students may drag cards, use large
+move-to-bucket controls, or use keyboard controls. Ranked cards also provide move-up and move-down
+controls. Focus, announcements, contrast and reduced-motion behavior must make every operation
+available without relying on drag precision, color or animation. Offering cards show the name and
+description needed to choose; operational details such as location, meeting point and dates are
+excluded because they do not inform this preference decision.
+
+**3. Submission ends in a dedicated completion state.** A persistent action area summarizes bucket
+counts and exposes the submission action. Moving an offering requires no confirmation and offers an
+undo action; confirmation is reserved for a final response with no favorites or unanswered offerings.
+After a successful submission, the form is replaced by a prominent, age-neutral `Done!` screen. A
+student who followed a direct code may use a subtle link to revise answers while voting remains open.
+
+**4. Administrator kiosk mode reuses the interaction, not the student credential.** Under SPEC
+§13.8 an authenticated administrator selects the year, program, ranked-choice session and student,
+then starts a dedicated full-screen form through an explicit handoff screen. The form submits through
+the administrator channel so the response records the actor, target student, channel and time; it
+must not generate, reveal or impersonate the student's private access code. An existing response is
+identified before handoff, may be reviewed after an administrator warning, and is preloaded for a
+legitimate correction.
+
+The completion screen in kiosk mode offers only a subtle administrator return link and requires no
+additional PIN. Returning preserves the selected year, program and session, clears the student,
+refreshes response status and prevents browser Back from reopening the completed form. The student
+picker defaults to students needing a response, supports search and status filters, and distinguishes
+duplicate display names with grade while continuing to key every operation by opaque student ID.
+Interest-profile surveys may adopt the same general kiosk approach later, but are outside this
+interaction decision.
+
+## Alternatives considered
+
+**Require a complete ranking of every offering.** Rejected. It captures a total order, but much of the
+additional information is false precision. Students may know their first few choices and have only
+broad acceptability or objection judgments about the rest. Requiring an order among those offerings
+increases cognitive and interaction cost, particularly for younger students and on small screens,
+without reliably improving the input. It also fails to express the important boundary between "least
+preferred but acceptable" and "do not place me here" unless another control is added, at which point
+the simplicity has disappeared.
+
+**Rank some offerings and treat every unranked offering as `Not interested`.** Rejected. It collapses
+acceptable fallbacks into explicit objections. Students would either overstate dislike, depriving the
+solver of useful options, or rank classes they do not genuinely prefer merely to say they would
+accept them. The resulting ranks would mix preference order with acceptability and would not have a
+stable meaning.
+
+**Use only `Very interested`, `Interested` and `Not interested` buckets.** Rejected as the domain
+model, though not necessarily as part of a future interface. Buckets are easy to understand and map
+well to placement quality, but they lose the ordering among scarce, highly desired offerings. A
+student who marks several classes `Very interested` has supplied no answer to which should be tried
+first. Fairness history and deterministic tie-breaking can resolve competition between students;
+they cannot recover a preference distinction the student was never allowed to express.
+
+**Give students with fewer acceptable choices priority for those choices.** Rejected. This is the
+strategic-withholding rule the model must avoid. It makes honesty costly: adding a class the student
+would enjoy can only weaken their claim to a favorite. It also confuses a self-reported preference
+shape with independently justified need. A student with a prior fairness deficit may properly receive
+more weight under SPEC §17.5; a student who merely reports fewer options may not.
+
+**Treat `Not interested` as a hard exclusion.** Rejected. A preference survey is not a reliable place
+to encode eligibility, safety, accessibility or organizer-mandated separation. Making every negative
+rating hard can leave a student unassignable and turn an expression of preference into an accidental
+veto over the session. Hard exclusions remain explicit constraints with their own provenance and
+override behavior.
+
+## Consequences
+
+- The model asks for more than three undifferentiated ratings, but every distinction has allocation
+  meaning: ordered favorite, acceptable fallback, explicit objection, or unknown.
+- Students can disclose flexibility without reducing the quality assigned to their ranked choices.
+  Product copy must say this plainly, and the four-bucket interaction must preserve that distinction.
+- The solver and reports must never infer `Not interested` from an omitted response, nor infer greater
+  priority from a shorter ranked or acceptable set.
+- A session may cap `N`, reducing student effort without changing the model. Offerings beyond that cap
+  can still be marked `Interested` or `Not interested`.
+- Reports can explain outcomes as top-ranked, lower-ranked, acceptable, neutral or unwanted, rather
+  than presenting every unranked placement as equally bad.
+- An unavoidable unwanted placement remains possible. It is visible as `Unwanted` and is optimized
+  before better categories, rather than being hidden by converting the response into a constraint.
+- The ranked-choice form requires responsive, non-drag controls and a distinct completion state in
+  both direct-link and administrator kiosk channels.
+- Interest-profile surveys are not changed by this decision; adapting their unranked interaction is
+  intentionally deferred.
+- Any future design that merges absence with objection, removes acceptable-but-unranked, rewards
+  withholding or submits administrator kiosk responses through student credentials would reverse this
+  decision and requires a superseding ADR.

--- a/frontend/e2e/preferences.spec.ts
+++ b/frontend/e2e/preferences.spec.ts
@@ -93,6 +93,7 @@ test("a student can submit ranked choices on a phone", async ({ page }) => {
     session_name: "Autumn clubs",
     name: "Autumn club choices",
     student_id: "student-1",
+    student_name: "Synthetic Student",
     rank_depth: 1,
     offerings: [
       {
@@ -120,10 +121,13 @@ test("a student can submit ranked choices on a phone", async ({ page }) => {
   });
 
   await page.goto("/respond/sessions/year-1/program-1/session-1?organization_id=org-1&code=secret");
-  await expect(page.getByRole("heading", { name: form.name })).toBeVisible();
-  await page.locator("#answer-offering-1").selectOption("ranked");
-  await page.locator("#rank-offering-1").fill("1");
-  await page.getByRole("button", { name: "Save ranked choices" }).click();
+  await expect(
+    page.getByRole("heading", {
+      name: "Hi, Synthetic — move classes into the buckets to show how you feel.",
+    }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Move to Very interested" }).click();
+  await page.getByRole("button", { name: "Submit my choices" }).click();
 
   await expect
     .poll(() => submittedBody)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/features/programs/ResponseTrackingPages";
 import {
   AdministratorPreferencePage,
+  AdministratorRankedChoiceKioskPage,
   GuardianPreferencePage,
   StudentCodeInterestProfilePage,
   StudentCodeRankedChoicePage,
@@ -91,6 +92,7 @@ function AppRoutes() {
       />
       <Route path="/mfa" element={<MfaPage />} />
       <Route element={<ProtectedRoute />}>
+        <Route path="/preferences/admin/kiosk" element={<AdministratorRankedChoiceKioskPage />} />
         <Route element={<AppShell />}>
           <Route path="/years" element={<SchoolYearListPage />} />
 

--- a/frontend/src/features/preferences/PreferenceForm.test.tsx
+++ b/frontend/src/features/preferences/PreferenceForm.test.tsx
@@ -1,103 +1,88 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { PreferenceForm } from "@/lib/apiResources";
 
 import { PreferenceFormEditor } from "./PreferenceForm";
 
-const interestForm = {
-  type: "interest_profile",
-  id: "survey-1",
-  school_year_id: "year-1",
-  program_id: "program-1",
-  program_name: "Clubs",
-  name: "Interest profile",
-  introduction: "Tell us what sounds fun.",
-  student_id: "student-1",
-  questions: [
-    { interest_area_id: "area-1", label: "Making things", ordinal: 1 },
-    { interest_area_id: "area-2", label: "Being outside", ordinal: 2 },
-  ],
-  scale_options: [
-    { value: "very_interested", label: "Very interested", ordinal: 1 },
-    { value: "interested", label: "Interested", ordinal: 2 },
-    { value: "not_interested", label: "Not interested", ordinal: 3 },
-  ],
-  interest_answers: [],
-} as PreferenceForm;
-
 const rankedForm = {
   type: "ranked_choice",
   id: "session-1",
-  session_id: "session-1",
   school_year_id: "year-1",
   program_id: "program-1",
   program_name: "Clubs",
-  session_name: "Autumn clubs",
-  name: "Autumn clubs",
+  name: "Activity choices",
   student_id: "student-1",
-  rank_depth: 2,
+  student_name: "Synthetic Student",
+  rank_depth: 1,
   offerings: [
     {
       id: "offering-1",
-      name: "Robotics",
-      description: "Build a robot.",
+      name: "Art",
+      description: "Make colorful art.",
+      location: "",
+      meeting_point: "",
+      meeting_instructions: "",
+      meeting_dates: [],
       min_grade_level_id: "grade-1",
       max_grade_level_id: "grade-6",
-      location: "Room 1",
-      meeting_point: "Library",
-      meeting_instructions: "Meet at the library.",
-      meeting_dates: [],
     },
     {
       id: "offering-2",
-      name: "Art",
-      description: "Make art.",
+      name: "Robotics",
+      description: "Build a robot.",
+      location: "",
+      meeting_point: "",
+      meeting_instructions: "",
+      meeting_dates: [],
       min_grade_level_id: "grade-1",
       max_grade_level_id: "grade-6",
-      location: "Room 2",
-      meeting_point: "Art room",
-      meeting_instructions: "Meet in the art room.",
-      meeting_dates: [],
     },
   ],
   ranked_answers: [],
 } as PreferenceForm;
 
-describe("PreferenceFormEditor", () => {
-  it("keeps the mobile interest form incomplete until every area has a response", () => {
-    const onSubmit = vi.fn();
-    render(<PreferenceFormEditor form={interestForm} onSubmit={onSubmit} />);
+function renderForm(onSubmit = vi.fn()) {
+  render(
+    <PreferenceFormEditor form={rankedForm} onSubmit={onSubmit} submitLabel="Submit my choices" />,
+  );
+  return onSubmit;
+}
 
-    const save = screen.getByRole("button", { name: "Save preferences" });
-    expect(save).toBeDisabled();
-    fireEvent.click(screen.getAllByLabelText("Very interested", { selector: "input" })[0]);
-    expect(save).toBeDisabled();
-    fireEvent.click(screen.getAllByLabelText("Interested", { selector: "input" })[1]);
-    expect(save).toBeEnabled();
-    fireEvent.click(save);
+describe("ranked choice preference form", () => {
+  it("serializes bucket choices and confirms unanswered offerings", () => {
+    const onSubmit = renderForm();
+    const art = screen.getByRole("heading", { name: "Art" }).closest("article");
+    expect(art).not.toBeNull();
 
+    fireEvent.click(within(art as HTMLElement).getByRole("button", { name: "Move to Interested" }));
+    fireEvent.click(screen.getByRole("button", { name: "Submit my choices" }));
+
+    expect(screen.getByText("1 class is left unanswered.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Yes, save these preferences" }));
     expect(onSubmit).toHaveBeenCalledWith([
-      { interest_area_id: "area-1", rating: "very_interested" },
-      { interest_area_id: "area-2", rating: "interested" },
+      { offering_id: "offering-1", answer: "interested" },
+      { offering_id: "offering-2", answer: "no_response" },
     ]);
   });
 
-  it("collects a complete ranked course guide with unique mobile positions", () => {
-    const onSubmit = vi.fn();
-    render(<PreferenceFormEditor form={rankedForm} onSubmit={onSubmit} />);
+  it("returns the lowest favorite to unanswered when the rank limit is full", () => {
+    renderForm();
+    const art = screen.getByRole("heading", { name: "Art" }).closest("article");
+    const robotics = screen.getByRole("heading", { name: "Robotics" }).closest("article");
+    expect(art).not.toBeNull();
+    expect(robotics).not.toBeNull();
 
-    const responseSelects = screen.getAllByLabelText("Response", { selector: "select" });
-    fireEvent.change(responseSelects[0], { target: { value: "ranked" } });
-    fireEvent.change(responseSelects[1], { target: { value: "interested" } });
-    fireEvent.change(screen.getByLabelText("Position"), { target: { value: "1" } });
-    const save = screen.getByRole("button", { name: "Save preferences" });
-    expect(save).toBeEnabled();
-    fireEvent.click(save);
+    fireEvent.click(
+      within(art as HTMLElement).getByRole("button", { name: "Move to Very interested" }),
+    );
+    fireEvent.click(
+      within(robotics as HTMLElement).getByRole("button", { name: "Move to Very interested" }),
+    );
 
-    expect(onSubmit).toHaveBeenCalledWith([
-      { offering_id: "offering-1", answer: "ranked", rank: 1 },
-      { offering_id: "offering-2", answer: "interested" },
-    ]);
+    const favorites = screen.getByRole("region", { name: "Very interested" });
+    const unanswered = screen.getByRole("region", { name: "Not answered" });
+    expect(within(favorites).getByRole("heading", { name: "Robotics" })).toBeInTheDocument();
+    expect(within(unanswered).getByRole("heading", { name: "Art" })).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/preferences/PreferenceForm.tsx
+++ b/frontend/src/features/preferences/PreferenceForm.tsx
@@ -1,7 +1,15 @@
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type DragEvent,
+  type FormEvent,
+  type ReactNode,
+} from "react";
+import { ThumbsUp } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import type {
   PreferenceForm,
   PreferenceInterestAnswerInput,
@@ -10,10 +18,61 @@ import type {
 
 type PreferenceAnswer = PreferenceInterestAnswerInput[] | PreferenceRankedAnswerInput[];
 
-type RankedDraft = {
-  answer: PreferenceRankedAnswerInput["answer"];
-  rank?: number;
+type RankedBucket = "no_response" | "ranked" | "interested" | "not_interested";
+type RankedBuckets = Record<RankedBucket, string[]>;
+
+const rankedBucketLabels: Record<RankedBucket, string> = {
+  no_response: "Not answered",
+  ranked: "Very interested",
+  interested: "Interested",
+  not_interested: "Not interested",
 };
+
+const rankedBucketOrder: RankedBucket[] = ["no_response", "ranked", "interested", "not_interested"];
+
+const rankedBucketIcons: Record<RankedBucket, ReactNode> = {
+  no_response: "?",
+  ranked: "★",
+  interested: <ThumbsUp className="size-4" strokeWidth={3} />,
+  not_interested: "↘",
+};
+
+const rankedBucketStyles: Record<RankedBucket, string> = {
+  no_response: "bg-[#86d2e6]/35",
+  ranked: "bg-[#ffcc2e]/35",
+  interested: "bg-[#f26a3d]/20",
+  not_interested: "bg-[#fff3df]",
+};
+
+const rankedBucketBorderColors: Record<RankedBucket, string> = {
+  no_response: "#78c5d9",
+  ranked: "#edc34d",
+  interested: "#ed9a82",
+  not_interested: "#ead0ba",
+};
+
+const rankedBucketTextColors: Record<RankedBucket, string> = {
+  no_response: "#287d96",
+  ranked: "#8a6800",
+  interested: "#ad4429",
+  not_interested: "#8f5d40",
+};
+
+const rankedBucketCountColors: Record<RankedBucket, string> = {
+  no_response: "#b9e5f0",
+  ranked: "#f7df8a",
+  interested: "#f5c5b6",
+  not_interested: "#f4dfcf",
+};
+
+const rankedBucketNotes: Record<Exclude<RankedBucket, "ranked">, string> = {
+  no_response: "Leave it here if you’re not sure.",
+  interested: "Put classes here you’d be happy to take.",
+  not_interested: "Put classes here you’d rather not take.",
+};
+
+const rankedPrimaryButtonClass =
+  "border-2 border-stone-950 bg-[#f2633b] font-black text-white shadow-[3px_3px_0_#1c1917] hover:bg-[#d94a24]";
 
 export function PreferenceFormEditor({
   form,
@@ -30,29 +89,60 @@ export function PreferenceFormEditor({
   error?: string | null;
   submitLabel?: string;
 }) {
+  const studentFirstName = form.student_name?.trim().split(/\s+/)[0];
+
   return (
-    <section className="rounded-lg border bg-card p-5 shadow-sm" aria-label={`${form.name} form`}>
-      <div>
-        <p className="text-sm font-medium text-primary">
-          {form.type === "interest_profile" ? "Interest profile" : "Ranked choice"}
-        </p>
-        <h2 className="mt-1 text-xl font-semibold">{form.name}</h2>
-        {form.program_name && (
-          <p className="mt-1 text-sm text-muted-foreground">{form.program_name}</p>
-        )}
-        {form.session_name && <p className="text-sm text-muted-foreground">{form.session_name}</p>}
-        {form.student_name && (
-          <p className="mt-3 text-sm font-medium">Responding for {form.student_name}</p>
-        )}
-        {form.introduction && (
-          <p className="mt-3 text-sm text-muted-foreground">{form.introduction}</p>
-        )}
-        {form.closes_at && (
-          <p className="mt-3 text-xs text-muted-foreground">
-            Closes {new Date(form.closes_at).toLocaleString()}
-          </p>
-        )}
-      </div>
+    <section
+      className={`rounded-2xl shadow-sm ${form.type === "ranked_choice" ? "bg-[#fffaf0]" : "border bg-card p-5"}`}
+      aria-label={`${form.name} form`}
+    >
+      {form.type === "ranked_choice" ? (
+        <header className="relative overflow-hidden rounded-t-2xl border-b-8 border-[#f2633b] bg-[#86d2e6] px-5 py-7 sm:px-8 sm:py-9">
+          <span
+            className="absolute -top-5 right-8 rotate-12 text-8xl text-white/25"
+            aria-hidden="true"
+          >
+            ★
+          </span>
+          <span
+            className="absolute -bottom-8 right-32 -rotate-12 text-7xl text-[#ffcc2e]/70"
+            aria-hidden="true"
+          >
+            ★
+          </span>
+          <div className="relative max-w-4xl">
+            <h2 className="max-w-5xl text-3xl font-black leading-tight tracking-tight text-stone-950 [text-shadow:3px_3px_0_rgba(255,255,255,0.75)] sm:text-5xl">
+              <span aria-hidden="true">⭐ </span>
+              {studentFirstName ? `Hi, ${studentFirstName} — ` : ""}move classes into the buckets to
+              show how you feel.
+            </h2>
+            {(form.session_name || form.name) && (
+              <p className="mt-5 inline-flex rounded-full border-2 border-stone-900 bg-[#ffcc2e] px-4 py-1.5 text-sm font-bold text-stone-950 shadow-[3px_3px_0_#1c1917]">
+                {form.session_name || form.name}
+              </p>
+            )}
+          </div>
+        </header>
+      ) : (
+        <div>
+          <p className="text-sm font-medium text-primary">Interest profile</p>
+          <h2 className="mt-1 text-xl font-semibold">{form.name}</h2>
+          {form.program_name && (
+            <p className="mt-1 text-sm text-muted-foreground">{form.program_name}</p>
+          )}
+          {form.student_name && (
+            <p className="mt-3 text-sm font-medium">Responding for {form.student_name}</p>
+          )}
+          {form.introduction && (
+            <p className="mt-3 text-sm text-muted-foreground">{form.introduction}</p>
+          )}
+          {form.closes_at && (
+            <p className="mt-3 text-xs text-muted-foreground">
+              Closes {new Date(form.closes_at).toLocaleString()}
+            </p>
+          )}
+        </div>
+      )}
 
       {form.type === "interest_profile" ? (
         <InterestProfileEditor
@@ -64,14 +154,16 @@ export function PreferenceFormEditor({
           submitLabel={submitLabel}
         />
       ) : (
-        <RankedChoiceEditor
-          form={form}
-          onSubmit={onSubmit}
-          isSubmitting={isSubmitting}
-          saved={saved}
-          error={error}
-          submitLabel={submitLabel}
-        />
+        <div className="p-5 sm:p-8">
+          <RankedChoiceEditor
+            form={form}
+            onSubmit={onSubmit}
+            isSubmitting={isSubmitting}
+            saved={saved}
+            error={error}
+            submitLabel={submitLabel}
+          />
+        </div>
       )}
     </section>
   );
@@ -201,141 +293,378 @@ function RankedChoiceEditor({
   submitLabel: string;
 }) {
   const offerings = useMemo(() => form.offerings ?? [], [form.offerings]);
+  const offeringByID = useMemo(
+    () => new Map(offerings.map((offering) => [offering.id, offering])),
+    [offerings],
+  );
   const rankDepth = form.rank_depth ?? 0;
-  const [drafts, setDrafts] = useState<Record<string, RankedDraft>>({});
+  const emptyBuckets = (): RankedBuckets => ({
+    no_response: [],
+    ranked: [],
+    interested: [],
+    not_interested: [],
+  });
+  const [buckets, setBuckets] = useState<RankedBuckets>(emptyBuckets);
+  const [undoBuckets, setUndoBuckets] = useState<RankedBuckets | null>(null);
+  const [activeBucket, setActiveBucket] = useState<RankedBucket>("no_response");
+  const [draggedID, setDraggedID] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+  const [confirmWarnings, setConfirmWarnings] = useState<string[] | null>(null);
+
+  const alphabetize = useCallback(
+    (ids: string[]) =>
+      [...ids].sort((left, right) =>
+        (offeringByID.get(left)?.name ?? "").localeCompare(offeringByID.get(right)?.name ?? ""),
+      ),
+    [offeringByID],
+  );
 
   useEffect(() => {
-    const existing = new Map(
+    if (!confirmWarnings) return;
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") setConfirmWarnings(null);
+    }
+    document.addEventListener("keydown", closeOnEscape);
+    return () => document.removeEventListener("keydown", closeOnEscape);
+  }, [confirmWarnings]);
+
+  useEffect(() => {
+    const initial = emptyBuckets();
+    const answers = new Map(
       (form.ranked_answers ?? []).map((answer) => [answer.offering_id, answer]),
     );
-    const initial: Record<string, RankedDraft> = {};
-    for (const offering of offerings) {
-      const answer = existing.get(offering.id);
-      initial[offering.id] = {
-        answer: answer?.answer ?? "no_response",
-        rank: answer?.rank ?? undefined,
-      };
-    }
-    setDrafts(initial);
-  }, [form.ranked_answers, offerings]);
+    const ranked = offerings
+      .filter((offering) => answers.get(offering.id)?.answer === "ranked")
+      .sort(
+        (left, right) =>
+          (answers.get(left.id)?.rank ?? Number.MAX_SAFE_INTEGER) -
+          (answers.get(right.id)?.rank ?? Number.MAX_SAFE_INTEGER),
+      );
+    const rankedIDs = new Set(ranked.slice(0, rankDepth).map((offering) => offering.id));
 
-  const rankedValues = Object.values(drafts)
-    .filter((draft) => draft.answer === "ranked")
-    .map((draft) => draft.rank);
-  const hasMissingRank = rankedValues.some((rank) => !rank || rank < 1 || rank > rankDepth);
-  const hasDuplicateRank =
-    new Set(rankedValues.filter((rank): rank is number => rank !== undefined)).size !==
-    rankedValues.length;
-  const missing = offerings.some((offering) => !drafts[offering.id]);
-  const validationError = hasMissingRank
-    ? `Ranked choices need a position from 1 to ${rankDepth}.`
-    : hasDuplicateRank
-      ? "Each ranked position can be used only once."
-      : missing
-        ? "Choose a response for each offering."
-        : null;
-  const values = useMemo<PreferenceRankedAnswerInput[]>(
-    () =>
-      offerings.map((offering) => {
-        const draft = drafts[offering.id] ?? { answer: "no_response" as const };
-        return {
-          offering_id: offering.id,
-          answer: draft.answer,
-          ...(draft.answer === "ranked" ? { rank: draft.rank } : {}),
-        };
-      }),
-    [drafts, offerings],
-  );
+    for (const offering of offerings) {
+      const answer = answers.get(offering.id)?.answer ?? "no_response";
+      if (answer === "ranked" && rankedIDs.has(offering.id)) initial.ranked.push(offering.id);
+      else if (answer === "interested" || answer === "not_interested") {
+        initial[answer].push(offering.id);
+      } else initial.no_response.push(offering.id);
+    }
+    initial.no_response.push(...ranked.slice(rankDepth).map((offering) => offering.id));
+    initial.no_response = [...new Set(alphabetize(initial.no_response))];
+    initial.interested = alphabetize(initial.interested);
+    initial.not_interested = alphabetize(initial.not_interested);
+    setBuckets(initial);
+    setUndoBuckets(null);
+    setConfirmWarnings(null);
+  }, [alphabetize, form.ranked_answers, offerings, rankDepth]);
+
+  function moveOffering(id: string, destination: RankedBucket, index?: number) {
+    const offering = offeringByID.get(id);
+    if (!offering) return;
+    let displacedName: string | undefined;
+    setBuckets((current) => {
+      const source = rankedBucketOrder.find((bucket) => current[bucket].includes(id));
+      if (!source) return current;
+      const next: RankedBuckets = {
+        no_response: current.no_response.filter((value) => value !== id),
+        ranked: current.ranked.filter((value) => value !== id),
+        interested: current.interested.filter((value) => value !== id),
+        not_interested: current.not_interested.filter((value) => value !== id),
+      };
+      const insertion =
+        index === undefined
+          ? destination === "ranked" && source !== "ranked" && next.ranked.length >= rankDepth
+            ? Math.max(0, rankDepth - 1)
+            : next[destination].length
+          : index;
+      next[destination].splice(Math.max(0, insertion), 0, id);
+      if (destination === "ranked" && next.ranked.length > rankDepth) {
+        const displaced = next.ranked.pop();
+        if (displaced && displaced !== id) {
+          next.no_response.push(displaced);
+          displacedName = offeringByID.get(displaced)?.name;
+        } else if (displaced === id) {
+          next.no_response.push(id);
+        }
+      }
+      next.no_response = alphabetize(next.no_response);
+      next.interested = alphabetize(next.interested);
+      next.not_interested = alphabetize(next.not_interested);
+      setUndoBuckets(current);
+      return next;
+    });
+    setConfirmWarnings(null);
+    setAnnouncement(
+      `${offering.name} moved to ${rankedBucketLabels[destination]}.${
+        displacedName ? ` ${displacedName} moved to Not answered.` : ""
+      }`,
+    );
+  }
+
+  function drop(event: DragEvent, destination: RankedBucket, index?: number) {
+    event.preventDefault();
+    const id = event.dataTransfer.getData("text/plain") || draggedID;
+    if (id) moveOffering(id, destination, index);
+    setDraggedID(null);
+  }
+
+  const values = useMemo<PreferenceRankedAnswerInput[]>(() => {
+    const bucketForID = new Map<string, { answer: RankedBucket; rank?: number }>();
+    rankedBucketOrder.forEach((bucket) =>
+      buckets[bucket].forEach((id, index) =>
+        bucketForID.set(id, {
+          answer: bucket,
+          ...(bucket === "ranked" ? { rank: index + 1 } : {}),
+        }),
+      ),
+    );
+    return offerings.map((offering) => ({
+      offering_id: offering.id,
+      ...(bucketForID.get(offering.id) ?? { answer: "no_response" as const }),
+    }));
+  }, [buckets, offerings]);
 
   function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!validationError) onSubmit(values);
+    const warnings = [];
+    if (buckets.no_response.length > 0) {
+      warnings.push(
+        `${buckets.no_response.length} class${buckets.no_response.length === 1 ? " is" : "es are"} left unanswered.`,
+      );
+    }
+    if (buckets.ranked.length === 0 && rankDepth > 0) {
+      warnings.push("You haven't ranked anything as Very Interested.");
+    }
+    if (warnings.length > 0) setConfirmWarnings(warnings);
+    else onSubmit(values);
+  }
+
+  function renderBucket(bucket: RankedBucket) {
+    const ids = buckets[bucket];
+    return (
+      <section
+        aria-label={rankedBucketLabels[bucket]}
+        className={`rounded-2xl border-4 p-3 transition-colors motion-reduce:transition-none ${rankedBucketStyles[bucket]} ${activeBucket === bucket ? "block" : "hidden md:block"}`}
+        key={bucket}
+        style={{ borderColor: rankedBucketBorderColors[bucket] }}
+        onDragOver={(event) => event.preventDefault()}
+        onDrop={(event) => drop(event, bucket)}
+      >
+        <div className="mb-3 flex items-center justify-between gap-2">
+          <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
+            <h3
+              className="flex items-center gap-2 text-lg font-black"
+              style={{ color: rankedBucketTextColors[bucket] }}
+            >
+              <span
+                className="flex size-9 items-center justify-center rounded-full border-2 text-base"
+                style={{
+                  backgroundColor: rankedBucketCountColors[bucket],
+                  borderColor: rankedBucketBorderColors[bucket],
+                  boxShadow: `2px 2px 0 ${rankedBucketBorderColors[bucket]}`,
+                  color: rankedBucketTextColors[bucket],
+                }}
+                aria-hidden="true"
+              >
+                {rankedBucketIcons[bucket]}
+              </span>
+              {rankedBucketLabels[bucket]}
+            </h3>
+            <p
+              className="text-xs font-semibold opacity-80 sm:text-sm"
+              style={{ color: rankedBucketTextColors[bucket] }}
+            >
+              {bucket === "ranked"
+                ? rankDepth >= offerings.length
+                  ? "Put favorites here, in order."
+                  : `Put up to ${rankDepth} favorites here, in order.`
+                : rankedBucketNotes[bucket]}
+            </p>
+          </div>
+          <span
+            className="rounded-full border px-2.5 py-1 text-sm font-bold"
+            style={{
+              backgroundColor: rankedBucketCountColors[bucket],
+              borderColor: rankedBucketBorderColors[bucket],
+              color: rankedBucketTextColors[bucket],
+            }}
+            aria-label={`${ids.length} offerings`}
+          >
+            {ids.length}
+            {bucket === "ranked" ? ` / ${rankDepth}` : ""}
+          </span>
+        </div>
+        <div className="space-y-3">
+          {ids.length === 0 && (
+            <p
+              className="rounded-lg border-2 border-dashed p-4 text-center text-sm font-semibold"
+              style={{
+                borderColor: rankedBucketBorderColors[bucket],
+                color: rankedBucketTextColors[bucket],
+              }}
+            >
+              <span className="opacity-80">Drop or move a class here</span>
+            </p>
+          )}
+          {ids.map((id, index) => {
+            const offering = offeringByID.get(id);
+            if (!offering) return null;
+            return (
+              <article
+                className="rounded-xl border-2 bg-[#fffaf0] p-3 shadow-[3px_3px_0_rgba(28,25,23,0.18)] transition-transform hover:-translate-y-0.5 motion-reduce:transform-none motion-reduce:transition-none"
+                draggable
+                style={{ borderColor: rankedBucketBorderColors[bucket] }}
+                key={id}
+                onDragStart={(event) => {
+                  event.dataTransfer.setData("text/plain", id);
+                  event.dataTransfer.effectAllowed = "move";
+                  setDraggedID(id);
+                }}
+                onDragOver={(event) => event.preventDefault()}
+                onDrop={(event) => drop(event, bucket, index)}
+              >
+                <div className="flex gap-3">
+                  {bucket === "ranked" && (
+                    <span
+                      className="flex size-11 shrink-0 items-center justify-center rounded-full border-2 bg-[#ffcc2e] text-xl font-black text-stone-950 shadow-[2px_2px_0_#1c1917]"
+                      style={{ borderColor: rankedBucketTextColors.ranked }}
+                      aria-label={`Rank ${index + 1}`}
+                    >
+                      {index + 1}
+                    </span>
+                  )}
+                  <div className="min-w-0">
+                    <h4 className="text-lg font-black leading-tight text-stone-950">
+                      {offering.name}
+                    </h4>
+                    {offering.description && (
+                      <p className="mt-1 text-sm text-muted-foreground">{offering.description}</p>
+                    )}
+                  </div>
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2 border-t pt-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="mr-1 text-xs font-semibold text-stone-500">Move to</span>
+                    {rankedBucketOrder
+                      .filter((target) => target !== bucket)
+                      .map((target) => (
+                        <button
+                          aria-label={`Move to ${rankedBucketLabels[target]}`}
+                          className="flex min-h-11 items-center gap-2 rounded-md border bg-background px-3 py-2 text-xs font-semibold text-stone-600 hover:bg-accent hover:text-stone-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          key={target}
+                          onClick={() => moveOffering(id, target)}
+                          type="button"
+                        >
+                          <span
+                            className="flex size-4 items-center justify-center text-stone-400"
+                            aria-hidden="true"
+                          >
+                            {rankedBucketIcons[target]}
+                          </span>
+                          {rankedBucketLabels[target]}
+                        </button>
+                      ))}
+                  </div>
+                  {bucket === "ranked" && index > 0 && (
+                    <button
+                      className="min-h-11 rounded-md border px-3 text-sm font-medium hover:bg-accent"
+                      onClick={() => moveOffering(id, "ranked", index - 1)}
+                      type="button"
+                    >
+                      Move up
+                    </button>
+                  )}
+                  {bucket === "ranked" && index < ids.length - 1 && (
+                    <button
+                      className="min-h-11 rounded-md border px-3 text-sm font-medium hover:bg-accent"
+                      onClick={() => moveOffering(id, "ranked", index + 1)}
+                      type="button"
+                    >
+                      Move down
+                    </button>
+                  )}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+    );
   }
 
   return (
-    <form className="mt-6 space-y-6" onSubmit={submit}>
-      <p className="text-sm text-muted-foreground">
-        Rank up to {rankDepth} offerings. You can also mark an offering interested or not
-        interested.
+    <form className="space-y-5" onSubmit={submit}>
+      <p aria-atomic="true" aria-live="polite" className="sr-only">
+        {announcement}
       </p>
-      <div className="space-y-4">
-        {offerings.map((offering) => {
-          const draft = drafts[offering.id] ?? { answer: "no_response" as const };
-          return (
-            <article className="rounded-md border p-4" key={offering.id}>
-              <h3 className="font-medium">{offering.name}</h3>
-              {offering.description && (
-                <p className="mt-1 text-sm text-muted-foreground">{offering.description}</p>
-              )}
-              {(offering.location || offering.meeting_point) && (
-                <p className="mt-2 text-sm text-muted-foreground">
-                  {[offering.location, offering.meeting_point].filter(Boolean).join(" · ")}
-                </p>
-              )}
-              {offering.meeting_dates?.length ? (
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Meets{" "}
-                  {offering.meeting_dates
-                    .map((date) => new Date(`${date}T00:00:00`).toLocaleDateString())
-                    .join(", ")}
-                </p>
-              ) : null}
-              <div className="mt-4 grid gap-3 sm:grid-cols-[minmax(0,1fr)_8rem]">
-                <label className="text-sm font-medium" htmlFor={`answer-${offering.id}`}>
-                  Response
-                  <select
-                    className="mt-1 flex h-10 w-full rounded-md border bg-background px-3 text-sm"
-                    id={`answer-${offering.id}`}
-                    onChange={(event) =>
-                      setDrafts((current) => ({
-                        ...current,
-                        [offering.id]: {
-                          ...current[offering.id],
-                          answer: event.target.value as RankedDraft["answer"],
-                          rank:
-                            event.target.value === "ranked"
-                              ? current[offering.id]?.rank
-                              : undefined,
-                        },
-                      }))
-                    }
-                    value={draft.answer}
-                  >
-                    <option value="no_response">Choose a response</option>
-                    <option value="ranked">Rank this offering</option>
-                    <option value="interested">Interested, but do not rank</option>
-                    <option value="not_interested">Not interested</option>
-                  </select>
-                </label>
-                {draft.answer === "ranked" && (
-                  <label className="text-sm font-medium" htmlFor={`rank-${offering.id}`}>
-                    Position
-                    <Input
-                      className="mt-1"
-                      id={`rank-${offering.id}`}
-                      inputMode="numeric"
-                      max={rankDepth}
-                      min={1}
-                      onChange={(event) =>
-                        setDrafts((current) => ({
-                          ...current,
-                          [offering.id]: {
-                            ...current[offering.id],
-                            rank: event.target.value ? Number(event.target.value) : undefined,
-                          },
-                        }))
-                      }
-                      type="number"
-                      value={draft.rank ?? ""}
-                    />
-                  </label>
-                )}
-              </div>
-            </article>
-          );
-        })}
+
+      <div className="grid grid-cols-2 gap-2 md:hidden" aria-label="Choose a preference bucket">
+        {rankedBucketOrder.map((bucket) => (
+          <button
+            aria-pressed={activeBucket === bucket}
+            className={`min-h-12 rounded-lg border-2 border-stone-900 px-2 text-sm font-bold shadow-[2px_2px_0_#1c1917] ${activeBucket === bucket ? rankedBucketStyles[bucket] : "bg-[#fffaf0]"}`}
+            key={bucket}
+            onClick={() => setActiveBucket(bucket)}
+            type="button"
+          >
+            {rankedBucketLabels[bucket]} ({buckets[bucket].length})
+          </button>
+        ))}
       </div>
-      {validationError && <p className="text-sm text-muted-foreground">{validationError}</p>}
+
+      <div className="grid items-start gap-4 md:grid-cols-2">
+        {renderBucket("no_response")}
+        <div className="space-y-4">
+          {renderBucket("ranked")}
+          {renderBucket("interested")}
+          {renderBucket("not_interested")}
+        </div>
+      </div>
+
+      {confirmWarnings && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-stone-950/60 p-4 backdrop-blur-sm"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) setConfirmWarnings(null);
+          }}
+        >
+          <div
+            aria-describedby="ranked-confirmation-description"
+            aria-labelledby="ranked-confirmation-title"
+            aria-modal="true"
+            className="w-full max-w-lg rounded-2xl border-4 border-stone-950 bg-[#fffaf0] p-6 text-stone-950 shadow-[8px_8px_0_#f2633b] sm:p-8"
+            role="dialog"
+          >
+            <h3 className="text-2xl font-black" id="ranked-confirmation-title">
+              Ready to save these preferences?
+            </h3>
+            <div id="ranked-confirmation-description">
+              <ul className="mt-4 list-disc space-y-2 pl-5 font-medium">
+                {confirmWarnings.map((warning) => (
+                  <li key={warning}>{warning}</li>
+                ))}
+              </ul>
+              <p className="mt-4 text-sm text-stone-600">
+                That is completely okay—just confirm this is what you want.
+              </p>
+            </div>
+            <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+              <Button onClick={() => setConfirmWarnings(null)} type="button" variant="outline">
+                Keep editing
+              </Button>
+              <Button
+                autoFocus
+                className={rankedPrimaryButtonClass}
+                disabled={isSubmitting}
+                onClick={() => onSubmit(values)}
+                type="button"
+              >
+                {isSubmitting ? "Saving…" : "Yes, save these preferences"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
       {error && (
         <p className="text-sm text-destructive" role="alert">
           {error}
@@ -346,12 +675,44 @@ function RankedChoiceEditor({
           Preferences saved. You can revise them while voting is open.
         </p>
       )}
-      <Button
-        disabled={Boolean(validationError) || isSubmitting || offerings.length === 0}
-        type="submit"
-      >
-        {isSubmitting ? "Saving…" : submitLabel}
-      </Button>
+
+      <div className="sticky bottom-0 z-10 -mx-5 flex flex-wrap items-center justify-between gap-3 border-t-4 border-[#d94a24] bg-[#fffaf0]/95 px-5 py-4 shadow-[0_-4px_12px_rgba(0,0,0,0.12)] backdrop-blur motion-reduce:backdrop-blur-none sm:-mx-8 sm:px-8">
+        <div
+          className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground"
+          aria-label="Bucket counts"
+        >
+          {rankedBucketOrder.map((bucket) => (
+            <span key={bucket}>
+              <strong className="text-foreground">{buckets[bucket].length}</strong>{" "}
+              {rankedBucketLabels[bucket]}
+            </span>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          <Button
+            disabled={!undoBuckets || isSubmitting}
+            onClick={() => {
+              if (!undoBuckets) return;
+              const current = buckets;
+              setBuckets(undoBuckets);
+              setUndoBuckets(current);
+              setConfirmWarnings(null);
+              setAnnouncement("Last move undone.");
+            }}
+            type="button"
+            variant="outline"
+          >
+            Undo last move
+          </Button>
+          <Button
+            className={rankedPrimaryButtonClass}
+            disabled={isSubmitting || offerings.length === 0}
+            type="submit"
+          >
+            {isSubmitting ? "Saving…" : submitLabel}
+          </Button>
+        </div>
+      </div>
     </form>
   );
 }

--- a/frontend/src/features/preferences/PreferencePages.tsx
+++ b/frontend/src/features/preferences/PreferencePages.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { Link, useSearchParams, useParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/button";
@@ -15,6 +15,7 @@ import {
   useGuardianPreferenceForms,
   usePrograms,
   useProgramMemberships,
+  useRankedChoiceResponseTracking,
   useSessions,
   useInterestProfileSurveys,
   useStudentCodeInterestProfileForm,
@@ -29,8 +30,14 @@ import {
 
 import { PreferenceFormEditor } from "./PreferenceForm";
 
-function PageFrame({ children }: { children: ReactNode }) {
-  return <main className="mx-auto w-full max-w-3xl px-4 py-6 sm:px-6 sm:py-10">{children}</main>;
+function PageFrame({ children, wide = false }: { children: ReactNode; wide?: boolean }) {
+  return (
+    <main
+      className={`mx-auto w-full px-4 py-6 sm:px-6 sm:py-10 ${wide ? "max-w-[100rem]" : "max-w-3xl"}`}
+    >
+      {children}
+    </main>
+  );
 }
 
 function ErrorMessage({ error, fallback }: { error: unknown; fallback: string }) {
@@ -251,15 +258,22 @@ export function StudentCodeRankedChoicePage() {
     );
 
   return (
-    <PageFrame>
-      <PreferenceFormEditor
-        error={submit.error instanceof Error ? submit.error.message : null}
-        form={formQuery.data}
-        isSubmitting={submit.isPending}
-        onSubmit={(value) => submit.mutate(value as PreferenceRankedAnswerInput[])}
-        saved={submit.isSuccess}
-        submitLabel="Save ranked choices"
-      />
+    <PageFrame wide>
+      {submit.isSuccess ? (
+        <RankedChoiceDone
+          onRevise={() => submit.reset()}
+          sessionName={formQuery.data.session_name || formQuery.data.name}
+        />
+      ) : (
+        <PreferenceFormEditor
+          error={submit.error instanceof Error ? submit.error.message : null}
+          form={formQuery.data}
+          isSubmitting={submit.isPending}
+          onSubmit={(value) => submit.mutate(value as PreferenceRankedAnswerInput[])}
+          saved={false}
+          submitLabel="Submit my choices"
+        />
+      )}
     </PageFrame>
   );
 }
@@ -368,12 +382,118 @@ export function GuardianPreferencePage() {
   );
 }
 
+function ExistingResponseModal({
+  studentName,
+  onCancel,
+  onConfirm,
+}: {
+  studentName: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  useEffect(() => {
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") onCancel();
+    }
+    document.addEventListener("keydown", closeOnEscape);
+    return () => document.removeEventListener("keydown", closeOnEscape);
+  }, [onCancel]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-stone-950/60 p-4 backdrop-blur-sm"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onCancel();
+      }}
+    >
+      <div
+        aria-describedby="existing-response-description"
+        aria-labelledby="existing-response-title"
+        aria-modal="true"
+        className="w-full max-w-lg rounded-2xl border-4 border-stone-950 bg-[#fffaf0] p-6 text-stone-950 shadow-[8px_8px_0_#f2633b] sm:p-8"
+        role="dialog"
+      >
+        <h2 className="text-2xl font-black" id="existing-response-title">
+          Review {studentName}’s response?
+        </h2>
+        <p className="mt-4 font-medium text-stone-700" id="existing-response-description">
+          A response has already been submitted. You can open it to review the choices and submit an
+          updated response.
+        </p>
+        <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <Button onClick={onCancel} type="button" variant="outline">
+            Cancel
+          </Button>
+          <Button
+            autoFocus
+            className="border-2 border-stone-950 bg-[#f2633b] font-black text-white shadow-[3px_3px_0_#1c1917] hover:bg-[#d94a24]"
+            onClick={onConfirm}
+            type="button"
+          >
+            Review response
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RankedChoiceDone({
+  sessionName,
+  onRevise,
+  administratorReturn,
+}: {
+  sessionName: string;
+  onRevise?: () => void;
+  administratorReturn?: string;
+}) {
+  return (
+    <section
+      className="flex min-h-[75vh] flex-col items-center justify-center text-center"
+      role="status"
+    >
+      <div className="text-7xl motion-safe:animate-bounce" aria-hidden="true">
+        🎉
+      </div>
+      <h1 className="mt-6 text-6xl font-black tracking-tight sm:text-8xl">Done!</h1>
+      <p className="mt-4 text-xl text-muted-foreground">
+        Your choices have been submitted for {sessionName}.
+      </p>
+      {onRevise && (
+        <button
+          className="mt-10 text-sm text-muted-foreground underline hover:text-foreground"
+          onClick={onRevise}
+          type="button"
+        >
+          Change my answers
+        </button>
+      )}
+      {administratorReturn && (
+        <Link
+          className="mt-12 text-xs text-muted-foreground/70 underline hover:text-foreground"
+          replace
+          to={administratorReturn}
+        >
+          Administrator: choose next student
+        </Link>
+      )}
+    </section>
+  );
+}
+
 export function AdministratorPreferencePage() {
   const yearsQuery = useSchoolYears();
-  const [schoolYearID, setSchoolYearID] = useState("");
-  const [programID, setProgramID] = useState("");
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [schoolYearID, setSchoolYearID] = useState(() => searchParams.get("year") ?? "");
+  const [programID, setProgramID] = useState(() => searchParams.get("program") ?? "");
   const [studentID, setStudentID] = useState("");
-  const [instrumentID, setInstrumentID] = useState("");
+  const [instrumentID, setInstrumentID] = useState(() => searchParams.get("session") ?? "");
+  const [studentSearch, setStudentSearch] = useState("");
+  const [studentFilter, setStudentFilter] = useState<"needs_response" | "submitted" | "all">(
+    "needs_response",
+  );
+  const [showReviewSubmittedResponseModal, setShowReviewSubmittedResponseModal] = useState(false);
   const programsQuery = usePrograms(schoolYearID || undefined);
   const membershipsQuery = useProgramMemberships(schoolYearID || undefined, programID || undefined);
   const studentsQuery = useQuery({
@@ -418,7 +538,42 @@ export function AdministratorPreferencePage() {
         }
       : null;
   }, [instrumentID, instruments, programID, schoolYearID, studentID]);
-  const formQuery = useAdministratorPreferenceForm(formInput);
+  const formQuery = useAdministratorPreferenceForm(
+    formInput?.type === "interest_profile" ? formInput : null,
+  );
+  const selectedInstrument = instruments.find((option) => option.id === instrumentID);
+  const selectedStudent = students.find((student) => student.id === studentID);
+  const trackingQuery = useRankedChoiceResponseTracking(
+    schoolYearID || undefined,
+    programID || undefined,
+    selectedInstrument?.type === "ranked_choice" ? instrumentID : undefined,
+  );
+  const nonResponderIDs = useMemo(
+    () => new Set((trackingQuery.data?.non_responders ?? []).map((student) => student.student_id)),
+    [trackingQuery.data],
+  );
+  const visibleStudents = useMemo(() => {
+    const duplicateNames = new Set(
+      students
+        .map((student) => student.display_name)
+        .filter((name, _index, names) => names.indexOf(name) !== names.lastIndexOf(name)),
+    );
+    return students
+      .filter((student) =>
+        student.display_name.toLowerCase().includes(studentSearch.trim().toLowerCase()),
+      )
+      .filter((student) => {
+        if (!trackingQuery.data || studentFilter === "all") return true;
+        const needsResponse = nonResponderIDs.has(student.id);
+        return studentFilter === "needs_response" ? needsResponse : !needsResponse;
+      })
+      .map((student) => ({
+        ...student,
+        pickerLabel: duplicateNames.has(student.display_name)
+          ? `${student.display_name} — ${student.grade_level_id ?? "Grade unassigned"}`
+          : student.display_name,
+      }));
+  }, [nonResponderIDs, studentFilter, studentSearch, students, trackingQuery.data]);
 
   useEffect(() => {
     if (!schoolYearID && years[0]) setSchoolYearID(years[0].id);
@@ -428,9 +583,15 @@ export function AdministratorPreferencePage() {
     setProgramID(programs[0]?.id ?? "");
   }, [programID, programs]);
   useEffect(() => {
-    if (studentID && students.some((student) => student.id === studentID)) return;
-    setStudentID(students[0]?.id ?? "");
+    if (studentID && !students.some((student) => student.id === studentID)) setStudentID("");
   }, [studentID, students]);
+  useEffect(() => {
+    const next = new URLSearchParams();
+    if (schoolYearID) next.set("year", schoolYearID);
+    if (programID) next.set("program", programID);
+    if (instrumentID) next.set("session", instrumentID);
+    setSearchParams(next, { replace: true });
+  }, [instrumentID, programID, schoolYearID, setSearchParams]);
   useEffect(() => {
     if (instrumentID && instruments.some((instrument) => instrument.id === instrumentID)) return;
     setInstrumentID(instruments[0]?.id ?? "");
@@ -488,22 +649,58 @@ export function AdministratorPreferencePage() {
               ))}
             </select>
           </label>
-          <label className="text-sm font-medium" htmlFor="admin-student">
-            Student
-            <select
-              className="mt-2 flex h-10 w-full rounded-md border bg-background px-3 text-sm"
-              id="admin-student"
-              onChange={(event) => setStudentID(event.target.value)}
-              value={studentID}
-            >
-              <option value="">Choose a student</option>
-              {students.map((student) => (
-                <option key={student.id} value={student.id}>
-                  {student.display_name}
-                </option>
-              ))}
-            </select>
-          </label>
+          <div className="sm:col-span-2">
+            <p className="text-sm font-medium">Student</p>
+            <div className="mt-2 grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+              <Input
+                aria-label="Search students"
+                onChange={(event) => setStudentSearch(event.target.value)}
+                placeholder="Search students"
+                value={studentSearch}
+              />
+              <div className="flex rounded-md border p-1" aria-label="Student status filter">
+                {(["needs_response", "submitted", "all"] as const).map((filter) => (
+                  <button
+                    className={`rounded px-3 py-1.5 text-xs font-medium ${studentFilter === filter ? "bg-primary text-primary-foreground" : "text-muted-foreground"}`}
+                    key={filter}
+                    onClick={() => {
+                      setStudentFilter(filter);
+                      setStudentID("");
+                    }}
+                    type="button"
+                  >
+                    {filter === "needs_response"
+                      ? "Needs response"
+                      : filter === "submitted"
+                        ? "Submitted"
+                        : "All"}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="mt-3 max-h-64 space-y-2 overflow-y-auto" role="list">
+              {visibleStudents.map((student) => {
+                const submitted = Boolean(trackingQuery.data && !nonResponderIDs.has(student.id));
+                return (
+                  <button
+                    className={`flex w-full items-center justify-between rounded-md border p-3 text-left hover:bg-accent ${studentID === student.id ? "border-primary ring-2 ring-primary/20" : ""}`}
+                    key={student.id}
+                    onClick={() => setStudentID(student.id)}
+                    role="listitem"
+                    type="button"
+                  >
+                    <span className="font-medium">{student.pickerLabel}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {submitted ? "Submitted" : "Not started"}
+                    </span>
+                  </button>
+                );
+              })}
+              {visibleStudents.length === 0 && (
+                <p className="p-3 text-sm text-muted-foreground">No students match this view.</p>
+              )}
+            </div>
+          </div>
           <label className="text-sm font-medium sm:col-span-2" htmlFor="admin-instrument">
             Open survey
             <select
@@ -529,6 +726,38 @@ export function AdministratorPreferencePage() {
       )}
       {formQuery.error && (
         <ErrorMessage error={formQuery.error} fallback="Unable to load the selected form." />
+      )}
+      {selectedInstrument?.type === "ranked_choice" && studentID && (
+        <div className="mt-6 flex justify-end">
+          <Button
+            onClick={() => {
+              const existing = Boolean(trackingQuery.data && !nonResponderIDs.has(studentID));
+              if (existing) {
+                setShowReviewSubmittedResponseModal(true);
+                return;
+              }
+              navigate(
+                `/preferences/admin/kiosk?year=${encodeURIComponent(schoolYearID)}&program=${encodeURIComponent(programID)}&session=${encodeURIComponent(instrumentID)}&student=${encodeURIComponent(studentID)}`,
+              );
+            }}
+            type="button"
+          >
+            {trackingQuery.data && !nonResponderIDs.has(studentID)
+              ? `Review response for ${selectedStudent?.display_name ?? "selected student"}`
+              : `Start for ${selectedStudent?.display_name ?? "selected student"}`}
+          </Button>
+        </div>
+      )}
+      {showReviewSubmittedResponseModal && selectedStudent && (
+        <ExistingResponseModal
+          onCancel={() => setShowReviewSubmittedResponseModal(false)}
+          onConfirm={() =>
+            navigate(
+              `/preferences/admin/kiosk?year=${encodeURIComponent(schoolYearID)}&program=${encodeURIComponent(programID)}&session=${encodeURIComponent(instrumentID)}&student=${encodeURIComponent(studentID)}`,
+            )
+          }
+          studentName={selectedStudent.display_name}
+        />
       )}
       {form && (
         <div className="mt-6">
@@ -566,6 +795,121 @@ export function AdministratorPreferencePage() {
           />
         </div>
       )}
+    </PageFrame>
+  );
+}
+
+export function AdministratorRankedChoiceKioskPage() {
+  const [searchParams] = useSearchParams();
+  const [started, setStarted] = useState(false);
+  const year = searchParams.get("year") ?? "";
+  const program = searchParams.get("program") ?? "";
+  const session = searchParams.get("session") ?? "";
+  const student = searchParams.get("student") ?? "";
+  const returnPath = `/preferences/admin?year=${encodeURIComponent(year)}&program=${encodeURIComponent(program)}&session=${encodeURIComponent(session)}`;
+  const formQuery = useAdministratorPreferenceForm(
+    year && program && session && student
+      ? {
+          type: "ranked_choice",
+          school_year_id: year,
+          program_id: program,
+          instrument_id: session,
+          student_id: student,
+        }
+      : null,
+  );
+  const submit = useSubmitAdministratorRankedChoice();
+
+  if (!year || !program || !session || !student) {
+    return (
+      <PageFrame>
+        <ErrorMessage error={null} fallback="This kiosk link is incomplete." />
+        <Link
+          className="mt-4 inline-block text-sm font-medium text-primary hover:underline"
+          replace
+          to="/preferences/admin"
+        >
+          Back to student selection
+        </Link>
+      </PageFrame>
+    );
+  }
+  if (formQuery.isLoading)
+    return (
+      <PageFrame>
+        <p role="status">Preparing the student form…</p>
+      </PageFrame>
+    );
+  if (formQuery.error || !formQuery.data) {
+    return (
+      <PageFrame>
+        <ErrorMessage error={formQuery.error} fallback="Unable to prepare this student form." />
+        <Link
+          className="mt-4 inline-block text-sm font-medium text-primary hover:underline"
+          replace
+          to={returnPath}
+        >
+          Back to student selection
+        </Link>
+      </PageFrame>
+    );
+  }
+  if (submit.isSuccess)
+    return (
+      <PageFrame wide>
+        <RankedChoiceDone
+          administratorReturn={returnPath}
+          sessionName={formQuery.data.session_name || formQuery.data.name}
+        />
+      </PageFrame>
+    );
+  if (!started) {
+    return (
+      <PageFrame>
+        <section className="flex min-h-[70vh] flex-col items-center justify-center text-center">
+          <h1 className="mt-3 text-4xl font-black tracking-tight sm:text-6xl">
+            Ready for {formQuery.data.student_name}
+          </h1>
+          <p className="mt-4 max-w-md text-xl text-muted-foreground">
+            Hand the device to the student, then have them press Start.
+          </p>
+          <Button
+            className="mt-8 min-h-14 px-10 text-xl"
+            onClick={() => setStarted(true)}
+            type="button"
+          >
+            Start
+          </Button>
+          <Link
+            className="mt-8 text-sm text-muted-foreground underline hover:text-foreground"
+            replace
+            to={returnPath}
+          >
+            Choose someone else
+          </Link>
+        </section>
+      </PageFrame>
+    );
+  }
+
+  return (
+    <PageFrame wide>
+      <PreferenceFormEditor
+        error={submit.error instanceof Error ? submit.error.message : null}
+        form={formQuery.data}
+        isSubmitting={submit.isPending}
+        onSubmit={(value) =>
+          submit.mutate({
+            schoolYearID: year,
+            programID: program,
+            sessionID: session,
+            studentID: student,
+            responses: value as PreferenceRankedAnswerInput[],
+          })
+        }
+        saved={false}
+        submitLabel="Submit my choices"
+      />
     </PageFrame>
   );
 }

--- a/frontend/src/features/programs/usePrograms.ts
+++ b/frontend/src/features/programs/usePrograms.ts
@@ -360,7 +360,16 @@ export function useSubmitAdministratorRankedChoice() {
         studentID,
         responses,
       ),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["administrator-preference-form"] }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["administrator-preference-form"] });
+      queryClient.invalidateQueries({
+        queryKey: [
+          ...sessionsKey(variables.schoolYearID, variables.programID),
+          variables.sessionID,
+          "response-tracking",
+        ],
+      });
+    },
   });
 }
 


### PR DESCRIPTION
<!--
Keep this short. CI reports the quality gates; do not restate them here.
-->

## What this implements

**Spec:** SPEC §<!-- e.g. 9.2, 8.2 --> — <!-- one line: which requirement -->

**ADR:** <!-- e.g. ADR 0007, or "none" if this change makes no architectural choice -->

Closes #<!-- issue number -->

## Notes for review

<!--
Anything a reviewer cannot see from the diff: a decision you had to make, a rejected
alternative, a limitation you accepted. Delete this section if there is nothing.
-->

## Checks

- [ ] This change adds no tenant-scoped table, **or** each new one has a factory registered in the
      entity registry (`AGENTS.md` → Standing rules 2).
- [ ] This change adds no endpoint, **or** each new one declares its required capability.
- [ ] Out-of-scope discoveries were filed as tracker issues rather than fixed here.
